### PR TITLE
fix(webapp): force nft to include ship-safe files via outputFileTracingIncludes

### DIFF
--- a/webapp/next.config.mjs
+++ b/webapp/next.config.mjs
@@ -14,6 +14,11 @@ const nextConfig = {
   // Exclude ship-safe from webpack bundling so its files are deployed as-is
   // and can be found by the scan API route at runtime via process.cwd().
   serverExternalPackages: ['ship-safe'],
+  // Explicitly include ship-safe files in the Lambda bundle — nft won't trace
+  // them automatically because we run ship-safe as a subprocess (no import).
+  outputFileTracingIncludes: {
+    '/api/scan': ['./node_modules/ship-safe/**/*'],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
serverExternalPackages prevents webpack bundling but Vercel's nft (Node File Tracer) still excludes ship-safe because it's never imported — only run as a subprocess. outputFileTracingIncludes explicitly tells nft to copy all ship-safe files into the Lambda bundle.