### PR TITLE
MCP auto-launch-on-trust + OWASP 2026 refresh + docs encoding fix (v9.5.0 P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,9 +81,23 @@ model supply chain.
   - `WORM_LIFECYCLE_OBFUSCATED_EXEC` (high) — `node -e` / `eval` / base64.
   - `WORM_BINDING_GYP` (high) — a weaponized `binding.gyp` node-gyp action that
     fetches, spawns, or evaluates rather than compiles. Maps to CWE-506, CWE-829.
+- **MCPSecurityAgent**: new `MCP_AUTO_LAUNCH_ON_TRUST` (high) — a repo-local
+  MCP config (`.mcp.json`, `.cursor/mcp.json`, `.vscode/mcp.json`) that defines
+  a stdio `command` server which auto-launches when the folder is trusted in an
+  agentic editor. A malicious repo weaponizes this to run code on the trust
+  prompt (Adversa, 2026). Excludes remote-only servers and the global
+  `claude_desktop_config.json`. Maps to CWE-829, ASI06:2026.
 
 ### Changed
 - Agent count 24 → 29 across CLI, README, docs, and marketing site.
+- Refreshed the OWASP Agentic coverage mapping to the finalized **OWASP Top 10
+  for Agentic Applications 2026** categories (inter-agent communication,
+  cascading failures, human-agent trust, rogue agents).
+
+### Fixed
+- Repaired pervasive mojibake (triple-encoded em-dashes and other punctuation)
+  in the documentation page — a pre-existing UTF-8 corruption that rendered as
+  garbled characters. 735+ occurrences corrected.
 
 ### Tests
 - 23 net new tests (212 → 235): ModelScan payload detection, unsafe-format flagging,

--- a/cli/__tests__/mcp-autolaunch.test.js
+++ b/cli/__tests__/mcp-autolaunch.test.js
@@ -1,0 +1,72 @@
+/**
+ * Ship Safe — MCPSecurityAgent auto-launch-on-trust
+ * ==================================================
+ *
+ * Verifies MCP_AUTO_LAUNCH_ON_TRUST fires on repo-local project MCP configs
+ * with a stdio command server, and not on remote-only or global configs.
+ *
+ * Run: npm test
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import { MCPSecurityAgent } from '../agents/mcp-security-agent.js';
+
+function tmp() { return fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-mcp-')); }
+function cleanup(dir) { try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* */ } }
+
+async function scan(dir, relFiles) {
+  const files = relFiles.map((r) => path.join(dir, r));
+  return new MCPSecurityAgent().analyze({ rootPath: dir, files, recon: {}, options: {} });
+}
+
+describe('MCPSecurityAgent — auto-launch on trust', () => {
+  it('flags a project-local .mcp.json stdio command server', async () => {
+    const dir = tmp();
+    try {
+      fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({
+        mcpServers: { evil: { command: 'node', args: ['./.tools/server.js'] } },
+      }));
+      const f = await scan(dir, ['.mcp.json']);
+      assert.ok(f.some((x) => x.rule === 'MCP_AUTO_LAUNCH_ON_TRUST' && x.severity === 'high'));
+    } finally { cleanup(dir); }
+  });
+
+  it('flags a .cursor/mcp.json command server', async () => {
+    const dir = tmp();
+    try {
+      fs.mkdirSync(path.join(dir, '.cursor'), { recursive: true });
+      fs.writeFileSync(path.join(dir, '.cursor', 'mcp.json'), JSON.stringify({
+        servers: { x: { command: 'python', args: ['run.py'] } },
+      }));
+      const f = await scan(dir, ['.cursor/mcp.json']);
+      assert.ok(f.some((x) => x.rule === 'MCP_AUTO_LAUNCH_ON_TRUST'));
+    } finally { cleanup(dir); }
+  });
+
+  it('does not flag a remote (url-only) server', async () => {
+    const dir = tmp();
+    try {
+      fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({
+        mcpServers: { remote: { url: 'https://mcp.example.com/sse' } },
+      }));
+      const f = await scan(dir, ['.mcp.json']);
+      assert.equal(f.filter((x) => x.rule === 'MCP_AUTO_LAUNCH_ON_TRUST').length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('does not flag the global claude_desktop_config.json', async () => {
+    const dir = tmp();
+    try {
+      fs.writeFileSync(path.join(dir, 'claude_desktop_config.json'), JSON.stringify({
+        mcpServers: { local: { command: 'node', args: ['server.js'] } },
+      }));
+      const f = await scan(dir, ['claude_desktop_config.json']);
+      assert.equal(f.filter((x) => x.rule === 'MCP_AUTO_LAUNCH_ON_TRUST').length, 0);
+    } finally { cleanup(dir); }
+  });
+});

--- a/cli/agents/mcp-security-agent.js
+++ b/cli/agents/mcp-security-agent.js
@@ -309,6 +309,7 @@ export class MCPSecurityAgent extends BaseAgent {
     for (const file of configFiles) {
       findings = findings.concat(this._checkMcpTyposquatting(file));
       findings = findings.concat(this._checkOverPermissioned(file));
+      findings = findings.concat(this._checkAutoLaunchOnTrust(file, rootPath));
     }
 
     // ── 5. Detect shadow MCP configs (not in version control) ───────────
@@ -384,6 +385,48 @@ export class MCPSecurityAgent extends BaseAgent {
       });
     }
 
+    return findings;
+  }
+
+  /**
+   * Detect repo-local MCP configs that auto-launch a local process when the
+   * developer accepts the editor's folder-trust prompt. A malicious repo can
+   * ship such a config so a stdio server (command) runs the moment the folder
+   * is trusted in Claude Code / Cursor / VS Code — the shared weak default
+   * across agentic CLI tools (Adversa, 2026).
+   */
+  _checkAutoLaunchOnTrust(filePath, rootPath) {
+    // Only project-local configs auto-load on trust; skip global user configs.
+    const rel = path.relative(rootPath, filePath).replace(/\\/g, '/');
+    const base = path.basename(filePath);
+    const isProjectLocal = base === '.mcp.json' || base === 'mcp.json'
+      || rel.endsWith('.cursor/mcp.json') || rel.endsWith('.vscode/mcp.json');
+    if (!isProjectLocal) return [];
+
+    const content = this.readFile(filePath);
+    if (!content) return [];
+    let config;
+    try { config = JSON.parse(content); } catch { return []; }
+    const servers = config.mcpServers || config.servers || (config.mcp && config.mcp.servers) || {};
+    const findings = [];
+
+    for (const [name, server] of Object.entries(servers)) {
+      if (!server || typeof server !== 'object' || typeof server.command !== 'string') continue;
+      const invocation = `${server.command} ${(server.args || []).join(' ')}`.trim();
+      findings.push({
+        file: filePath, line: 1, column: 0,
+        severity: 'high',
+        category: this.category,
+        rule: 'MCP_AUTO_LAUNCH_ON_TRUST',
+        title: `MCP: Server "${name}" auto-launches on folder trust`,
+        description: `Project-local ${base} defines a stdio server ("${name}") that runs \`${invocation.slice(0, 80)}\`. If this repo is opened and trusted in an agentic editor (Claude Code, Cursor, VS Code), the command executes automatically — a malicious repo weaponizes this to run code the moment you accept the trust prompt.`,
+        matched: invocation.slice(0, 100),
+        confidence: 'high',
+        cwe: 'CWE-829',
+        owasp: 'ASI06:2026',
+        fix: 'Do not ship auto-launching MCP servers in a repo. Review the command, require explicit per-server approval, and never trust a repo-supplied server definition without inspecting what it runs.',
+      });
+    }
     return findings;
   }
 

