### PR TITLE
fix(webapp): construct ship-safe bin path without require.resolve

### DIFF
--- a/webapp/app/api/scan/route.ts
+++ b/webapp/app/api/scan/route.ts
@@ -10,13 +10,11 @@ import { mkdtemp, rm, writeFile, mkdir } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import * as tar from 'tar';
-import { createRequire } from 'module';
 
 const execAsync = promisify(exec);
 
-// Resolve ship-safe bin path at startup — works regardless of process.cwd()
-const _require = createRequire(import.meta.url);
-const SHIP_SAFE_BIN = _require.resolve('ship-safe/cli/bin/ship-safe.js');
+// Construct path at runtime — avoids webpack module ID substitution
+const SHIP_SAFE_BIN = join(process.cwd(), 'node_modules', 'ship-safe', 'cli', 'bin', 'ship-safe.js');
 const FREE_MONTHLY_LIMIT = 5;
 
 export async function POST(req: NextRequest) {


### PR DESCRIPTION
require.resolve() is intercepted by webpack at build time and replaced with a numeric module ID (e.g. 56123). Construct the path as a plain string using join(process.cwd(), 'node_modules', 'ship-safe', 'cli', 'bin', 'ship-safe.js') which webpack cannot statically analyze.