### PR TITLE
fix: patch ReDoS, command injection, and security vulnerabilities

### DIFF
--- a/cli/agents/api-fuzzer.js
+++ b/cli/agents/api-fuzzer.js
@@ -166,6 +166,16 @@ const PATTERNS = [
 
   // ── Sensitive Data in URL ──────────────────────────────────────────────────
   {
+    rule: 'API_KEY_IN_URL',
+    title: 'API: Secret in URL Query Parameter',
+    regex: /(?:url|endpoint|href)\s*[:=]\s*[`"'][^`"']*\?[^`"']*(?:key|token|secret|password|apiKey|api_key)\s*=/gi,
+    severity: 'high',
+    cwe: 'CWE-598',
+    owasp: 'A02:2021',
+    description: 'API key or secret passed in URL query parameter. URLs are logged in server logs, browser history, and proxies.',
+    fix: 'Move secrets to request headers (e.g., Authorization, x-api-key) instead of URL parameters.',
+  },
+  {
     rule: 'API_SECRET_IN_URL',
     title: 'API: Sensitive Data in URL Parameters',
     regex: /(?:app|router)\.(?:get|post)\s*\(\s*['"][^'"]*(?::token|:apiKey|:password|:secret|:key)\b/g,

--- a/cli/agents/auth-bypass-agent.js
+++ b/cli/agents/auth-bypass-agent.js
@@ -59,7 +59,7 @@ const PATTERNS = [
   {
     rule: 'COOKIE_NO_HTTPONLY',
     title: 'Cookie Missing httpOnly Flag',
-    regex: /(?:cookie|Cookie|setCookie|set-cookie)[^;]*(?!httpOnly|httponly).*(?:secure|domain|path|maxAge|max-age)/gi,
+    regex: /(?:cookie|Cookie|setCookie|set-cookie)[^;]{0,100}(?:secure|domain|path|maxAge|max-age)(?![^;]*httpOnly)/gi,
     severity: 'medium',
     cwe: 'CWE-1004',
     owasp: 'A05:2021',
@@ -103,7 +103,7 @@ const PATTERNS = [
   {
     rule: 'SESSION_NO_REGENERATE',
     title: 'Session Not Regenerated After Login',
-    regex: /(?:login|authenticate|signIn)\s*(?:=|:)\s*(?:async\s+)?(?:function|\([^)]*\)\s*=>)[^}]{50,500}(?!regenerate|destroy|rotate)/g,
+    regex: /(?:login|authenticate|signIn)\s*(?:=|:)\s*(?:async\s+)?(?:function|\([^)]*\)\s*=>)/g,
     severity: 'medium',
     cwe: 'CWE-384',
     owasp: 'A07:2021',

--- a/cli/agents/cicd-scanner.js
+++ b/cli/agents/cicd-scanner.js
@@ -17,11 +17,12 @@ const PATTERNS = [
   {
     rule: 'CICD_PR_TARGET_CHECKOUT',
     title: 'CI/CD: pull_request_target with PR Checkout',
-    regex: /pull_request_target[\s\S]{0,500}(?:actions\/checkout|checkout@)[\s\S]{0,200}(?:ref:\s*\$\{\{.*github\.event\.pull_request|head\.ref)/g,
+    regex: /\bpull_request_target\b/g,
     severity: 'critical',
     cwe: 'CWE-94',
     owasp: 'CICD-SEC-4',
-    description: 'pull_request_target with checkout of PR branch enables arbitrary code execution from forks.',
+    confidence: 'medium',
+    description: 'pull_request_target trigger detected. Runs with base branch privileges and can be exploited if combined with PR checkout.',
     fix: 'Use pull_request trigger instead, or never checkout PR branch in pull_request_target',
   },
   {
@@ -156,7 +157,7 @@ const PATTERNS = [
   {
     rule: 'CICD_SCRIPT_INJECTION',
     title: 'CI/CD: Script Injection via Expressions',
-    regex: /run\s*:\s*.*\$\{\{\s*(?:github\.event\.(?:issue|comment|pull_request|review)\.(?:title|body|head\.ref|label))/g,
+    regex: /run\s*:\s*[^\n]*\$\{\{\s*(?:github\.event\.(?:issue|comment|pull_request|review)\.(?:title|body|head\.ref|label))/g,
     severity: 'critical',
     cwe: 'CWE-78',
     owasp: 'CICD-SEC-4',

--- a/cli/agents/git-history-scanner.js
+++ b/cli/agents/git-history-scanner.js
@@ -8,7 +8,7 @@
  * they're deleted but they're still accessible.
  */
 
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import path from 'path';
 import { BaseAgent, createFinding } from './base-agent.js';
 import { SECRET_PATTERNS } from '../utils/patterns.js';
@@ -37,14 +37,14 @@ export class GitHistoryScanner extends BaseAgent {
       const maxCommits = options?.maxCommits || 50;
       const since = options?.since || null;
 
-      let gitLogCmd = `git -C "${rootPath}" log --all --diff-filter=A --diff-filter=M -p --no-color --max-count=${maxCommits}`;
+      const gitArgs = ['-C', rootPath, 'log', '--all', '--diff-filter=A', '--diff-filter=M', '-p', '--no-color', `--max-count=${parseInt(maxCommits, 10)}`];
       if (since) {
-        gitLogCmd += ` --since="${since}"`;
+        gitArgs.push(`--since=${since}`);
       }
 
       let diffOutput;
       try {
-        diffOutput = execSync(gitLogCmd, {
+        diffOutput = execFileSync('git', gitArgs, {
           cwd: rootPath,
           encoding: 'utf-8',
           maxBuffer: 50 * 1024 * 1024, // 50MB buffer
@@ -139,7 +139,10 @@ export class GitHistoryScanner extends BaseAgent {
 
   existsInWorkingTree(rootPath, secret) {
     try {
-      const result = execSync(`git -C "${rootPath}" grep -l "${secret.slice(0, 12)}" -- "*.js" "*.ts" "*.py" "*.env" "*.json" 2>/dev/null`, {
+      const result = execFileSync('git', [
+        '-C', rootPath, 'grep', '-l', secret.slice(0, 12),
+        '--', '*.js', '*.ts', '*.py', '*.env', '*.json'
+      ], {
         cwd: rootPath,
         encoding: 'utf-8',
         timeout: 5000,

--- a/cli/agents/injection-tester.js
+++ b/cli/agents/injection-tester.js
@@ -311,6 +311,38 @@ const PATTERNS = [
     description: 'User-controlled regex can cause catastrophic backtracking (ReDoS). Validate or use RE2.',
     fix: 'Use the re2 package for user-supplied patterns, or validate regex complexity',
   },
+  {
+    rule: 'REDOS_NESTED_QUANTIFIER',
+    title: 'ReDoS: Nested Quantifiers in Regex',
+    regex: /\/[^/]*\([^)]*[+*][^)]*\)[+*][^/]*\//g,
+    severity: 'high',
+    cwe: 'CWE-1333',
+    owasp: 'A03:2021',
+    description: 'Regex with nested quantifiers like (a+)+ or (\\w+)* causes catastrophic backtracking.',
+    fix: 'Rewrite to avoid nested repetition or use a non-backtracking engine (re2 package).',
+  },
+  {
+    rule: 'REDOS_DOT_STAR_LOOKAHEAD',
+    title: 'ReDoS: .* with Lookahead',
+    regex: /\/[^/]*\.\*[^/]*\(\?[!=][^/]*\//g,
+    severity: 'medium',
+    cwe: 'CWE-1333',
+    owasp: 'A03:2021',
+    description: 'Regex with .* followed by lookahead can cause catastrophic backtracking on non-matching input.',
+    fix: 'Replace .* with a bounded class like [^\\n]{0,N} or use a non-backtracking engine (re2).',
+  },
+
+  // ── Command Injection with Secrets ────────────────────────────────────────
+  {
+    rule: 'CMD_INJECTION_SECRET_INTERPOLATION',
+    title: 'Command Injection: Secret in Shell Command',
+    regex: /\bexec(?:Sync)?\s*\(\s*`[^`]*\$\{[^}]*(?:secret|password|token|apiKey|api_key|credential)[^}]*\}/gi,
+    severity: 'critical',
+    cwe: 'CWE-78',
+    owasp: 'A03:2021',
+    description: 'Secret or credential interpolated into shell command. Both a command injection and credential exposure risk.',
+    fix: 'Use execFileSync(cmd, [args]) with argument arrays. Never interpolate secrets into shell strings.',
+  },
 
   // ── Prototype Pollution ────────────────────────────────────────────────────
   {

--- a/cli/agents/llm-redteam.js
+++ b/cli/agents/llm-redteam.js
@@ -15,7 +15,7 @@ const PATTERNS = [
   {
     rule: 'LLM_PROMPT_INJECTION_NO_SANITIZE',
     title: 'Prompt Injection: No Input Sanitization',
-    regex: /(?:messages|prompt|content)\s*[:=]\s*(?:`[^`]*\$\{(?:req\.|request\.|body|query|params|input|user)|.*\+\s*(?:req\.|request\.|body|query|params|input|user))/g,
+    regex: /(?:messages|prompt|content)\s*[:=]\s*(?:`[^`]*\$\{(?:req\.|request\.|body|query|params|input|user)|[^\n]*\+\s*(?:req\.|request\.|body|query|params|input|user))/g,
     severity: 'high',
     cwe: 'CWE-77',
     owasp: 'LLM01',
@@ -25,7 +25,7 @@ const PATTERNS = [
   {
     rule: 'LLM_SYSTEM_USER_CONCAT',
     title: 'Prompt Injection: System + User Concatenation',
-    regex: /(?:system|systemPrompt|system_prompt)\s*[:=].*(?:\+\s*(?:user|input|query|message)|`[^`]*\$\{)/g,
+    regex: /(?:system|systemPrompt|system_prompt)\s*[:=][^\n]*(?:\+\s*(?:user|input|query|message)|`[^`]*\$\{)/g,
     severity: 'critical',
     cwe: 'CWE-77',
     owasp: 'LLM01',
@@ -37,7 +37,7 @@ const PATTERNS = [
   {
     rule: 'LLM_SECRET_IN_PROMPT',
     title: 'Sensitive Data in LLM Prompt',
-    regex: /(?:system|prompt|content)\s*[:=].*(?:API_KEY|api_key|SECRET|PASSWORD|TOKEN|PRIVATE_KEY|DATABASE_URL)/g,
+    regex: /(?:system|prompt|content)\s*[:=][^\n]*(?:API_KEY|api_key|SECRET|PASSWORD|TOKEN|PRIVATE_KEY|DATABASE_URL)/g,
     severity: 'critical',
     cwe: 'CWE-200',
     owasp: 'LLM02',

--- a/cli/agents/mobile-scanner.js
+++ b/cli/agents/mobile-scanner.js
@@ -60,12 +60,12 @@ const PATTERNS = [
   {
     rule: 'MOBILE_DEEPLINK_INJECTION',
     title: 'Mobile: Deep Link Parameter Injection',
-    regex: /(?:Linking\.getInitialURL|useURL|addEventListener.*url).*(?!validate|sanitize|verify)/g,
+    regex: /(?:Linking\.getInitialURL|useURL|addEventListener\s*\(\s*['"]url['"])/g,
     severity: 'high',
     cwe: 'CWE-20',
     owasp: 'M4',
     confidence: 'low',
-    description: 'Deep link URL parameters used without validation. Attacker can craft malicious links.',
+    description: 'Deep link URL handler detected. Ensure parameters from deep links are validated before use.',
     fix: 'Validate and sanitize all parameters from deep links before use',
   },
 

--- a/cli/commands/remediate.js
+++ b/cli/commands/remediate.js
@@ -34,7 +34,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { createInterface } from 'readline';
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import chalk from 'chalk';
 import ora from 'ora';
 import pkg from 'write-file-atomic';
@@ -270,6 +270,11 @@ function createBackupDir(rootPath) {
 function backupFile(filePath, backupDir, rootPath) {
   const rel = path.relative(rootPath, filePath);
   const dest = path.join(backupDir, rel);
+  const resolvedDest = path.resolve(dest);
+  const resolvedBackupDir = path.resolve(backupDir);
+  if (!resolvedDest.startsWith(resolvedBackupDir + path.sep) && resolvedDest !== resolvedBackupDir) {
+    throw new Error(`Path traversal detected: ${rel} escapes backup directory`);
+  }
   fs.mkdirSync(path.dirname(dest), { recursive: true });
   fs.copyFileSync(filePath, dest);
 }
@@ -414,8 +419,7 @@ function checkPublicRepo(rootPath) {
 function stageFiles(files, rootPath) {
   if (files.length === 0) return;
   try {
-    const quoted = files.map(f => `"${f}"`).join(' ');
-    execSync(`git add ${quoted}`, { cwd: rootPath, stdio: 'inherit' }); // ship-safe-ignore — paths come from our own file scan
+    execFileSync('git', ['add', ...files], { cwd: rootPath, stdio: 'inherit' });
     output.success(`Staged ${files.length} file(s) with git add`);
   } catch {
     output.warning('Could not stage files — run git add manually.');

--- a/cli/providers/llm-provider.js
+++ b/cli/providers/llm-provider.js
@@ -105,8 +105,7 @@ class AnthropicProvider extends BaseLLMProvider {
     });
 
     if (!response.ok) {
-      const body = await response.text();
-      throw new Error(`Anthropic API error ${response.status}: ${body.slice(0, 200)}`);
+      throw new Error(`Anthropic API error: HTTP ${response.status}`);
     }
 
     const data = await response.json();
@@ -143,8 +142,7 @@ class OpenAIProvider extends BaseLLMProvider {
     });
 
     if (!response.ok) {
-      const body = await response.text();
-      throw new Error(`OpenAI API error ${response.status}: ${body.slice(0, 200)}`);
+      throw new Error(`OpenAI API error: HTTP ${response.status}`);
     }
 
     const data = await response.json();
@@ -163,11 +161,14 @@ class GoogleProvider extends BaseLLMProvider {
   }
 
   async complete(systemPrompt, userPrompt, options = {}) {
-    const url = `https://generativelanguage.googleapis.com/v1beta/models/${this.model}:generateContent?key=${this.apiKey}`;
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${this.model}:generateContent`;
 
     const response = await fetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-goog-api-key': this.apiKey,
+      },
       body: JSON.stringify({
         systemInstruction: { parts: [{ text: systemPrompt }] },
         contents: [{ parts: [{ text: userPrompt }] }],
@@ -176,8 +177,7 @@ class GoogleProvider extends BaseLLMProvider {
     });
 
     if (!response.ok) {
-      const body = await response.text();
-      throw new Error(`Google API error ${response.status}: ${body.slice(0, 200)}`);
+      throw new Error(`Google API error: HTTP ${response.status}`);
     }
 
     const data = await response.json();
@@ -211,8 +211,7 @@ class OllamaProvider extends BaseLLMProvider {
     });
 
     if (!response.ok) {
-      const body = await response.text();
-      throw new Error(`Ollama error ${response.status}: ${body.slice(0, 200)}`);
+      throw new Error(`Ollama error: HTTP ${response.status}`);
     }
 
     const data = await response.json();


### PR DESCRIPTION
## Summary
Community-reported ReDoS vulnerability led to a full security audit of ship-safe's own codebase. This PR fixes **18 issues** across 9 files:

### ReDoS Fixes (8 patterns)
- Replace unbounded `.*` with line-scoped `[^\n]*` in cicd-scanner, llm-redteam, auth-bypass-agent
- Replace broken `[\s\S]{0,500}` multi-line pattern with simple keyword match in cicd-scanner
- Remove `.*(?!lookahead)` anti-pattern from mobile-scanner
- Replace `[^}]{50,500}(?!...)` with simpler login detection in auth-bypass-agent
- Add bounded `[^;]{0,100}` to cookie pattern in auth-bypass-agent

### Security Fixes (6 vulnerabilities)
- **Command injection** in git-history-scanner: `execSync` → `execFileSync` with argument arrays (2 instances)
- **Command injection** in remediate `stageFiles()`: same fix
- **API key in URL**: Google provider now uses `x-goog-api-key` header instead of query param
- **Info disclosure**: LLM provider errors no longer include response body
- **Path traversal**: `backupFile()` now validates destination stays within backup directory

### New Detection Rules (4 rules)
- `REDOS_NESTED_QUANTIFIER` — detects `(a+)+`, `(\w+)*` patterns
- `REDOS_DOT_STAR_LOOKAHEAD` — detects `.*` followed by lookahead
- `CMD_INJECTION_SECRET_INTERPOLATION` — detects secrets interpolated into exec calls
- `API_KEY_IN_URL` — detects API keys passed in URL query parameters

## Test plan
- [x] All 9 modified modules import without errors
- [x] CLI `--help` works
- [ ] Run `npx ship-safe audit .` on a test project
- [ ] Verify new rules detect known-bad patterns