--- a/webapp/app/docs/page.tsx
+++ b/webapp/app/docs/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
     canonical: 'https://www.shipsafecli.com/docs',
   },
   openGraph: {
-    title: 'Ship Safe Documentation ÃÂ¢ÃÂÃÂ v9.5.0',
+    title: 'Ship Safe Documentation — v9.5.0',
     description: 'Every command, agent, and flag. LLM vulnerability CLI, MCP security configuration, RAG poisoning detection, CI/CD integration, and API reference.',
     type: 'website',
     url: 'https://www.shipsafecli.com/docs',
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Ship Safe Documentation ÃÂ¢ÃÂÃÂ v9.5.0',
+    title: 'Ship Safe Documentation — v9.5.0',
     description: 'Every command, agent, and flag. LLM vulnerability CLI, MCP security configuration, RAG poisoning detection, CI/CD integration, and API reference.',
     images: [ogImage],
   },
@@ -41,7 +41,7 @@ export default function Docs() {
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} // ship-safe-ignore ÃÂ¢ÃÂÃÂ static JSON-LD, no user input
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} // ship-safe-ignore — static JSON-LD, no user input
       />
       <Nav />
       <main className={styles.docsPage}>
@@ -78,7 +78,7 @@ export default function Docs() {
               <pre className={styles.heroCode}><code>npx ship-safe audit .</code></pre>
             </header>
 
-            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ Installation ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
+            {/* ── Installation ──────────────────────────────────────── */}
             <section id="installation">
               <h2>Installation</h2>
               <p>Ship Safe requires Node.js 18 or later. No signup or API key required.</p>
@@ -94,7 +94,7 @@ export OPENAI_API_KEY=sk-...
 export GOOGLE_AI_API_KEY=AIza...`}</code></pre>
             </section>
 
-            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ Quick Start ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
+            {/* ── Quick Start ───────────────────────────────────────── */}
             <section id="quick-start">
               <h2>Quick Start</h2>
               <pre><code>{`# Full security audit with remediation plan + HTML report
@@ -119,7 +119,7 @@ npx ship-safe diff --staged
 npx ship-safe ci . --threshold 80`}</code></pre>
             </section>
 
-            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ Commands ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
+            {/* ── Commands ──────────────────────────────────────────── */}
             <section id="commands">
               <h2>Commands</h2>
 
@@ -144,12 +144,12 @@ npx ship-safe ci . --threshold 80`}</code></pre>
                   <thead><tr><th>Command</th><th>Description</th></tr></thead>
                   <tbody>
                     <tr><td><code>ship-safe</code></td><td>Drop into the interactive REPL (bare invocation on a TTY)</td></tr>
