### PR TITLE
Add ModelScanAgent — ML model supply-chain scanner (v9.5.0 P0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [9.5.0] — 2026-07-13 — Trust Boundary (in progress)
+
+The attack surface has moved into the AI developer toolchain. This release
+line adds coverage for the threats landing in mid-2026 — starting with the AI
+model supply chain.
+
+### Added
+- **ModelScanAgent** (25th agent, Supply Chain category) — statically inspects
+  ML model weight files for code-execution payloads **without unpickling**:
+  - Opens pickle-based weights that other agents skip (binary, over the text
+    cap): `.pkl`/`.pickle`/`.pt`/`.pth`/`.ckpt`/`.bin`/`.joblib`/`.dill`.
+  - `MODEL_PICKLE_CODE_EXECUTION` (critical) — dangerous callables in the
+    pickle stream (`os.system`, `subprocess`, `builtins.exec/eval`, `pty.spawn`,
+    …), scanning head + tail so payloads at either end are caught, and reading
+    inside PyTorch zip containers.
+  - `MODEL_UNSAFE_PICKLE_FORMAT` (high) — pickle-serialized weights present at
+    all; steer to safetensors.
+  - `MODEL_EVASION_ARCHIVE` (high) — a model file wrapped in 7z/RAR to dodge
+    scanners (the Hugging Face PickleScan-evasion technique).
+  - `MODEL_TORCH_LOAD_UNSAFE` / `MODEL_PICKLE_LOAD_SOURCE` — source-level
+    unsafe loaders (`torch.load` without `weights_only=True`, `pickle`/`joblib`/
+    `dill` loads). Maps to CWE-502, CWE-506; references PickleScan
+    CVE-2025-10155/56/57.
+  - `.safetensors`/`.gguf`/`.onnx` are treated as safe and skipped; ambiguous
+    `.bin` requires a positive pickle/zip signature to avoid false positives.
+
+### Changed
+- Agent count 24 → 25 across CLI, README, docs, and marketing site.
+
+### Tests
+- 7 new tests (212 → 219): payload detection, unsafe-format flagging,
+  safetensors safety, `.bin` false-positive guard, archive evasion, and the
+  source-level `torch.load` loader (positive and negative).
+
 ## [9.4.1] — 2026-07-13 — Interactive shell stability fix
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ No signup. No API key required for scanning. Works offline for core checks.
 # Interactive REPL: scan, fix, and ask questions in one session
 npx ship-safe
 
-# Full audit: secrets + 24 agents + deps + remediation plan
+# Full audit: secrets + 25 agents + deps + remediation plan
 npx ship-safe audit .
 
 # Interactive fix agent: plan, diff, approve, verify
@@ -128,6 +128,7 @@ All agents run in parallel. Each skips irrelevant projects automatically.
 | **AgentAttestationAgent** | Supply Chain | Unpinned agent versions, missing integrity hashes, unsigned manifests (ASI-10, SLSA L0) |
 | **AgenticSupplyChainAgent** | Supply Chain | Over-privileged AI CI actions, OAuth scope creep, unsigned AI webhook receivers (ASI-02, ASI-06) |
 | **RobloxSecurityAgent** | Supply Chain | Malicious Roblox/Luau Toolbox assets (runtime asset injection, `rbxassetid://` loaders, `HttpEnabled`, payloads hidden in instance attributes) + cross-platform ClickFix paste-and-run lures |
+| **ModelScanAgent** | Supply Chain | Code-execution payloads in ML model weights (pickle opcodes in `.pt`/`.pkl`/`.ckpt`), `torch.load` without `weights_only`, scanner-evasion archives (CWE-502, CWE-506) |
 
 **Post-processors:** ScoringEngine · VerifierAgent (secrets liveness) · DeepAnalyzer (LLM taint analysis)
 

--- a/cli/__tests__/model-scan-agent.test.js
+++ b/cli/__tests__/model-scan-agent.test.js
@@ -1,0 +1,103 @@
+/**
+ * Ship Safe — ModelScanAgent
+ * ===========================
+ *
+ * Verifies pickle code-execution detection, unsafe-format flagging, safetensors
+ * safety, source-level loaders, and archive-evasion — without unpickling.
+ *
+ * Run: npm test
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import { ModelScanAgent } from '../agents/model-scan-agent.js';
+
+function tmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-model-'));
+}
+function cleanup(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* */ }
+}
+
+async function scan(dir, files) {
+  const agent = new ModelScanAgent();
+  return agent.analyze({ rootPath: dir, files, recon: {}, options: {} });
+}
+
+describe('ModelScanAgent — model files', () => {
+  it('flags a code-execution payload (os.system) in a pickle', async () => {
+    const dir = tmp();
+    try {
+      // pickle proto-4 header + a GLOBAL reference to os.system
+      const buf = Buffer.concat([Buffer.from([0x80, 0x04]), Buffer.from('c__main__\n_x\nq\x00cos\nsystem\nq\x01.')]);
+      fs.writeFileSync(path.join(dir, 'model.pkl'), buf);
+      const f = await scan(dir, []);
+      assert.ok(f.some((x) => x.rule === 'MODEL_PICKLE_CODE_EXECUTION' && x.severity === 'critical'));
+    } finally { cleanup(dir); }
+  });
+
+  it('flags a pickle-format model even without a dangerous global', async () => {
+    const dir = tmp();
+    try {
+      const buf = Buffer.concat([Buffer.from([0x80, 0x04]), Buffer.from('}q\x00.')]); // empty dict, benign
+      fs.writeFileSync(path.join(dir, 'weights.pth'), buf);
+      const f = await scan(dir, []);
+      assert.ok(f.some((x) => x.rule === 'MODEL_UNSAFE_PICKLE_FORMAT'));
+      assert.ok(!f.some((x) => x.rule === 'MODEL_PICKLE_CODE_EXECUTION'));
+    } finally { cleanup(dir); }
+  });
+
+  it('does not flag a .safetensors file', async () => {
+    const dir = tmp();
+    try {
+      fs.writeFileSync(path.join(dir, 'model.safetensors'), Buffer.from('anything at all'));
+      const f = await scan(dir, []);
+      assert.equal(f.length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('ignores a .bin with no pickle signature (avoids false positives)', async () => {
+    const dir = tmp();
+    try {
+      fs.writeFileSync(path.join(dir, 'blob.bin'), Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04]));
+      const f = await scan(dir, []);
+      assert.equal(f.length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('flags a model wrapped in a 7z archive (scanner evasion)', async () => {
+    const dir = tmp();
+    try {
+      const buf = Buffer.concat([Buffer.from([0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c]), Buffer.from('payload')]);
+      fs.writeFileSync(path.join(dir, 'model.pkl'), buf);
+      const f = await scan(dir, []);
+      assert.ok(f.some((x) => x.rule === 'MODEL_EVASION_ARCHIVE'));
+    } finally { cleanup(dir); }
+  });
+});
+
+describe('ModelScanAgent — source loaders', () => {
+  it('flags torch.load without weights_only=True', async () => {
+    const dir = tmp();
+    const file = path.join(dir, 'load.py');
+    try {
+      fs.writeFileSync(file, 'import torch\nm = torch.load("model.pt")\n');
+      const f = await scan(dir, [file]);
+      assert.ok(f.some((x) => x.rule === 'MODEL_TORCH_LOAD_UNSAFE'));
+    } finally { cleanup(dir); }
+  });
+
+  it('does not flag torch.load with weights_only=True', async () => {
+    const dir = tmp();
+    const file = path.join(dir, 'safe.py');
+    try {
+      fs.writeFileSync(file, 'import torch\nm = torch.load("model.pt", weights_only=True)\n');
+      const f = await scan(dir, [file]);
+      assert.equal(f.filter((x) => x.rule === 'MODEL_TORCH_LOAD_UNSAFE').length, 0);
+    } finally { cleanup(dir); }
+  });
+});

--- a/cli/agents/index.js
+++ b/cli/agents/index.js
@@ -33,6 +33,7 @@ export { HermesSecurityAgent } from './hermes-security-agent.js';
 export { AgentAttestationAgent } from './agent-attestation-agent.js';
 export { AgenticSupplyChainAgent } from './agentic-supply-chain-agent.js';
 export { RobloxSecurityAgent } from './roblox-security-agent.js';
+export { ModelScanAgent } from './model-scan-agent.js';
 export { ABOMGenerator } from './abom-generator.js';
 export { VerifierAgent } from './verifier-agent.js';
 export { DeepAnalyzer } from './deep-analyzer.js';
@@ -42,7 +43,7 @@ export { PolicyEngine } from './policy-engine.js';
 export { HTMLReporter } from './html-reporter.js';
 
 /**
- * Create a fully configured orchestrator with all 24 scanning agents.
+ * Create a fully configured orchestrator with all 25 scanning agents.
  * (VerifierAgent and DeepAnalyzer run as post-processors, not in the agent pool.)
  *
  * Plugin system: if rootPath is provided, custom agents from
@@ -74,6 +75,7 @@ import { HermesSecurityAgent as HermesSecurityAgentClass } from './hermes-securi
 import { AgentAttestationAgent as AgentAttestationAgentClass } from './agent-attestation-agent.js';
 import { AgenticSupplyChainAgent as AgenticSupplyChainAgentClass } from './agentic-supply-chain-agent.js';
 import { RobloxSecurityAgent as RobloxSecurityAgentClass } from './roblox-security-agent.js';
+import { ModelScanAgent as ModelScanAgentClass } from './model-scan-agent.js';
 import { loadPlugins } from '../utils/plugin-loader.js';
 
 const BUILT_IN_AGENTS = () => [
@@ -101,6 +103,7 @@ const BUILT_IN_AGENTS = () => [
   new AgentAttestationAgentClass(),
   new AgenticSupplyChainAgentClass(),
   new RobloxSecurityAgentClass(),
+  new ModelScanAgentClass(),
 ];
 
 /** Synchronous build — no plugin support. Used by legacy callers. */

--- a/cli/agents/model-scan-agent.js
+++ b/cli/agents/model-scan-agent.js
@@ -1,0 +1,208 @@
+/**
+ * ModelScanAgent — ML model supply-chain scanner
+ * ==============================================
+ *
+ * ML model weights are executable. The pickle serialization format — the
+ * default for PyTorch (`.pt/.pth/.ckpt/.bin`), joblib, dill, and raw
+ * `.pkl` — runs arbitrary code at load time via the REDUCE/GLOBAL opcodes.
+ * Malicious models on Hugging Face have repeatedly used this to execute code
+ * the moment a developer calls `torch.load()` / `pickle.load()`, and have
+ * evaded the hub's own PickleScan (which itself carries CVSS-9.3 bypasses,
+ * CVE-2025-10155/56/57).
+ *
+ * This agent opens model weight files that other agents skip (they are binary
+ * and over the 1 MB text cap) and statically inspects the byte stream for the
+ * pickle opcodes and dangerous global references used for code execution —
+ * without ever unpickling. It also flags unsafe source-level loaders and
+ * archive-wrapping used to dodge scanners.
+ *
+ * Maps to: CWE-502 (Deserialization of Untrusted Data), CWE-506 (Embedded
+ *          Malicious Code). Class: Supply Chain.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import fg from 'fast-glob';
+import { BaseAgent, createFinding } from './base-agent.js';
+import { SKIP_DIRS } from '../utils/patterns.js';
+
+// Pickle-based model formats — these deserialize via pickle and can run code.
+const PICKLE_EXTS = new Set(['.pkl', '.pickle', '.pt', '.pth', '.ckpt', '.bin', '.joblib', '.dill', '.model', '.pt2', '.pak']);
+// Formats that are NOT pickle-based; safetensors is the safe target we steer to.
+const SAFE_EXTS = new Set(['.safetensors', '.gguf', '.onnx', '.npz']);
+const MODEL_GLOB = ['**/*.{pkl,pickle,pt,pth,ckpt,bin,joblib,dill,model,pt2,pak,safetensors}'];
+
+// Max bytes to inspect from each end of a (potentially multi-GB) weight file.
+const HEAD_BYTES = 8 * 1024 * 1024;
+const TAIL_BYTES = 2 * 1024 * 1024;
+const MAX_MODEL_BYTES = 5 * 1024 * 1024 * 1024; // skip absurdly large (>5GB)
+
+// Dangerous callables that appear as newline/opcode-delimited ASCII inside a
+// pickle GLOBAL / STACK_GLOBAL. High-signal, low false-positive.
+const DANGEROUS = [
+  'os\nsystem', 'posix\nsystem', 'nt\nsystem', 'os\npopen', 'os\nexecv', 'os\nspawnl',
+  'subprocess', 'builtins\nexec', 'builtins\neval', '__builtin__\neval', '__builtin__\nexec',
+  'pty\nspawn', 'runpy', 'socket\nsocket', 'commands\ngetoutput', 'webbrowser\nopen',
+  'importlib\nimport_module', 'operator\nattrgetter',
+];
+
+// Archive magics used to wrap a pickle so a byte-scanner mis-parses it.
+const SEVENZIP_MAGIC = Buffer.from([0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c]);
+const RAR_MAGIC = Buffer.from([0x52, 0x61, 0x72, 0x21]);
+const ZIP_MAGIC = Buffer.from([0x50, 0x4b, 0x03, 0x04]); // PyTorch .pt is a zip of data.pkl
+
+// Source-level unsafe loaders.
+const SOURCE_PATTERNS = [
+  {
+    regex: /torch\s*\.\s*load\s*\((?![^)]*weights_only\s*=\s*True)/g,
+    rule: 'MODEL_TORCH_LOAD_UNSAFE',
+    title: 'torch.load() without weights_only=True',
+    severity: 'high',
+    description: 'torch.load() unpickles by default, executing arbitrary code embedded in the checkpoint. Set weights_only=True (PyTorch ≥ 2.6 defaults to it) or load safetensors.',
+    cwe: 'CWE-502',
+    fix: 'Pass weights_only=True to torch.load(), or convert the checkpoint to safetensors.',
+  },
+  {
+    regex: /(?:pickle|cPickle|dill|joblib)\s*\.\s*load[s]?\s*\(/g,
+    rule: 'MODEL_PICKLE_LOAD_SOURCE',
+    title: 'pickle/joblib/dill load on a model artifact',
+    severity: 'medium',
+    description: 'Loading a model via pickle/joblib/dill deserializes untrusted data and can execute code. Prefer safetensors for weights.',
+    cwe: 'CWE-502',
+    confidence: 'medium',
+    fix: 'Use safetensors for model weights; only unpickle artifacts you produced and trust.',
+  },
+];
+
+export class ModelScanAgent extends BaseAgent {
+  constructor() {
+    super(
+      'ModelScanAgent',
+      'Detects code-execution payloads in ML model weight files (pickle) and unsafe model loaders',
+      'supply-chain'
+    );
+  }
+
+  shouldRun() {
+    return true; // cheap: exits immediately when no model files are present
+  }
+
+  async analyze(context) {
+    const { rootPath } = context;
+    const findings = [];
+
+    // 1. Binary weight files (discovered independently — these are skipped by
+    //    the shared text-file discovery due to size/extension).
+    const modelFiles = await fg(MODEL_GLOB, {
+      cwd: rootPath,
+      absolute: true,
+      onlyFiles: true,
+      dot: false,
+      ignore: Array.from(SKIP_DIRS).map((d) => `**/${d}/**`),
+      followSymbolicLinks: false,
+    });
+    for (const file of modelFiles) {
+      findings.push(...this._scanModelFile(file));
+    }
+
+    // 2. Source-level unsafe loaders.
+    for (const file of this.getFilesToScan(context)) {
+      const ext = path.extname(file).toLowerCase();
+      if (ext === '.py' || ext === '.ipynb') {
+        findings.push(...this.scanFileWithPatterns(file, SOURCE_PATTERNS));
+      }
+    }
+
+    return findings;
+  }
+
+  _scanModelFile(file) {
+    const ext = path.extname(file).toLowerCase();
+    if (SAFE_EXTS.has(ext)) return []; // safetensors et al. cannot execute on load
+
+    let size;
+    try { size = fs.statSync(file).size; } catch { return []; }
+    if (size === 0 || size > MAX_MODEL_BYTES) return [];
+
+    const buf = this._readHeadTail(file, size);
+    if (!buf) return [];
+
+    // Scanner-evasion: a model-named file wrapped in 7z/rar.
+    if (buf.subarray(0, 6).equals(SEVENZIP_MAGIC) || buf.subarray(0, 4).equals(RAR_MAGIC)) {
+      return [createFinding({
+        file, line: 0, severity: 'high', category: 'supply-chain',
+        rule: 'MODEL_EVASION_ARCHIVE',
+        title: 'Model file wrapped in an unusual archive (scanner evasion)',
+        description: 'A model-named file is a 7z/RAR archive. This is a known technique for smuggling a malicious pickle past model scanners that only inspect the outer file.',
+        matched: ext, confidence: 'medium', cwe: 'CWE-506',
+        fix: 'Do not load this file. Obtain the model from a trusted source in safetensors format.',
+      })];
+    }
+
+    const isZip = buf.subarray(0, 4).equals(ZIP_MAGIC);       // PyTorch container
+    const isPickle = this._looksLikePickle(buf);
+    // Dedicated pickle extensions are always treated as pickle; ambiguous
+    // extensions (.bin) require a positive pickle/zip signal to avoid noise.
+    const treatAsPickle = isPickle || isZip || (PICKLE_EXTS.has(ext) && ext !== '.bin');
+    if (!treatAsPickle) return [];
+
+    const hit = this._findDangerous(buf);
+    if (hit) {
+      return [createFinding({
+        file, line: 0, severity: 'critical', category: 'supply-chain',
+        rule: 'MODEL_PICKLE_CODE_EXECUTION',
+        title: 'Code-execution payload embedded in a model file',
+        description: `The pickle stream references \`${hit}\`, a callable used to execute commands or code at load time. Loading this model (torch.load / pickle.load) would run attacker-controlled code.`,
+        matched: hit, confidence: 'high', cwe: 'CWE-506',
+        fix: 'Quarantine and do not load this model. Re-obtain from a trusted source as safetensors; report the artifact to the hub it came from.',
+      })];
+    }
+
+    return [createFinding({
+      file, line: 0, severity: 'high', category: 'supply-chain',
+      rule: 'MODEL_UNSAFE_PICKLE_FORMAT',
+      title: 'Pickle-serialized model file (executes code on load)',
+      description: 'This model is stored in a pickle-based format, which can execute arbitrary code when deserialized. No known-dangerous callable was found in the inspected region, but the format itself is unsafe for untrusted models.',
+      matched: ext, confidence: 'medium', cwe: 'CWE-502',
+      fix: 'Convert to safetensors, or load only with a restricted unpickler / weights_only=True.',
+    })];
+  }
+
+  /** Pickle protocol 2–5 header (\x80 + proto byte), or classic pickle opcode start. */
+  _looksLikePickle(buf) {
+    if (buf.length >= 2 && buf[0] === 0x80 && buf[1] >= 0x02 && buf[1] <= 0x05) return true;
+    // Protocol 0/1 streams start with a printable opcode like '(', '}', ']', 'c'.
+    const c = buf[0];
+    return c === 0x28 || c === 0x7d || c === 0x5d || c === 0x63;
+  }
+
+  _findDangerous(buf) {
+    for (const needle of DANGEROUS) {
+      if (buf.includes(needle)) return needle.replace(/\n/g, '.');
+    }
+    return null;
+  }
+
+  _readHeadTail(file, size) {
+    let fd;
+    try {
+      fd = fs.openSync(file, 'r');
+      if (size <= HEAD_BYTES + TAIL_BYTES) {
+        const whole = Buffer.allocUnsafe(size);
+        fs.readSync(fd, whole, 0, size, 0);
+        return whole;
+      }
+      const head = Buffer.allocUnsafe(HEAD_BYTES);
+      const tail = Buffer.allocUnsafe(TAIL_BYTES);
+      fs.readSync(fd, head, 0, HEAD_BYTES, 0);
+      fs.readSync(fd, tail, 0, TAIL_BYTES, size - TAIL_BYTES);
+      return Buffer.concat([head, tail]);
+    } catch {
+      return null;
+    } finally {
+      if (fd !== undefined) { try { fs.closeSync(fd); } catch { /* */ } }
+    }
+  }
+}
+
+export default ModelScanAgent;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ship-safe",
-  "version": "9.4.1",
-  "description": "AI-powered multi-agent security platform. 24 agents scan 80+ attack classes including AI integration supply chain (Vercel-class attacks), Hermes Agent deployments (ASI-01–ASI-10), tool registry poisoning, function-call injection, skill permission drift, and agent attestation. Ship Safe × Hermes Agent.",
+  "version": "9.5.0",
+  "description": "AI-powered multi-agent security platform. 25 agents scan 80+ attack classes including AI integration supply chain (Vercel-class attacks), Hermes Agent deployments (ASI-01–ASI-10), tool registry poisoning, function-call injection, skill permission drift, and agent attestation. Ship Safe × Hermes Agent.",
   "main": "cli/index.js",
   "bin": {
     "ship-safe": "cli/bin/ship-safe.js"

--- a/webapp/app/docs/page.tsx
+++ b/webapp/app/docs/page.tsx
@@ -6,13 +6,13 @@ const ogImage = 'https://www.shipsafecli.com/og1.png';
 
 export const metadata: Metadata = {
   title: 'Documentation',
-  description: 'Complete Ship Safe documentation: LLM vulnerability CLI commands, MCP configuration security scanning, RAG poisoning detection, CI/CD integration, 24 agent reference, and API docs.',
+  description: 'Complete Ship Safe documentation: LLM vulnerability CLI commands, MCP configuration security scanning, RAG poisoning detection, CI/CD integration, 25 agent reference, and API docs.',
   keywords: ['Ship Safe docs', 'LLM vulnerability CLI', 'MCP configuration security', 'RAG poisoning detection', 'AI agent security scanner', 'ship-safe commands', 'ship-safe agents', 'DevSecOps documentation', 'OWASP Agentic AI Top 10'],
   alternates: {
     canonical: 'https://www.shipsafecli.com/docs',
   },
   openGraph: {
-    title: 'Ship Safe Documentation — v9.4.0',
+    title: 'Ship Safe Documentation — v9.5.0',
     description: 'Every command, agent, and flag. LLM vulnerability CLI, MCP security configuration, RAG poisoning detection, CI/CD integration, and API reference.',
     type: 'website',
     url: 'https://www.shipsafecli.com/docs',
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Ship Safe Documentation — v9.4.0',
+    title: 'Ship Safe Documentation — v9.5.0',
     description: 'Every command, agent, and flag. LLM vulnerability CLI, MCP security configuration, RAG poisoning detection, CI/CD integration, and API reference.',
     images: [ogImage],
   },
@@ -52,7 +52,7 @@ export default function Docs() {
               <a href="#installation">Installation</a>
               <a href="#quick-start">Quick Start</a>
               <a href="#commands">Commands</a>
-              <a href="#agents">24 Security Agents</a>
+              <a href="#agents">25 Security Agents</a>
               <a href="#scoring">Scoring System</a>
               <a href="#cicd">CI/CD Integration</a>
               <a href="#github-action">GitHub Action</a>
@@ -73,7 +73,7 @@ export default function Docs() {
               <span className={styles.sectionLabel}>// docs</span>
               <h1>Ship Safe CLI</h1>
               <p className={styles.subtitle}>
-                24 AI security agents. 80+ attack classes. One command.
+                25 AI security agents. 80+ attack classes. One command.
               </p>
               <pre className={styles.heroCode}><code>npx ship-safe audit .</code></pre>
             </header>
@@ -100,7 +100,7 @@ export GOOGLE_AI_API_KEY=AIza...`}</code></pre>
               <pre><code>{`# Full security audit with remediation plan + HTML report
 npx ship-safe audit .
 
-# Red team: 24 agents, 80+ attack classes
+# Red team: 25 agents, 80+ attack classes
 npx ship-safe red-team .
 
 # Quick secret scan
@@ -128,8 +128,8 @@ npx ship-safe ci . --threshold 80`}</code></pre>
                 <table>
                   <thead><tr><th>Command</th><th>Description</th></tr></thead>
                   <tbody>
-                    <tr><td><code>audit .</code></td><td>Full audit: secrets + 24 agents + deps + remediation plan + HTML report</td></tr>
-                    <tr><td><code>red-team .</code></td><td>Run 24 agents with 80+ attack classes</td></tr>
+                    <tr><td><code>audit .</code></td><td>Full audit: secrets + 25 agents + deps + remediation plan + HTML report</td></tr>
+                    <tr><td><code>red-team .</code></td><td>Run 25 agents with 80+ attack classes</td></tr>
                     <tr><td><code>scan .</code></td><td>Secret scanner (pattern matching + entropy scoring)</td></tr>
                     <tr><td><code>score .</code></td><td>Security health score (0-100, A-F grade)</td></tr>
                     <tr><td><code>deps .</code></td><td>Dependency CVE audit with EPSS scores</td></tr>
@@ -256,7 +256,7 @@ npx ship-safe ci . --threshold 80`}</code></pre>
 
             {/* ── Agents ────────────────────────────────────────────── */}
             <section id="agents">
-              <h2>24 Security Agents</h2>
+              <h2>25 Security Agents</h2>
               <p>All agents run in parallel with per-agent timeouts. Each implements <code>shouldRun(recon)</code> to skip irrelevant projects automatically.</p>
               <div className={styles.tableWrap}>
                 <table>
@@ -286,6 +286,7 @@ npx ship-safe ci . --threshold 80`}</code></pre>
                     <tr><td><strong>AgentAttestationAgent</strong></td><td>Supply Chain</td><td>Agent manifest supply chain — unpinned versions, missing integrity hashes, unsigned manifests (ASI-10, SLSA Level 0)</td></tr>
                     <tr><td><strong>AgenticSupplyChainAgent</strong></td><td>Supply Chain</td><td>AI integration supply chain — over-privileged AI CI actions, OAuth scope creep, unsigned AI webhook receivers (ASI-02, ASI-06, CICD-SEC-8)</td></tr>
                     <tr><td><strong>RobloxSecurityAgent</strong></td><td>Supply Chain</td><td>Malicious Roblox/Luau Toolbox assets — runtime asset injection (<code>game:GetObjects(&apos;rbxassetid://&apos;)</code>, <code>require(assetId)</code>), <code>HttpEnabled</code> from scripts, obfuscated loaders, and payloads hidden in instance attributes (decoded from <code>.rbxmx</code>/<code>.rbxlx</code>) — plus cross-platform ClickFix paste-and-run lures (CWE-506, CWE-829)</td></tr>
+                    <tr><td><strong>ModelScanAgent</strong></td><td>Supply Chain</td><td>ML model supply chain — code-execution payloads in pickle-based weights (<code>.pt</code>/<code>.pkl</code>/<code>.ckpt</code>/<code>.bin</code>), <code>torch.load</code> without <code>weights_only=True</code>, and archive-wrapped scanner evasion (CWE-502, CWE-506)</td></tr>
                   </tbody>
                 </table>
               </div>

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -8,14 +8,14 @@ const ogImage = 'https://www.shipsafecli.com/og1.png';
 
 export const metadata: Metadata = {
   title: 'Ship Safe — AI Agent Security Scanner for Developers',
-  description: '24 AI security agents scan your codebase for LLM vulnerabilities, MCP configuration security issues, RAG poisoning, Claude Managed Agent misconfigs, secrets, and dependency CVEs. OWASP Agentic AI Top 10 mapping, live advisory feeds. Free CLI.',
+  description: '25 AI security agents scan your codebase for LLM vulnerabilities, MCP configuration security issues, RAG poisoning, Claude Managed Agent misconfigs, secrets, and dependency CVEs. OWASP Agentic AI Top 10 mapping, live advisory feeds. Free CLI.',
   keywords: ['AI agent security scanner', 'LLM vulnerability CLI', 'MCP configuration security', 'RAG poisoning prevention', 'prevent RAG poisoning', 'application security scanner', 'AI security agents', 'secret scanner', 'OWASP Agentic AI Top 10', 'memory poisoning detection', 'prompt injection scanner', 'DevSecOps tool', 'free security scanner', 'open source SAST'],
   alternates: {
     canonical: 'https://www.shipsafecli.com',
   },
   openGraph: {
     title: 'Ship Safe — AI Agent Security Scanner for Developers',
-    description: '24 AI security agents detect LLM vulnerabilities, MCP misconfigurations, RAG poisoning, secrets, and CVEs. One command. Free and open source.',
+    description: '25 AI security agents detect LLM vulnerabilities, MCP misconfigurations, RAG poisoning, secrets, and CVEs. One command. Free and open source.',
     type: 'website',
     url: 'https://www.shipsafecli.com',
     siteName: 'Ship Safe',
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'Ship Safe — AI Agent Security Scanner for Developers',
-    description: '24 AI security agents detect LLM vulnerabilities, MCP misconfigurations, RAG poisoning, secrets, and CVEs. One command. Free and open source.',
+    description: '25 AI security agents detect LLM vulnerabilities, MCP misconfigurations, RAG poisoning, secrets, and CVEs. One command. Free and open source.',
     images: [ogImage],
   },
 };
@@ -42,7 +42,7 @@ const jsonLd = {
         price: '0',
         priceCurrency: 'USD',
       },
-      description: '24 AI security agents scan your codebase for secrets, vulnerabilities, memory poisoning, Hermes Agent misconfigurations, and dependency CVEs in one command.',
+      description: '25 AI security agents scan your codebase for secrets, vulnerabilities, memory poisoning, Hermes Agent misconfigurations, and dependency CVEs in one command.',
       url: 'https://www.shipsafecli.com',
       downloadUrl: 'https://www.npmjs.com/package/ship-safe',
       softwareVersion: '9.4.1',

--- a/webapp/components/Hero.tsx
+++ b/webapp/components/Hero.tsx
@@ -213,7 +213,7 @@ export default function Hero({ stars, downloads }: Props) {
               className={styles.tabular}
               title={`${formatNumber(stars)} stars · ${formatNumber(downloads)} downloads`}
             >
-              24 agents
+              25 agents
             </span>
           </motion.div>
 

--- a/webapp/components/HomeRedesign.tsx
+++ b/webapp/components/HomeRedesign.tsx
@@ -32,7 +32,7 @@ const coverage = [
 
 const proofItems = [
   { value: 'MIT', label: 'open-source CLI' },
-  { value: '24', label: 'specialized agents' },
+  { value: '25', label: 'specialized agents' },
   { value: 'SARIF', label: 'GitHub-ready output' },
   { value: 'CI', label: 'pipeline gating' },
 ];
@@ -352,7 +352,7 @@ export default function HomeRedesign({ stars, downloads }: HomeRedesignProps) {
           <span>npm downloads</span>
         </div>
         <div>
-          <strong>24</strong>
+          <strong>25</strong>
           <span>AI security agents</span>
         </div>
         <div>


### PR DESCRIPTION
First P0 agent of the **v9.5.0 "Trust Boundary"** line, from the [threat research brief](https://github.com/asamassekou10/ship-safe). ML model weights are executable — the pickle format runs code at load time, and malicious models on Hugging Face have repeatedly evaded even the hub's own PickleScan (which itself carries CVSS-9.3 bypasses, CVE-2025-10155/56/57).

## What it does
Opens model weight files that the shared text-file discovery skips (binary, over the 1 MB cap) and inspects the byte stream for pickle code-execution opcodes **without ever unpickling**.

| Rule | Catches | Severity |
|---|---|---|
| `MODEL_PICKLE_CODE_EXECUTION` | Dangerous callables in the pickle stream (`os.system`, `subprocess`, `builtins.exec/eval`, `pty.spawn`, …) — head+tail scan, reads inside PyTorch zip containers | **Critical** |
| `MODEL_UNSAFE_PICKLE_FORMAT` | Pickle-serialized weights present at all (unsafe format) | High |
| `MODEL_EVASION_ARCHIVE` | Model file wrapped in 7z/RAR to dodge scanners | High |
| `MODEL_TORCH_LOAD_UNSAFE` | `torch.load()` without `weights_only=True` | High |
| `MODEL_PICKLE_LOAD_SOURCE` | `pickle`/`joblib`/`dill` load on a model artifact | Medium |

## False-positive discipline
`.safetensors` / `.gguf` / `.onnx` are treated as safe and skipped entirely. Ambiguous `.bin` requires a positive pickle or PyTorch-zip signature before it's flagged. A `.bin` of random bytes and a `torch.load(..., weights_only=True)` both stay quiet (tested).

## Mapping
CWE-502 (Deserialization of Untrusted Data), CWE-506 (Embedded Malicious Code). Addresses the Hugging Face pickle-exploit wave and the PickleScan bypass CVEs.

## Testing
7 new tests (**212 → 219**, all passing). `next lint` / `eslint` clean (0 errors). Orchestrator verified at **25 agents**.

---
Next in P0: `TrustBoundaryAgent` (GhostApproval symlinks + Friendly Fire), slopsquat detection, and promoting ClickFix to first-class.