### PR TITLE
fix(webapp): serverExternalPackages for ship-safe

### DIFF
--- a/webapp/next.config.mjs
+++ b/webapp/next.config.mjs
@@ -11,6 +11,9 @@ const nextConfig = {
   // Pin trace root to webapp/ so Next.js doesn't crawl into the parent monorepo.
   // Vercel sets its own root, so this only matters for local Windows builds.
   outputFileTracingRoot: resolve(__dirname),
+  // Exclude ship-safe from webpack bundling so its files are deployed as-is
+  // and can be found by the scan API route at runtime via process.cwd().
+  serverExternalPackages: ['ship-safe'],
 };
 
 export default nextConfig;


### PR DESCRIPTION
Vercel bundles all node_modules via webpack — ship-safe files don't exist at runtime. Adding ship-safe to serverExternalPackages tells Next.js to skip bundling it, so nft (Node File Tracing) includes the real files in the Lambda deployment.