-                    <tr><td><code>shell .</code></td><td>Explicit REPL ÃÂ¢ÃÂÃÂ slash commands, streaming LLM, persistent session</td></tr>
-                    <tr><td><code>agent .</code></td><td>Interactive fix loop: scan ÃÂ¢ÃÂÃÂ plan ÃÂ¢ÃÂÃÂ diff ÃÂ¢ÃÂÃÂ accept/skip/edit/quit ÃÂ¢ÃÂÃÂ verify</td></tr>
+                    <tr><td><code>shell .</code></td><td>Explicit REPL — slash commands, streaming LLM, persistent session</td></tr>
+                    <tr><td><code>agent .</code></td><td>Interactive fix loop: scan → plan → diff → accept/skip/edit/quit → verify</td></tr>
                     <tr><td><code>agent . --plan-only</code></td><td>Preview fix plans without writing any files</td></tr>
                     <tr><td><code>agent . --severity critical</code></td><td>Only plan/fix findings at the given severity or above</td></tr>
                     <tr><td><code>agent . --branch --pr</code></td><td>Commit fixes on a new branch and open a PR via <code>gh</code></td></tr>
-                    <tr><td><code>agent . --yolo --branch</code></td><td>Unattended CI mode ÃÂ¢ÃÂÃÂ auto-accept all plans</td></tr>
+                    <tr><td><code>agent . --yolo --branch</code></td><td>Unattended CI mode — auto-accept all plans</td></tr>
                     <tr><td><code>undo</code></td><td>Revert the last fix applied by the agent</td></tr>
                     <tr><td><code>undo --all</code></td><td>Revert every fix in <code>.ship-safe/fixes.jsonl</code></td></tr>
                   </tbody>
@@ -183,7 +183,7 @@ npx ship-safe ci . --threshold 80`}</code></pre>
                 <table>
                   <thead><tr><th>Command</th><th>Description</th></tr></thead>
                   <tbody>
-                    <tr><td><code>hooks install</code></td><td>Install real-time Claude Code hooks ÃÂ¢ÃÂÃÂ block secrets before they land on disk</td></tr>
+                    <tr><td><code>hooks install</code></td><td>Install real-time Claude Code hooks — block secrets before they land on disk</td></tr>
                     <tr><td><code>hooks status</code></td><td>Check if Claude Code hooks are installed</td></tr>
                     <tr><td><code>hooks remove</code></td><td>Uninstall Claude Code hooks</td></tr>
                     <tr><td><code>remediate .</code></td><td>Auto-fix hardcoded secrets (rewrite code + write .env)</td></tr>
@@ -254,7 +254,7 @@ npx ship-safe ci . --threshold 80`}</code></pre>
               </div>
             </section>
 
