### PR TITLE
Phase 3: re-engagement trigger route

### DIFF
--- a/webapp/app/api/dev/reengage/route.ts
+++ b/webapp/app/api/dev/reengage/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { sendReengagementBatch, reengageEligibleCount } from '@/lib/lifecycle-emails';
+
+/**
+ * POST /api/dev/reengage
+ * Header: Authorization: Bearer <CRON_SECRET>
+ * Body:   { "dryRun": true }            → count eligible users, send nothing
+ *         { "limit": 10 }               → send one batch (default 10, max 50)
+ *
+ * One-time re-engagement to the existing signup backlog. Idempotent: users
+ * already sent a 'reengage' email are skipped (EmailEvent unique constraint),
+ * so re-running just continues where it left off. Batched for deliverability.
+ */
+export async function POST(req: NextRequest) {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) {
+    return NextResponse.json({ error: 'CRON_SECRET not set' }, { status: 500 });
+  }
+  if ((req.headers.get('authorization') ?? '') !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => ({}));
+
+  try {
+    if (body.dryRun === true) {
+      const eligible = await reengageEligibleCount();
+      return NextResponse.json({ dryRun: true, eligible });
+    }
+
+    const limit = typeof body.limit === 'number' && body.limit > 0 ? Math.min(body.limit, 50) : 10;
+    const result = await sendReengagementBatch(limit);
+    const remaining = await reengageEligibleCount();
+    return NextResponse.json({ ...result, remaining, limit });
+  } catch (err) {
+    // Surfaces "table does not exist" if the migration hasn't been applied yet.
+    return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+  }
+}

--- a/webapp/lib/lifecycle-emails.ts
+++ b/webapp/lib/lifecycle-emails.ts
@@ -308,6 +308,20 @@ export async function runLifecycleEmails(now: Date = new Date()): Promise<{
   return results;
 }
 
+// Shared eligibility for the one-time re-engagement: real email, not opted out,
+// older than the day-3 window, and not already re-engaged.
+const REENGAGE_WHERE = {
+  email: { not: null },
+  lifecycleOptOut: false,
+  createdAt: { lte: new Date(Date.now() - 5 * DAY) },
+  emailEvents: { none: { type: 'reengage' } },
+} as const;
+
+/** How many users are still eligible for the re-engagement send (no send). */
+export async function reengageEligibleCount(): Promise<number> {
+  return prisma.user.count({ where: REENGAGE_WHERE });
+}
+
 /**
  * One-time re-engagement to the existing signup backlog (users older than the
  * day-3 window). Call manually/deliberately (Phase 3), not from the cron.
@@ -315,12 +329,7 @@ export async function runLifecycleEmails(now: Date = new Date()): Promise<{
  */
 export async function sendReengagementBatch(limit = 20): Promise<{ sent: number; scanned: number }> {
   const users = await prisma.user.findMany({
-    where: {
-      email: { not: null },
-      lifecycleOptOut: false,
-      createdAt: { lte: new Date(Date.now() - 5 * DAY) },
-      emailEvents: { none: { type: 'reengage' } },
-    },
+    where: REENGAGE_WHERE,
     select: USER_SELECT,
     orderBy: { createdAt: 'asc' },
     take: limit,


### PR DESCRIPTION
CRON_SECRET-protected POST /api/dev/reengage. dryRun counts eligible backlog users; otherwise sends one batched re-engagement (default 10, max 50). Idempotent via EmailEvent. tsc + lint clean.