### PR TITLE
fix(webapp): stripe pre-live fixes

### DIFF
--- a/webapp/app/api/checkout/route.ts
+++ b/webapp/app/api/checkout/route.ts
@@ -21,16 +21,7 @@ export async function POST(req: NextRequest) {
   const checkoutSession = await stripe.checkout.sessions.create({
     mode: 'payment',
     customer_email: session.user.email,
-    line_items: [
-      {
-        price_data: {
-          currency: 'usd',
-          product_data: { name: planConfig.name },
-          unit_amount: planConfig.price,
-        },
-        quantity: 1,
-      },
-    ],
+    line_items: [{ price: planConfig.priceId, quantity: 1 }],
     metadata: {
       userId: session.user.id,
       plan,

--- a/webapp/app/app/UpgradeToast.tsx
+++ b/webapp/app/app/UpgradeToast.tsx
@@ -1,0 +1,62 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
+
+export default function UpgradeToast() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const [plan, setPlan] = useState<string | null>(null);
+
+  useEffect(() => {
+    const upgraded = searchParams.get('upgraded');
+    if (upgraded) {
+      setPlan(upgraded);
+      // Remove the query param without a full reload
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete('upgraded');
+      const newUrl = pathname + (params.size > 0 ? `?${params}` : '');
+      router.replace(newUrl);
+      // Auto-dismiss after 6s
+      const t = setTimeout(() => setPlan(null), 6000);
+      return () => clearTimeout(t);
+    }
+  }, [searchParams, router, pathname]);
+
+  if (!plan) return null;
+
+  const label = plan === 'team' ? 'Team' : 'Pro';
+
+  return (
+    <div style={{
+      position: 'fixed',
+      bottom: '1.5rem',
+      right: '1.5rem',
+      zIndex: 1000,
+      background: 'var(--cyan)',
+      color: '#fff',
+      padding: '0.85rem 1.25rem',
+      borderRadius: '12px',
+      fontWeight: 600,
+      fontSize: '0.9rem',
+      boxShadow: '0 4px 24px rgba(8,145,178,0.35)',
+      display: 'flex',
+      alignItems: 'center',
+      gap: '0.6rem',
+      animation: 'slideUp 0.3s ease',
+    }}>
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+        <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+        <polyline points="22 4 12 14.01 9 11.01" />
+      </svg>
+      Welcome to Ship Safe {label}! Your plan is now active.
+      <button
+        onClick={() => setPlan(null)}
+        style={{ background: 'none', border: 'none', color: '#fff', cursor: 'pointer', opacity: 0.7, marginLeft: '0.25rem', fontSize: '1rem', lineHeight: 1 }}
+        aria-label="Dismiss"
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/webapp/app/app/page.tsx
+++ b/webapp/app/app/page.tsx
@@ -1,8 +1,10 @@
 import Link from 'next/link';
+import { Suspense } from 'react';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { redirect } from 'next/navigation';
 import styles from './dashboard.module.css';
+import UpgradeToast from './UpgradeToast';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -51,6 +53,7 @@ export default async function Dashboard() {
 
   return (
     <div className={styles.page}>
+      <Suspense fallback={null}><UpgradeToast /></Suspense>
       <div className={styles.header}>
         <div>
           <h1>Dashboard</h1>

--- a/webapp/app/app/scan/page.tsx
+++ b/webapp/app/app/scan/page.tsx
@@ -50,7 +50,11 @@ export default function NewScan() {
 
         const res = await fetch('/api/scan/upload', { method: 'POST', body: formData });
         const data = await res.json();
-        if (!res.ok) { setError(data.error || 'Upload failed'); setScanning(false); return; }
+        if (!res.ok) {
+          setError(res.status === 429 ? '__LIMIT__' : (data.error || 'Upload failed'));
+          setScanning(false);
+          return;
+        }
         router.push(`/app/scans/${data.id}`);
         return;
       }
@@ -69,7 +73,15 @@ export default function NewScan() {
       });
 
       const data = await res.json();
-      if (!res.ok) { setError(data.error || 'Scan failed'); setScanning(false); return; }
+      if (!res.ok) {
+        if (res.status === 429) {
+          setError('__LIMIT__');
+        } else {
+          setError(data.error || 'Scan failed');
+        }
+        setScanning(false);
+        return;
+      }
       router.push(`/app/scans/${data.id}`);
     } catch {
       setError('Network error. Please try again.');
@@ -210,7 +222,17 @@ export default function NewScan() {
           </label>
         </div>
 
-        {error && <div className={styles.error}>{error}</div>}
+        {error === '__LIMIT__' ? (
+          <div className={styles.error}>
+            Free plan limit reached (5 scans/month).{' '}
+            <a href="/app/settings" style={{ color: 'var(--cyan)', textDecoration: 'underline' }}>
+              Upgrade to Pro
+            </a>{' '}
+            for unlimited scans.
+          </div>
+        ) : error ? (
+          <div className={styles.error}>{error}</div>
+        ) : null}
 
         <button type="submit" className={`btn btn-primary ${styles.submitBtn}`} disabled={scanning}>
           {scanning ? (

--- a/webapp/app/app/settings/UpgradeButton.tsx
+++ b/webapp/app/app/settings/UpgradeButton.tsx
@@ -1,29 +1,62 @@
 'use client';
 import { useState } from 'react';
+import s from './settings.module.css';
+
+type Plan = 'pro' | 'team';
+
+const PLAN_INFO = {
+  pro:  { label: 'Pro',  price: '$9',  desc: 'Unlimited scans · Private repos · AI analysis · API access' },
+  team: { label: 'Team', price: '$19', desc: 'Everything in Pro · Shared workspace · Role-based access · Webhooks' },
+} as const;
 
 export default function UpgradeButton() {
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState<Plan | null>(null);
+  const [error, setError] = useState('');
 
-  async function handleUpgrade() {
-    setLoading(true);
+  async function handleUpgrade(plan: Plan) {
+    setError('');
+    setLoading(plan);
     try {
       const res = await fetch('/api/checkout', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ plan: 'pro' }),
+        body: JSON.stringify({ plan }),
       });
       const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || 'Something went wrong. Please try again.');
+        setLoading(null);
+        return;
+      }
       if (data.url) {
         window.location.href = data.url;
       }
     } catch {
-      setLoading(false);
+      setError('Network error. Please try again.');
+      setLoading(null);
     }
   }
 
   return (
-    <button className="btn btn-primary" onClick={handleUpgrade} disabled={loading}>
-      {loading ? 'Redirecting...' : 'Upgrade to Pro — $9'}
-    </button>
+    <div className={s.planOptions}>
+      {(['pro', 'team'] as Plan[]).map(plan => (
+        <div key={plan} className={s.planOption}>
+          <div className={s.planOptionHeader}>
+            <span className={s.planOptionName}>{PLAN_INFO[plan].label}</span>
+            <span className={s.planOptionPrice}>{PLAN_INFO[plan].price} <span className={s.planOptionOnce}>one-time</span></span>
+          </div>
+          <p className={s.planOptionDesc}>{PLAN_INFO[plan].desc}</p>
+          <button
+            className="btn btn-primary"
+            onClick={() => handleUpgrade(plan)}
+            disabled={loading !== null}
+            style={{ width: '100%', marginTop: '0.5rem' }}
+          >
+            {loading === plan ? 'Redirecting...' : `Upgrade to ${PLAN_INFO[plan].label}`}
+          </button>
+        </div>
+      ))}
+      {error && <p className={s.error}>{error}</p>}
+    </div>
   );
 }

--- a/webapp/app/app/settings/page.tsx
+++ b/webapp/app/app/settings/page.tsx
@@ -66,12 +66,14 @@ export default async function Settings() {
             </div>
             <div className={s.planDesc}>
               {user.plan === 'free'
-                ? '5 cloud scans per month · Public repos'
-                : 'Unlimited cloud scans · Private repos · AI analysis'}
+                ? '5 cloud scans per month · Public repos only'
+                : user.plan === 'team'
+                ? 'Unlimited scans · Private repos · Shared workspace · Webhooks'
+                : 'Unlimited scans · Private repos · AI analysis · API access'}
             </div>
           </div>
-          {user.plan === 'free' && <UpgradeButton />}
         </div>
+        {user.plan === 'free' && <UpgradeButton />}
       </div>
 
       {/* Payment history */}

--- a/webapp/app/app/settings/settings.module.css
+++ b/webapp/app/app/settings/settings.module.css
@@ -167,3 +167,35 @@
 }
 
 .error { color: var(--red); font-size: 0.82rem; margin-top: 0.5rem; }
+
+/* Plan upgrade options */
+.planOptions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-top: 1rem;
+  width: 100%;
+}
+
+@media (max-width: 600px) {
+  .planOptions { grid-template-columns: 1fr; }
+}
+
+.planOption {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.1rem 1.25rem;
+}
+
+.planOptionHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 0.35rem;
+}
+
+.planOptionName { font-weight: 700; font-size: 1rem; }
+.planOptionPrice { font-weight: 700; font-size: 1.1rem; color: var(--cyan); }
+.planOptionOnce { font-size: 0.72rem; font-weight: 400; color: var(--text-dim); }
+.planOptionDesc { font-size: 0.78rem; color: var(--text-muted); line-height: 1.5; }

--- a/webapp/lib/stripe.ts
+++ b/webapp/lib/stripe.ts
@@ -21,10 +21,12 @@ export const stripe = new Proxy({} as Stripe, {
 
 export const PLANS = {
   pro: {
+    priceId: 'price_1TD476CDeQdNDMtzO0XkRs8o',
     price: 900, // $9 in cents
     name: 'Ship Safe Pro',
   },
   team: {
+    priceId: 'price_1TD47iCDeQdNDMtzpvJelLIa',
     price: 1900, // $19 in cents
     name: 'Ship Safe Team',
   },


### PR DESCRIPTION
## Summary
- **Checkout priceId bug**: was using `price_data` (ad-hoc prices) instead of `price: planConfig.priceId` — revenue was not tied to the real Stripe products configured in the dashboard
- **Upgrade success toast**: after payment completes, users land on `/app?upgraded=pro` and now see a dismissible toast confirming their new plan; URL is cleaned up with `router.replace`
- **Plan selector in Settings**: `UpgradeButton` now shows Pro ($9) and Team ($19) side by side with feature descriptions; errors surface to the user instead of silently stopping
- **Scan limit UX**: when free users hit 5 scans/month, the error on the scan page is now an inline link to `/app/settings` to upgrade (covers both GitHub URL and ZIP upload paths)

## Files changed
- `webapp/app/api/checkout/route.ts` — use `price: priceId` instead of `price_data`
- `webapp/app/app/UpgradeToast.tsx` — new client component
- `webapp/app/app/page.tsx` — add `<UpgradeToast>` wrapped in `<Suspense>`
- `webapp/app/app/settings/UpgradeButton.tsx` — two-plan selector with error feedback
- `webapp/app/app/settings/settings.module.css` — plan option grid styles
- `webapp/app/app/settings/page.tsx` — improved plan descriptions, layout tweak
- `webapp/app/app/scan/page.tsx` — 429 → upgrade link instead of raw error text