-            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ Agents ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
+            {/* ── Agents ────────────────────────────────────────────── */}
             <section id="agents">
               <h2>29 Security Agents</h2>
               <p>All agents run in parallel with per-agent timeouts. Each implements <code>shouldRun(recon)</code> to skip irrelevant projects automatically.</p>
@@ -281,23 +281,23 @@ npx ship-safe ci . --threshold 80`}</code></pre>
                     <tr><td><strong>GitHistoryScanner</strong></td><td>Secrets</td><td>Leaked secrets in git commit history</td></tr>
                     <tr><td><strong>CICDScanner</strong></td><td>CI/CD</td><td>OWASP CI/CD Top 10: pipeline poisoning, unpinned actions, secret logging</td></tr>
                     <tr><td><strong>APIFuzzer</strong></td><td>API</td><td>Routes without auth, mass assignment, GraphQL introspection, debug endpoints</td></tr>
-                    <tr><td><strong>ManagedAgentScanner</strong></td><td>AI/LLM</td><td>Claude Managed Agent misconfigs ÃÂ¢ÃÂÃÂ always_allow policies, unrestricted networking, unpinned packages</td></tr>
-                    <tr><td><strong>HermesSecurityAgent</strong></td><td>AI/LLM</td><td>Hermes Agent deployments ÃÂ¢ÃÂÃÂ tool registry poisoning, function-call injection, skill permission drift (ASI-01ÃÂ¢ÃÂÃÂASI-10)</td></tr>
-                    <tr><td><strong>AgentAttestationAgent</strong></td><td>Supply Chain</td><td>Agent manifest supply chain ÃÂ¢ÃÂÃÂ unpinned versions, missing integrity hashes, unsigned manifests (ASI-10, SLSA Level 0)</td></tr>
-                    <tr><td><strong>AgenticSupplyChainAgent</strong></td><td>Supply Chain</td><td>AI integration supply chain ÃÂ¢ÃÂÃÂ over-privileged AI CI actions, OAuth scope creep, unsigned AI webhook receivers (ASI-02, ASI-06, CICD-SEC-8)</td></tr>
-                    <tr><td><strong>RobloxSecurityAgent</strong></td><td>Supply Chain</td><td>Malicious Roblox/Luau Toolbox assets ÃÂ¢ÃÂÃÂ runtime asset injection (<code>game:GetObjects(&apos;rbxassetid://&apos;)</code>, <code>require(assetId)</code>), <code>HttpEnabled</code> from scripts, obfuscated loaders, and payloads hidden in instance attributes (decoded from <code>.rbxmx</code>/<code>.rbxlx</code>) ÃÂ¢ÃÂÃÂ (CWE-506, CWE-829)</td></tr>
-                    <tr><td><strong>ModelScanAgent</strong></td><td>Supply Chain</td><td>ML model supply chain ÃÂ¢ÃÂÃÂ code-execution payloads in pickle-based weights (<code>.pt</code>/<code>.pkl</code>/<code>.ckpt</code>/<code>.bin</code>), <code>torch.load</code> without <code>weights_only=True</code>, and archive-wrapped scanner evasion (CWE-502, CWE-506)</td></tr>
-                    <tr><td><strong>TrustBoundaryAgent</strong></td><td>Agentic</td><td>AI coding-agent trust boundary ÃÂ¢ÃÂÃÂ GhostApproval symlinks (config-named links into <code>~/.ssh</code>/<code>~/.aws</code>/<code>.env</code>), symlinks escaping the repo, and Friendly Fire run-on-review/curl-pipe-bash instructions in agent-read files (CWE-59, CWE-61)</td></tr>
-                    <tr><td><strong>SlopSquatAgent</strong></td><td>Supply Chain</td><td>Slopsquatting / hallucinated packages Ã¢ÂÂ imports that are neither declared in <code>package.json</code>, present in <code>node_modules</code>, nor Node builtins (the slot attackers register), plus documented AI-hallucinated names (CWE-1357)</td></tr>
-                    <tr><td><strong>ClickFixAgent</strong></td><td>Supply Chain</td><td>ClickFix / fake-CAPTCHA paste-and-run social engineering â fake error framing next to Win+R/Ctrl+V/command-bar keystrokes and PowerShell cradles, plus fake-installer <code>preinstall</code>/<code>postinstall</code> scripts (CWE-1357, CWE-506)</td></tr>
-                    <tr><td><strong>InstallGuardAgent</strong></td><td>Supply Chain</td><td>npm worm hardening (Shai-Hulud/Miasma) — <code>pre/postinstall</code> credential harvesting, env exfiltration, destructive commands, obfuscated <code>node -e</code>, and weaponized <code>binding.gyp</code> node-gyp actions (CWE-506, CWE-829)</td></tr>
+                    <tr><td><strong>ManagedAgentScanner</strong></td><td>AI/LLM</td><td>Claude Managed Agent misconfigs — always_allow policies, unrestricted networking, unpinned packages</td></tr>
+                    <tr><td><strong>HermesSecurityAgent</strong></td><td>AI/LLM</td><td>Hermes Agent deployments — tool registry poisoning, function-call injection, skill permission drift (ASI-01–ASI-10)</td></tr>
+                    <tr><td><strong>AgentAttestationAgent</strong></td><td>Supply Chain</td><td>Agent manifest supply chain — unpinned versions, missing integrity hashes, unsigned manifests (ASI-10, SLSA Level 0)</td></tr>
+                    <tr><td><strong>AgenticSupplyChainAgent</strong></td><td>Supply Chain</td><td>AI integration supply chain — over-privileged AI CI actions, OAuth scope creep, unsigned AI webhook receivers (ASI-02, ASI-06, CICD-SEC-8)</td></tr>
+                    <tr><td><strong>RobloxSecurityAgent</strong></td><td>Supply Chain</td><td>Malicious Roblox/Luau Toolbox assets — runtime asset injection (<code>game:GetObjects(&apos;rbxassetid://&apos;)</code>, <code>require(assetId)</code>), <code>HttpEnabled</code> from scripts, obfuscated loaders, and payloads hidden in instance attributes (decoded from <code>.rbxmx</code>/<code>.rbxlx</code>) — (CWE-506, CWE-829)</td></tr>
+                    <tr><td><strong>ModelScanAgent</strong></td><td>Supply Chain</td><td>ML model supply chain — code-execution payloads in pickle-based weights (<code>.pt</code>/<code>.pkl</code>/<code>.ckpt</code>/<code>.bin</code>), <code>torch.load</code> without <code>weights_only=True</code>, and archive-wrapped scanner evasion (CWE-502, CWE-506)</td></tr>
+                    <tr><td><strong>TrustBoundaryAgent</strong></td><td>Agentic</td><td>AI coding-agent trust boundary — GhostApproval symlinks (config-named links into <code>~/.ssh</code>/<code>~/.aws</code>/<code>.env</code>), symlinks escaping the repo, and Friendly Fire run-on-review/curl-pipe-bash instructions in agent-read files (CWE-59, CWE-61)</td></tr>
+                    <tr><td><strong>SlopSquatAgent</strong></td><td>Supply Chain</td><td>Slopsquatting / hallucinated packages  imports that are neither declared in <code>package.json</code>, present in <code>node_modules</code>, nor Node builtins (the slot attackers register), plus documented AI-hallucinated names (CWE-1357)</td></tr>
+                    <tr><td><strong>ClickFixAgent</strong></td><td>Supply Chain</td><td>ClickFix / fake-CAPTCHA paste-and-run social engineering  fake error framing next to Win+R/Ctrl+V/command-bar keystrokes and PowerShell cradles, plus fake-installer <code>preinstall</code>/<code>postinstall</code> scripts (CWE-1357, CWE-506)</td></tr>
+                    <tr><td><strong>InstallGuardAgent</strong></td><td>Supply Chain</td><td>npm worm hardening (Shai-Hulud/Miasma)  <code>pre/postinstall</code> credential harvesting, env exfiltration, destructive commands, obfuscated <code>node -e</code>, and weaponized <code>binding.gyp</code> node-gyp actions (CWE-506, CWE-829)</td></tr>
                   </tbody>
                 </table>
               </div>
               <p><strong>Post-processors:</strong> ScoringEngine (8-category weighted scoring), VerifierAgent (secrets liveness verification), DeepAnalyzer (LLM-powered taint analysis)</p>
             </section>
 
-            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ Scoring ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
+            {/* ── Scoring ───────────────────────────────────────────── */}
             <section id="scoring">
               <h2>Scoring System</h2>
               <p>Starts at 100. Each finding deducts points by severity and category, weighted by confidence level (high: 100%, medium: 60%, low: 30%).</p>
@@ -320,7 +320,7 @@ npx ship-safe ci . --threshold 80`}</code></pre>
               <p><strong>Exit codes:</strong> <code>0</code> for A/B (&gt;= 75), <code>1</code> for C/D/F. Use in CI to fail builds.</p>
             </section>
 
