### PR TITLE
Run migrations on Vercel deploy

### DIFF
--- a/webapp/vercel.json
+++ b/webapp/vercel.json
@@ -1,6 +1,6 @@
 {
   "framework": "nextjs",
-  "buildCommand": "prisma generate && next build",
+  "buildCommand": "prisma migrate deploy && prisma generate && next build",
   "outputDirectory": ".next",
   "installCommand": "npm install",
   "crons": [


### PR DESCRIPTION
vercel.json buildCommand skipped 'prisma migrate deploy', so schema migrations (incl. the EmailEvent table + User.lifecycleOptOut) never reached prod. Align it with package.json's build script. If DATABASE_URL isn't a build-time env var the build will fail harmlessly (previous deploy keeps serving) and we revert.