### PR TITLE
feat(webapp): real stats + landing page demo scanner

### DIFF
--- a/webapp/app/api/demo-scan/route.ts
+++ b/webapp/app/api/demo-scan/route.ts
@@ -1,0 +1,148 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const execAsync = promisify(exec);
+
+/* ── Rate limiting (in-memory, per-IP) ── */
+const rateMap = new Map<string, { count: number; resetAt: number }>();
+const MAX_PER_HOUR = 3;
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const entry = rateMap.get(ip);
+  if (!entry || now > entry.resetAt) {
+    rateMap.set(ip, { count: 1, resetAt: now + 3600_000 });
+    return false;
+  }
+  if (entry.count >= MAX_PER_HOUR) return true;
+  entry.count++;
+  return false;
+}
+
+// Cleanup stale entries every 10 minutes
+setInterval(() => {
+  const now = Date.now();
+  for (const [ip, entry] of rateMap) {
+    if (now > entry.resetAt) rateMap.delete(ip);
+  }
+}, 600_000).unref?.();
+
+/* ── Validation ── */
+const GITHUB_URL_RE = /^https:\/\/github\.com\/[\w.-]+\/[\w.-]+(\.git)?$/;
+
+function parseGitHubUrl(url: string): { owner: string; repo: string } | null {
+  const m = url.match(/^https:\/\/github\.com\/([\w.-]+)\/([\w.-]+?)(?:\.git)?$/);
+  return m ? { owner: m[1], repo: m[2] } : null;
+}
+
+/* ── Handler ── */
+export async function POST(req: NextRequest) {
+  const ip =
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    req.headers.get('x-real-ip') ||
+    'unknown';
+
+  if (isRateLimited(ip)) {
+    return NextResponse.json(
+      { error: 'Rate limit exceeded. Try again in an hour.' },
+      { status: 429 },
+    );
+  }
+
+  let body: { repoUrl?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const { repoUrl } = body;
+  if (!repoUrl || !GITHUB_URL_RE.test(repoUrl)) {
+    return NextResponse.json(
+      { error: 'Provide a valid public GitHub repo URL (https://github.com/owner/repo)' },
+      { status: 400 },
+    );
+  }
+
+  const parsed = parseGitHubUrl(repoUrl);
+  if (!parsed) {
+    return NextResponse.json({ error: 'Invalid GitHub URL' }, { status: 400 });
+  }
+
+  const tmpDir = await mkdtemp(join(tmpdir(), 'shipsafe-demo-'));
+  const startTime = Date.now();
+
+  try {
+    // Shallow clone
+    await execAsync(`git clone --depth 1 ${repoUrl} ${join(tmpDir, 'repo')}`, {
+      timeout: 30_000,
+    });
+
+    const scanDir = join(tmpDir, 'repo');
+
+    // Run a lightweight scan with JSON output
+    const { stdout } = await execAsync(
+      `npx ship-safe audit ${scanDir} --json`,
+      { timeout: 60_000, maxBuffer: 10 * 1024 * 1024 },
+    );
+
+    const duration = Math.round((Date.now() - startTime) / 1000);
+    let report: Record<string, unknown> = {};
+    try {
+      report = JSON.parse(stdout);
+    } catch {
+      report = { raw: stdout };
+    }
+
+    const score = typeof report.score === 'number' ? report.score : null;
+    const grade = typeof report.grade === 'string' ? report.grade : null;
+    const totalFindings = typeof report.totalFindings === 'number' ? report.totalFindings : 0;
+
+    // Extract top findings for highlights
+    const findings = Array.isArray(report.findings) ? report.findings : [];
+    const highlights = findings.slice(0, 5).map((f: Record<string, unknown>) => ({
+      title: f.title || f.message || 'Finding',
+      severity: f.severity || 'medium',
+      category: f.category || 'general',
+    }));
+
+    // Category summary
+    const cats = report.categories as Record<string, { findingCount?: number }> | undefined;
+    const categories: Record<string, number> = {};
+    if (cats) {
+      for (const [key, val] of Object.entries(cats)) {
+        if (val?.findingCount) categories[key] = val.findingCount;
+      }
+    }
+
+    return NextResponse.json({
+      repo: `${parsed.owner}/${parsed.repo}`,
+      score,
+      grade,
+      totalFindings,
+      categories,
+      highlights,
+      duration,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+
+    if (message.includes('Repository not found') || message.includes('fatal:')) {
+      return NextResponse.json(
+        { error: 'Could not clone repository. Make sure it exists and is public.' },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json(
+      { error: 'Scan failed. The repository may be too large or private.' },
+      { status: 500 },
+    );
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+}

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -7,15 +7,20 @@ import PricingTeaser from '@/components/PricingTeaser';
 import FAQ from '@/components/FAQ';
 import CTA from '@/components/CTA';
 import ScrollAnimator from '@/components/ScrollAnimator';
+import DemoScanner from '@/components/DemoScanner';
+import { getRepoStats } from '@/lib/stats';
 
-export default function Home() {
+export default async function Home() {
+  const { stars, downloads } = await getRepoStats();
+
   return (
     <>
       <ScrollAnimator />
       <Nav />
       <main>
-        <Hero />
-        <TrustBar />
+        <Hero stars={stars} downloads={downloads} />
+        <TrustBar stars={stars} downloads={downloads} />
+        <DemoScanner />
         <HowItWorks />
         <Features />
         <PricingTeaser />

--- a/webapp/components/DemoScanner.module.css
+++ b/webapp/components/DemoScanner.module.css
@@ -1,0 +1,386 @@
+.section {
+  padding: 4rem 0;
+  position: relative;
+}
+
+.sectionHeader {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.sectionTag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--cyan);
+  margin-bottom: 0.75rem;
+}
+
+.sectionTitle {
+  font-size: 1.5rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin-bottom: 0.5rem;
+}
+
+.sectionSub {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  max-width: 480px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+/* Input row */
+.inputRow {
+  display: flex;
+  gap: 0.5rem;
+  max-width: 560px;
+  margin: 0 auto 2rem;
+}
+
+.urlInput {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  padding: 0.7rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.7);
+  backdrop-filter: blur(8px);
+  color: var(--text);
+  outline: none;
+  transition: border-color 0.15s;
+}
+.urlInput::placeholder { color: var(--text-dim); }
+.urlInput:focus { border-color: var(--cyan); }
+
+.scanBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.7rem 1.25rem;
+  border: none;
+  border-radius: var(--radius);
+  background: var(--cyan);
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: opacity 0.15s;
+  white-space: nowrap;
+}
+.scanBtn:hover { opacity: 0.9; }
+.scanBtn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Result card */
+.resultCard {
+  max-width: 600px;
+  margin: 0 auto;
+  background: rgba(255, 255, 255, 0.7);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.06), 0 8px 32px rgba(0,0,0,0.06);
+}
+
+/* Terminal header */
+.cardHeader {
+  background: var(--bg-card2);
+  border-bottom: 1px solid var(--border);
+  padding: 0.6rem 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dots { display: flex; gap: 0.3rem; }
+.dot { width: 10px; height: 10px; border-radius: 50%; }
+.dotR { background: #dc2626; }
+.dotY { background: #d97706; }
+.dotG { background: #16a34a; }
+
+.cardTitle {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--text-dim);
+  margin-left: 0.35rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cardBadge {
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 0.15em 0.5em;
+  border-radius: 4px;
+}
+.badgeDemo {
+  color: var(--cyan);
+  background: rgba(8,145,178,0.08);
+  border: 1px solid rgba(8,145,178,0.2);
+}
+.badgeLive {
+  color: var(--green);
+  background: rgba(22,163,74,0.08);
+  border: 1px solid rgba(22,163,74,0.2);
+}
+
+/* Scanning state */
+.scanning {
+  padding: 1.5rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.scanLine {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--border);
+  border-top-color: var(--cyan);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.checkmark {
+  color: var(--green);
+  font-size: 0.8rem;
+  flex-shrink: 0;
+  width: 14px;
+  text-align: center;
+}
+
+.shimmer {
+  height: 12px;
+  flex: 1;
+  background: linear-gradient(90deg, var(--border) 25%, rgba(8,145,178,0.08) 50%, var(--border) 75%);
+  background-size: 200% 100%;
+  border-radius: 4px;
+  animation: shimmer 1.5s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* Results body */
+.resultBody {
+  padding: 1.25rem;
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+/* Score ring (left side) */
+.scoreCol {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.ringWrap { position: relative; width: 88px; height: 88px; }
+
+.scoreRing { display: block; }
+
+.scoreArc {
+  transition: stroke-dashoffset 1.5s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.ringLabel {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+}
+
+.scoreNum {
+  font-family: var(--font-mono);
+  font-size: 1.35rem;
+  font-weight: 700;
+  line-height: 1;
+}
+.scoreSub {
+  font-family: var(--font-mono);
+  font-size: 0.55rem;
+  color: var(--text-dim);
+  margin-top: 1px;
+}
+
+.gradeRow {
+  display: flex;
+  align-items: baseline;
+  gap: 0.3rem;
+}
+.gradeLetter {
+  font-family: var(--font-mono);
+  font-size: 1.1rem;
+  font-weight: 800;
+  line-height: 1;
+}
+.gradeText {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+/* Findings (right side) */
+.findingsCol {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.findingsTitle {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.findingRow {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.severityDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.sevCritical { background: var(--red); }
+.sevHigh { background: #f59e0b; }
+.sevMedium { background: var(--yellow); }
+.sevLow { background: var(--green); }
+
+.findingText {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.findingCat {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  color: var(--text-dim);
+  flex-shrink: 0;
+}
+
+.statsPills {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.25rem;
+}
+
+.pill {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-weight: 600;
+  padding: 0.2em 0.55em;
+  border-radius: 5px;
+  border: 1px solid var(--border);
+  background: var(--bg-card2);
+  color: var(--text-muted);
+}
+
+.duration {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--text-dim);
+  margin-top: 0.2rem;
+}
+
+/* Footer CTA */
+.cardFooter {
+  border-top: 1px solid var(--border);
+  padding: 0.75rem 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.footerText {
+  font-size: 0.75rem;
+  color: var(--text-dim);
+}
+
+.footerCta {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--cyan);
+  text-decoration: none;
+  white-space: nowrap;
+}
+.footerCta:hover { text-decoration: underline; }
+
+/* Error */
+.error {
+  padding: 1.25rem;
+  text-align: center;
+  color: var(--red);
+  font-size: 0.85rem;
+}
+
+/* Empty / example label */
+.exampleLabel {
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  margin-bottom: 0.75rem;
+}
+
+@media (max-width: 600px) {
+  .inputRow {
+    flex-direction: column;
+  }
+  .resultBody {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+  .findingRow {
+    justify-content: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner { animation: none; }
+  .shimmer { animation: none; }
+}

--- a/webapp/components/DemoScanner.tsx
+++ b/webapp/components/DemoScanner.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import Link from 'next/link';
+import styles from './DemoScanner.module.css';
+
+interface ScanResult {
+  repo: string;
+  score: number | null;
+  grade: string | null;
+  totalFindings: number;
+  categories: Record<string, number>;
+  highlights: { title: string; severity: string; category: string }[];
+  duration: number;
+}
+
+/* Pre-rendered example so visitors see value immediately */
+const EXAMPLE_RESULT: ScanResult = {
+  repo: 'example/vulnerable-app',
+  score: 62,
+  grade: 'C',
+  totalFindings: 12,
+  categories: { secrets: 3, injection: 4, auth: 2, dependencies: 3 },
+  highlights: [
+    { title: 'AWS access key exposed in .env.example', severity: 'critical', category: 'secrets' },
+    { title: 'SQL injection in user query endpoint', severity: 'high', category: 'injection' },
+    { title: 'JWT secret hardcoded in auth config', severity: 'critical', category: 'auth' },
+    { title: 'lodash@4.17.20 — prototype pollution (CVE-2021-23337)', severity: 'high', category: 'dependencies' },
+    { title: 'Missing rate limiting on login route', severity: 'medium', category: 'auth' },
+  ],
+  duration: 4,
+};
+
+type Phase = 'idle' | 'scanning' | 'done' | 'error';
+
+const SCAN_STEPS = [
+  'Cloning repository…',
+  'Scanning for secrets…',
+  'Analyzing dependencies…',
+  'Checking code patterns…',
+  'Generating report…',
+];
+
+function scoreColor(score: number | null) {
+  if (score === null) return 'var(--text-dim)';
+  if (score >= 90) return 'var(--green)';
+  if (score >= 70) return 'var(--cyan)';
+  if (score >= 50) return 'var(--yellow)';
+  return 'var(--red)';
+}
+
+function sevClass(sev: string) {
+  switch (sev) {
+    case 'critical': return styles.sevCritical;
+    case 'high': return styles.sevHigh;
+    case 'medium': return styles.sevMedium;
+    default: return styles.sevLow;
+  }
+}
+
+export default function DemoScanner() {
+  const [url, setUrl] = useState('');
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [step, setStep] = useState(0);
+  const [result, setResult] = useState<ScanResult | null>(null);
+  const [error, setError] = useState('');
+  const [isExample, setIsExample] = useState(true);
+
+  const displayResult = isExample ? EXAMPLE_RESULT : result;
+
+  async function handleScan(e: FormEvent) {
+    e.preventDefault();
+    if (!url.trim()) return;
+
+    setPhase('scanning');
+    setStep(0);
+    setError('');
+    setIsExample(false);
+    setResult(null);
+
+    // Animate through steps
+    const stepInterval = setInterval(() => {
+      setStep((s) => Math.min(s + 1, SCAN_STEPS.length - 1));
+    }, 3000);
+
+    try {
+      const res = await fetch('/api/demo-scan', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ repoUrl: url.trim() }),
+      });
+
+      clearInterval(stepInterval);
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({ error: 'Scan failed' }));
+        setError(data.error || 'Scan failed');
+        setPhase('error');
+        return;
+      }
+
+      const data: ScanResult = await res.json();
+      setResult(data);
+      setPhase('done');
+    } catch {
+      clearInterval(stepInterval);
+      setError('Network error. Please try again.');
+      setPhase('error');
+    }
+  }
+
+  const showResult = phase === 'idle' || phase === 'done';
+  const activeResult = showResult ? displayResult : null;
+
+  return (
+    <section className={styles.section} id="demo">
+      <div className="container">
+        <div className={styles.sectionHeader}>
+          <div className={styles.sectionTag}>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+              <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+            </svg>
+            Live Demo
+          </div>
+          <h2 className={styles.sectionTitle}>Try it now</h2>
+          <p className={styles.sectionSub}>
+            Paste any public GitHub repo URL and see what ship-safe finds in seconds.
+          </p>
+        </div>
+
+        <form onSubmit={handleScan} className={styles.inputRow}>
+          <input
+            type="url"
+            className={styles.urlInput}
+            placeholder="https://github.com/owner/repo"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            disabled={phase === 'scanning'}
+          />
+          <button
+            type="submit"
+            className={styles.scanBtn}
+            disabled={phase === 'scanning' || !url.trim()}
+          >
+            {phase === 'scanning' ? (
+              <>
+                <span className={styles.spinner} />
+                Scanning…
+              </>
+            ) : (
+              <>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+                  <circle cx="11" cy="11" r="8" />
+                  <line x1="21" y1="21" x2="16.65" y2="16.65" />
+                </svg>
+                Scan
+              </>
+            )}
+          </button>
+        </form>
+
+        {/* Result card */}
+        <div className={styles.resultCard}>
+          <div className={styles.cardHeader}>
+            <div className={styles.dots}>
+              <span className={`${styles.dot} ${styles.dotR}`} />
+              <span className={`${styles.dot} ${styles.dotY}`} />
+              <span className={`${styles.dot} ${styles.dotG}`} />
+            </div>
+            <span className={styles.cardTitle}>
+              {activeResult ? `ship-safe audit — ${activeResult.repo}` : 'ship-safe audit'}
+            </span>
+            <span className={`${styles.cardBadge} ${isExample ? styles.badgeDemo : styles.badgeLive}`}>
+              {isExample ? 'EXAMPLE' : 'LIVE'}
+            </span>
+          </div>
+
+          {/* Scanning state */}
+          {phase === 'scanning' && (
+            <div className={styles.scanning}>
+              {SCAN_STEPS.map((text, i) => (
+                <div key={i} className={styles.scanLine}>
+                  {i < step ? (
+                    <span className={styles.checkmark}>✓</span>
+                  ) : i === step ? (
+                    <span className={styles.spinner} />
+                  ) : (
+                    <span style={{ width: 14 }} />
+                  )}
+                  <span style={{ opacity: i <= step ? 1 : 0.4 }}>{text}</span>
+                  {i > step && <span className={styles.shimmer} />}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Error state */}
+          {phase === 'error' && (
+            <div className={styles.error}>{error}</div>
+          )}
+
+          {/* Results */}
+          {activeResult && showResult && (
+            <>
+              {isExample && (
+                <div className={styles.exampleLabel}>Example scan result</div>
+              )}
+              <div className={styles.resultBody}>
+                <div className={styles.scoreCol}>
+                  <div className={styles.ringWrap}>
+                    <svg viewBox="0 0 88 88" width="88" height="88" className={styles.scoreRing}>
+                      <circle cx="44" cy="44" r="36" fill="none" stroke="var(--border)" strokeWidth="5" />
+                      <circle
+                        cx="44" cy="44" r="36"
+                        fill="none"
+                        stroke={scoreColor(activeResult.score)}
+                        strokeWidth="5"
+                        strokeLinecap="round"
+                        strokeDasharray={`${2 * Math.PI * 36}`}
+                        strokeDashoffset={`${2 * Math.PI * 36 * (1 - (activeResult.score ?? 0) / 100)}`}
+                        transform="rotate(-90 44 44)"
+                        className={styles.scoreArc}
+                      />
+                    </svg>
+                    <div className={styles.ringLabel}>
+                      <span className={styles.scoreNum} style={{ color: scoreColor(activeResult.score) }}>
+                        {activeResult.score ?? '—'}
+                      </span>
+                      <span className={styles.scoreSub}>/100</span>
+                    </div>
+                  </div>
+                  <div className={styles.gradeRow}>
+                    <span className={styles.gradeLetter} style={{ color: scoreColor(activeResult.score) }}>
+                      {activeResult.grade ?? '—'}
+                    </span>
+                    <span className={styles.gradeText}>
+                      {(activeResult.score ?? 0) >= 90 ? 'Ship it!' :
+                       (activeResult.score ?? 0) >= 70 ? 'Almost there' :
+                       (activeResult.score ?? 0) >= 50 ? 'Needs work' : 'Critical'}
+                    </span>
+                  </div>
+                </div>
+
+                <div className={styles.findingsCol}>
+                  <div className={styles.findingsTitle}>
+                    {activeResult.totalFindings} finding{activeResult.totalFindings !== 1 ? 's' : ''} detected
+                  </div>
+                  {activeResult.highlights.map((h, i) => (
+                    <div key={i} className={styles.findingRow}>
+                      <span className={`${styles.severityDot} ${sevClass(h.severity)}`} />
+                      <span className={styles.findingText}>{h.title}</span>
+                      <span className={styles.findingCat}>{h.category}</span>
+                    </div>
+                  ))}
+                  {Object.keys(activeResult.categories).length > 0 && (
+                    <div className={styles.statsPills}>
+                      {Object.entries(activeResult.categories).map(([cat, count]) => (
+                        <span key={cat} className={styles.pill}>{cat}: {count}</span>
+                      ))}
+                    </div>
+                  )}
+                  <div className={styles.duration}>{activeResult.duration}s scan time</div>
+                </div>
+              </div>
+
+              <div className={styles.cardFooter}>
+                <span className={styles.footerText}>
+                  {isExample
+                    ? 'Scan your own repo to see real results'
+                    : 'Full report available with a free account'}
+                </span>
+                <Link href="/signup" className={styles.footerCta}>
+                  Get full report →
+                </Link>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/webapp/components/Hero.tsx
+++ b/webapp/components/Hero.tsx
@@ -2,15 +2,20 @@
 import { useEffect } from 'react';
 import Link from 'next/link';
 import styles from './Hero.module.css';
+import { formatNumber } from '@/lib/stats';
 
-const stats = [
-  { num: '16', label: 'Security agents' },
-  { num: '80+', label: 'Attack classes' },
-  { num: '5', label: 'OWASP standards' },
-  { num: '<5s', label: 'To run' },
-];
+interface HeroProps {
+  stars?: number;
+  downloads?: number;
+}
 
-export default function Hero() {
+export default function Hero({ stars, downloads }: HeroProps) {
+  const stats = [
+    { num: '16', label: 'Security agents' },
+    { num: '80+', label: 'Attack classes' },
+    { num: stars ? formatNumber(stars) : '1.2k', label: 'GitHub stars' },
+    { num: downloads ? formatNumber(downloads) : '8k+', label: 'Weekly downloads' },
+  ];
   useEffect(() => {
     const scoreEl = document.getElementById('score-val');
     const arcEl = document.getElementById('score-arc') as SVGCircleElement | null;

--- a/webapp/components/TrustBar.tsx
+++ b/webapp/components/TrustBar.tsx
@@ -1,4 +1,5 @@
 import styles from './TrustBar.module.css';
+import { formatNumber } from '@/lib/stats';
 
 const badges = [
   { label: 'Node.js', icon: '⬢' },
@@ -8,7 +9,12 @@ const badges = [
   { label: 'Claude Code', icon: '◈' },
 ];
 
-export default function TrustBar() {
+interface TrustBarProps {
+  stars?: number;
+  downloads?: number;
+}
+
+export default function TrustBar({ stars, downloads }: TrustBarProps) {
   return (
     <section className={styles.trustBar}>
       <div className="container">
@@ -17,7 +23,7 @@ export default function TrustBar() {
             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" className={styles.statIcon}>
               <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
             </svg>
-            <span className={styles.statNum}>★ 1.2k</span>
+            <span className={styles.statNum}>★ {stars ? formatNumber(stars) : '1.2k'}</span>
             <span className={styles.statLabel}>GitHub stars</span>
           </div>
 
@@ -29,7 +35,7 @@ export default function TrustBar() {
               <polyline points="7 10 12 15 17 10" />
               <line x1="12" y1="15" x2="12" y2="3" />
             </svg>
-            <span className={styles.statNum}>8k+</span>
+            <span className={styles.statNum}>{downloads ? formatNumber(downloads) : '8k+'}</span>
             <span className={styles.statLabel}>weekly downloads</span>
           </div>
 

--- a/webapp/lib/stats.ts
+++ b/webapp/lib/stats.ts
@@ -1,0 +1,37 @@
+import { unstable_cache } from 'next/cache';
+
+const GITHUB_OWNER = 'asamassekou10';
+const GITHUB_REPO = 'ship-safe';
+const NPM_PACKAGE = 'ship-safe';
+
+const FALLBACK = { stars: 1200, downloads: 8000 };
+
+export function formatNumber(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1).replace(/\.0$/, '')}k`;
+  return String(n);
+}
+
+async function fetchRepoStats(): Promise<{ stars: number; downloads: number }> {
+  const [stars, downloads] = await Promise.all([
+    fetch(`https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}`, {
+      headers: { Accept: 'application/vnd.github.v3+json' },
+      next: { revalidate: 3600 },
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => d?.stargazers_count ?? FALLBACK.stars)
+      .catch(() => FALLBACK.stars),
+
+    fetch(`https://api.npmjs.org/downloads/point/last-week/${NPM_PACKAGE}`, {
+      next: { revalidate: 3600 },
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => d?.downloads ?? FALLBACK.downloads)
+      .catch(() => FALLBACK.downloads),
+  ]);
+
+  return { stars, downloads };
+}
+
+export const getRepoStats = unstable_cache(fetchRepoStats, ['repo-stats'], {
+  revalidate: 3600,
+});


### PR DESCRIPTION
## Summary
- **Real stats**: Hero and TrustBar now display live GitHub stars and npm weekly downloads (fetched server-side, cached 1 hour, graceful fallback to hardcoded values)
- **Demo scanner**: Interactive section on the landing page where visitors can paste any public GitHub repo URL and see a scan result in seconds — no signup required
- **Pre-rendered example**: A hardcoded example scan result is shown on page load so visitors immediately see what the tool does

## New files
- `webapp/lib/stats.ts` — GitHub/npm stats fetcher with `unstable_cache`
- `webapp/app/api/demo-scan/route.ts` — Public scan API (rate-limited 3/IP/hr, 60s timeout, temp dir cleanup)
- `webapp/components/DemoScanner.tsx` — Client component with input, animated progress, and score ring results
- `webapp/components/DemoScanner.module.css` — Frosted glass card styling, responsive, reduced-motion support

## Modified files
- `webapp/app/page.tsx` — Async server component, fetches stats, passes props, adds DemoScanner section
- `webapp/components/Hero.tsx` — Accepts stats props, replaces hardcoded values
- `webapp/components/TrustBar.tsx` — Accepts stats props, replaces hardcoded values

## Test plan
- [ ] Landing page loads with real star/download counts (or fallback values)
- [ ] Demo scanner shows pre-rendered example on page load
- [ ] Entering a valid public repo URL triggers scan with animated progress
- [ ] Scan results display score ring, grade, findings, and categories
- [ ] Rate limiting returns 429 after 3 scans in an hour
- [ ] Invalid URLs show validation error
- [ ] Mobile responsive layout works correctly