-            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ CI/CD ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
+            {/* ── CI/CD ─────────────────────────────────────────────── */}
             <section id="cicd">
               <h2>CI/CD Integration</h2>
               <pre><code>{`# Basic CI: fail if score < 75
@@ -340,7 +340,7 @@ npx ship-safe ci . --baseline`}</code></pre>
               <p>Export formats: <code>--json</code>, <code>--sarif</code>, <code>--csv</code>, <code>--md</code>, <code>--html</code>, <code>--pdf</code></p>
             </section>
 
-            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ GitHub Action ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
+            {/* ── GitHub Action ──────────────────────────────────────── */}
             <section id="github-action">
               <h2>GitHub Action</h2>
               <pre><code>{`# .github/workflows/security.yml
@@ -381,7 +381,7 @@ jobs:
               </div>
             </section>
 
-            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ LLM ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
+            {/* ── LLM ───────────────────────────────────────────────── */}
             <section id="llm">
               <h2>Multi-LLM Support</h2>
               <p>AI classification is optional. All core commands work fully offline. Use <code>--provider &lt;name&gt;</code> or set the matching environment variable.</p>
@@ -406,7 +406,7 @@ jobs:
               </div>
             </section>
 
-            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ Incremental Scanning ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
+            {/* ── Incremental Scanning ──────────────────────────────── */}
             <section id="scanning">
               <h2>Incremental Scanning</h2>
               <p>Ship Safe caches file hashes and findings in <code>.ship-safe/context.json</code>. Only changed files are re-scanned on subsequent runs.</p>
@@ -418,7 +418,7 @@ jobs:
               <p>LLM responses are cached in <code>.ship-safe/llm-cache.json</code> with a 7-day TTL to reduce API costs.</p>
             </section>
 
-            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ Suppression ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
+            {/* ── Suppression ───────────────────────────────────────── */}
             <section id="suppression">
               <h2>Suppressing Findings</h2>
               <p><strong>Inline:</strong> Add <code># ship-safe-ignore</code> on any line:</p>
@@ -432,7 +432,7 @@ tests/fixtures/
 docs/`}</code></pre>
             </section>
 
-            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ Policy ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
+            {/* ── Policy ────────────────────────────────────────────── */}
             <section id="policy">
               <h2>Policy-as-Code</h2>
               <pre><code>{`npx ship-safe policy init`}</code></pre>
@@ -446,7 +446,7 @@ docs/`}</code></pre>
 }`}</code></pre>
             </section>
 
-            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ OWASP ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
+            {/* ── OWASP ─────────────────────────────────────────────── */}
             <section id="owasp">
               <h2>OWASP Coverage</h2>
               <div className={styles.tableWrap}>
@@ -457,14 +457,14 @@ docs/`}</code></pre>
                     <tr><td><strong>OWASP Mobile 2024</strong></td><td>M1-M10: Improper Credentials, Supply Chain, Insecure Auth, Insufficient Validation, Insecure Communication, Privacy, Binary Protections, Misconfiguration, Insecure Storage, Insufficient Crypto</td></tr>
                     <tr><td><strong>OWASP LLM 2025</strong></td><td>LLM01-LLM10: Prompt Injection, Sensitive Disclosure, Supply Chain, Data Poisoning, Output Handling, Excessive Agency, System Prompt Leakage, Vector Weaknesses, Misinformation, Unbounded Consumption</td></tr>
                     <tr><td><strong>OWASP CI/CD Top 10</strong></td><td>CICD-SEC-1 to 10: Flow Control, Identity Management, Dependency Chain, Pipeline Poisoning, PBAC, Credential Hygiene, System Config, Ungoverned Usage, Artifact Integrity, Logging</td></tr>
-                    <tr><td><strong>OWASP Agentic AI</strong></td><td>ASI01-ASI10: Agent Hijacking, Tool Misuse, Privilege Escalation, Unsafe Execution, Memory Poisoning, Identity Spoofing, Excessive Autonomy, Logging Gaps, Supply Chain, Cascading Hallucination</td></tr>
+                    <tr><td><strong>OWASP Agentic Applications 2026</strong></td><td>ASI01-ASI10: Agent Planning/Reasoning Manipulation, Tool Misuse, Identity &amp; Privilege Abuse, Agent Supply Chain, Unsafe Code Execution, Memory &amp; Context Poisoning, Insecure Inter-Agent Communication, Cascading Agent Failures, Human-Agent Trust Exploitation, Rogue Agents</td></tr>
                   </tbody>
                 </table>
               </div>
               <p>Compliance mapping to SOC 2 Type II, ISO 27001:2022, and NIST AI RMF is included in audit reports.</p>
             </section>
 
-            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ OpenClaw ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
+            {/* ── OpenClaw ──────────────────────────────────────────── */}
             <section id="openclaw">
               <h2>OpenClaw Security</h2>
               <pre><code>{`# Focused OpenClaw security scan
@@ -516,7 +516,7 @@ jobs:
               <p>Scans <code>openclaw.json</code>, <code>.cursorrules</code>, <code>CLAUDE.md</code>, Claude Code hooks, and MCP configs. Checks against the bundled threat intelligence database for known ClawHavoc IOCs.</p>
             </section>
 
-            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ Claude Code ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
+            {/* ── Claude Code ───────────────────────────────────────── */}
             <section id="claude-code">
               <h2>Claude Code Plugin</h2>
               <pre><code>{`claude plugin add github:asamassekou10/ship-safe`}</code></pre>
@@ -534,7 +534,7 @@ jobs:
               </div>
             </section>
 
-            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ Config Files ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
+            {/* ── Config Files ──────────────────────────────────────── */}
             <section id="config">
               <h2>Configuration Files</h2>
               <div className={styles.tableWrap}>
@@ -548,14 +548,14 @@ jobs:
                     <tr><td><code>.ship-safe/baseline.json</code></td><td>Accepted findings baseline</td></tr>
                     <tr><td><code>.ship-safe/llm-cache.json</code></td><td>LLM response cache (7-day TTL)</td></tr>
                     <tr><td><code>.ship-safe/fixes.jsonl</code></td><td>Log of every fix applied by <code>agent</code> (used by <code>undo</code>)</td></tr>
-                    <tr><td><code>.ship-safe/failures.jsonl</code></td><td>Plans that failed to apply ÃÂ¢ÃÂÃÂ parse errors, declined plans, provider errors</td></tr>
+                    <tr><td><code>.ship-safe/failures.jsonl</code></td><td>Plans that failed to apply — parse errors, declined plans, provider errors</td></tr>
                   </tbody>
                 </table>
               </div>
               <p>The <code>.ship-safe/</code> directory is automatically excluded from scans and should be added to <code>.gitignore</code>.</p>
             </section>
 
-            {/* ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ Supply Chain ÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂÃÂ¢ÃÂÃÂ */}
+            {/* ── Supply Chain ──────────────────────────────────────── */}
             <section id="supply-chain">
               <h2>Supply Chain Hardening</h2>
               <p>Ship Safe practices what it preaches. Our own supply chain is hardened against the <a href="/blog/supply-chain-attacks-2026-how-we-hardened-ship-safe">2026 Trivy/CanisterWorm attack chain</a>:</p>


### PR DESCRIPTION
Completes **P1** (non-agent items).

## MCP auto-launch-on-trust
New `MCP_AUTO_LAUNCH_ON_TRUST` rule in MCPSecurityAgent. A repo-local `.mcp.json` / `.cursor/mcp.json` / `.vscode/mcp.json` that defines a stdio `command` server auto-launches the moment a developer accepts the editor's folder-trust prompt — the shared weak default across Claude Code, Cursor, and VS Code (Adversa, 2026). Excludes remote-only servers and the global `claude_desktop_config.json` (both tested).

## OWASP Agentic 2026
Refreshed the docs coverage mapping to the finalized **OWASP Top 10 for Agentic Applications 2026** categories.

## Docs encoding fix (bonus)
Repaired pre-existing mojibake in `webapp/app/docs/page.tsx` — em-dashes were triple-UTF-8-encoded and rendered as garbled `Ã‚Â¢`-style characters. 735+ occurrences corrected via a validated iterative un-mojibake (0 residual, tsc clean, all content intact).

## Verified
**246 tests** (+4), lint 0 errors, webapp tsc clean.