### PR TITLE
Add AIBOM generator + EU AI Act readiness report (v9.5.0 P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,15 @@ model supply chain.
   for Agentic Applications 2026** categories (inter-agent communication,
   cascading failures, human-agent trust, rogue agents).
 
+- **`aibom` command + AIBOMGenerator** — an AI Bill of Materials (CycloneDX
+  1.5) that inventories the AI supply chain an SBOM misses: model weights (with
+  pickle/safe serialization flagged), LLM/ML SDKs and providers (npm + PyPI),
+  MCP servers, and agent instruction files. `--ai-act` adds a heuristic **EU AI
+  Act high-risk readiness report** (Articles 9–17 obligations, Aug 2 2026
+  deadline) scoring risk-management, data-governance, logging, transparency,
+  human-oversight, testing, and AI-security signals, with a gap list. Framed as
+  an engineering indicator, not legal advice.
+
 ### Fixed
 - Repaired pervasive mojibake (triple-encoded em-dashes and other punctuation)
   in the documentation page — a pre-existing UTF-8 corruption that rendered as

--- a/cli/__tests__/aibom-generator.test.js
+++ b/cli/__tests__/aibom-generator.test.js
@@ -1,0 +1,82 @@
+/**
+ * Ship Safe — AIBOMGenerator
+ * ===========================
+ *
+ * Verifies AI component inventory (models, SDKs, MCP, agent configs) and the
+ * EU AI Act readiness scoring.
+ *
+ * Run: npm test
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import { AIBOMGenerator } from '../agents/aibom-generator.js';
+
+function tmp() { return fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-aibom-')); }
+function cleanup(dir) { try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* */ } }
+
+describe('AIBOMGenerator — inventory', () => {
+  it('inventories models, SDKs, MCP servers and agent configs', async () => {
+    const dir = tmp();
+    try {
+      fs.writeFileSync(path.join(dir, 'model.safetensors'), 'x');
+      fs.writeFileSync(path.join(dir, 'weights.pkl'), 'x');
+      fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'app', dependencies: { openai: '^4', '@anthropic-ai/sdk': '^0.30' } }));
+      fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({ mcpServers: { fs: { command: 'node', args: ['s.js'] } } }));
+      fs.writeFileSync(path.join(dir, 'CLAUDE.md'), '# rules');
+
+      const bom = new AIBOMGenerator().generate(dir);
+      const typeVals = bom.components.flatMap((c) => c.properties.filter((p) => p.name === 'ai:type').map((p) => p.value));
+      assert.equal(bom.bomFormat, 'CycloneDX');
+      assert.ok(typeVals.includes('model'));
+      assert.ok(typeVals.includes('sdk'));
+      assert.ok(typeVals.includes('mcp-server'));
+      assert.ok(typeVals.includes('agent-config'));
+      // pickle model flagged as unsafe serialization
+      const pkl = bom.components.find((c) => c.name === 'weights.pkl');
+      assert.ok(pkl.properties.some((p) => p.name === 'ai:serialization' && /pickle/.test(p.value)));
+    } finally { cleanup(dir); }
+  });
+
+  it('detects Python AI SDKs from requirements.txt', async () => {
+    const dir = tmp();
+    try {
+      fs.writeFileSync(path.join(dir, 'requirements.txt'), 'torch==2.3\ntransformers>=4.40\nnumpy\n');
+      const bom = new AIBOMGenerator().generate(dir);
+      const names = bom.components.map((c) => c.name);
+      assert.ok(names.includes('torch'));
+      assert.ok(names.includes('transformers'));
+    } finally { cleanup(dir); }
+  });
+});
+
+describe('AIBOMGenerator — EU AI Act readiness', () => {
+  it('scores higher for a governed project than a bare one', async () => {
+    const bare = tmp();
+    const governed = tmp();
+    try {
+      fs.writeFileSync(path.join(bare, 'package.json'), JSON.stringify({ name: 'bare', dependencies: { openai: '^4' } }));
+
+      fs.writeFileSync(path.join(governed, 'package.json'), JSON.stringify({ name: 'gov', dependencies: { openai: '^4' } }));
+      fs.writeFileSync(path.join(governed, 'README.md'), '# Project');
+      fs.writeFileSync(path.join(governed, 'RISK.md'), '# Risk management');
+      fs.writeFileSync(path.join(governed, 'MODEL_CARD.md'), '# Model card / data governance');
+      fs.mkdirSync(path.join(governed, 'tests'));
+      fs.writeFileSync(path.join(governed, 'tests', 'a.test.js'), 'test');
+      fs.writeFileSync(path.join(governed, 'app.js'), 'const logger = require("winston"); // require_approval human-in-the-loop');
+
+      const gen = new AIBOMGenerator();
+      const rBare = gen.generateAIActReadiness(bare);
+      const rGov = gen.generateAIActReadiness(governed);
+
+      assert.ok(rGov.score > rBare.score, `governed (${rGov.score}) should exceed bare (${rBare.score})`);
+      assert.equal(rGov.total, 8);
+      assert.ok(Array.isArray(rGov.gaps));
+      assert.ok(rBare.isLikelyAISystem);
+    } finally { cleanup(bare); cleanup(governed); }
+  });
+});

--- a/cli/agents/aibom-generator.js
+++ b/cli/agents/aibom-generator.js
@@ -1,0 +1,211 @@
+/**
+ * AIBOMGenerator — AI Bill of Materials + EU AI Act readiness
+ * ===========================================================
+ *
+ * An AIBOM inventories the AI supply chain of a project: model weights, LLM/ML
+ * SDKs and providers, MCP servers, and agent instruction files — the artifacts
+ * an SBOM misses. It also produces a heuristic EU AI Act high-risk readiness
+ * report, timed to the Aug 2 2026 obligations deadline (Articles 9–17 / 26),
+ * where ~78% of organizations are unprepared.
+ *
+ * The readiness report is an engineering indicator (presence of governance
+ * artifacts + AI usage signals), not legal advice.
+ *
+ * Output: CycloneDX 1.5-style JSON. Class: Compliance / Supply Chain.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import fg from 'fast-glob';
+import { SKIP_DIRS } from '../utils/patterns.js';
+
+const MODEL_EXTS = new Set(['.pkl', '.pt', '.pth', '.ckpt', '.bin', '.safetensors', '.gguf', '.onnx', '.h5', '.joblib']);
+const UNSAFE_MODEL_EXTS = new Set(['.pkl', '.pt', '.pth', '.ckpt', '.bin', '.joblib']);
+const MCP_CONFIG_FILES = ['mcp.json', '.mcp.json', 'mcp-config.json', 'claude_desktop_config.json', '.cursor/mcp.json', '.vscode/mcp.json'];
+const AGENT_CONFIG_FILES = ['CLAUDE.md', 'AGENTS.md', '.cursorrules', '.windsurfrules', '.github/copilot-instructions.md'];
+
+// Known LLM/ML SDKs and providers (npm + pypi).
+const AI_SDKS = {
+  openai: 'OpenAI', '@anthropic-ai/sdk': 'Anthropic', anthropic: 'Anthropic',
+  '@google/generative-ai': 'Google Gemini', 'google-generativeai': 'Google Gemini',
+  'cohere-ai': 'Cohere', cohere: 'Cohere', mistralai: 'Mistral', '@mistralai/mistralai': 'Mistral',
+  langchain: 'LangChain', '@langchain/core': 'LangChain', llamaindex: 'LlamaIndex', 'llama-index': 'LlamaIndex',
+  ollama: 'Ollama', replicate: 'Replicate', 'groq-sdk': 'Groq', groq: 'Groq',
+  '@huggingface/inference': 'Hugging Face', transformers: 'Hugging Face Transformers',
+  torch: 'PyTorch', tensorflow: 'TensorFlow', 'onnxruntime': 'ONNX Runtime', 'vllm': 'vLLM',
+};
+
+export class AIBOMGenerator {
+  generate(rootPath) {
+    const components = [];
+    let idx = 0;
+    const ref = () => `ai-${idx++}`;
+
+    // ── Model weights ────────────────────────────────────────────────────────
+    const modelFiles = fg.sync(['**/*.{pkl,pt,pth,ckpt,bin,safetensors,gguf,onnx,h5,joblib}'], {
+      cwd: rootPath, absolute: true, onlyFiles: true,
+      ignore: Array.from(SKIP_DIRS).map((d) => `**/${d}/**`),
+    });
+    for (const file of modelFiles) {
+      const ext = path.extname(file).toLowerCase();
+      if (!MODEL_EXTS.has(ext)) continue;
+      const unsafe = UNSAFE_MODEL_EXTS.has(ext);
+      components.push({
+        'bom-ref': ref(), type: 'machine-learning-model',
+        name: path.basename(file),
+        version: 'unknown',
+        description: `ML model weights (${ext})`,
+        properties: [
+          { name: 'ai:type', value: 'model' },
+          { name: 'ai:format', value: ext.slice(1) },
+          { name: 'ai:serialization', value: unsafe ? 'pickle-based (executes on load)' : 'safe' },
+          { name: 'ai:path', value: path.relative(rootPath, file) },
+        ],
+      });
+    }
+
+    // ── AI SDKs / providers ──────────────────────────────────────────────────
+    for (const [dep, provider] of Object.entries(this._detectDeps(rootPath))) {
+      components.push({
+        'bom-ref': ref(), type: 'library',
+        name: dep, version: provider.version || 'unknown',
+        description: `AI SDK / provider: ${provider.label}`,
+        purl: `pkg:${provider.ecosystem}/${encodeURIComponent(dep)}`,
+        properties: [
+          { name: 'ai:type', value: 'sdk' },
+          { name: 'ai:provider', value: provider.label },
+        ],
+      });
+    }
+
+    // ── MCP servers ──────────────────────────────────────────────────────────
+    for (const rel of MCP_CONFIG_FILES) {
+      const full = path.join(rootPath, rel);
+      if (!fs.existsSync(full)) continue;
+      try {
+        const data = JSON.parse(fs.readFileSync(full, 'utf-8'));
+        const servers = data.mcpServers || data.servers || {};
+        for (const [name, cfg] of Object.entries(servers)) {
+          components.push({
+            'bom-ref': ref(), type: 'application',
+            name, version: cfg.version || 'unknown',
+            description: `MCP server from ${rel}`,
+            properties: [
+              { name: 'ai:type', value: 'mcp-server' },
+              { name: 'ai:source', value: rel },
+              { name: 'ai:transport', value: cfg.command ? 'stdio' : (cfg.url ? 'remote' : 'unknown') },
+            ],
+          });
+        }
+      } catch { /* skip */ }
+    }
+
+    // ── Agent instruction files ──────────────────────────────────────────────
+    for (const rel of AGENT_CONFIG_FILES) {
+      const full = path.join(rootPath, rel);
+      if (!fs.existsSync(full)) continue;
+      components.push({
+        'bom-ref': ref(), type: 'data',
+        name: rel, version: this._mtime(full),
+        description: 'AI agent instruction / rules file',
+        properties: [{ name: 'ai:type', value: 'agent-config' }],
+      });
+    }
+
+    return {
+      bomFormat: 'CycloneDX',
+      specVersion: '1.5',
+      version: 1,
+      metadata: {
+        timestamp: new Date().toISOString(),
+        component: { type: 'application', name: path.basename(path.resolve(rootPath)) },
+        tools: [{ name: 'ship-safe', description: 'AIBOM generator' }],
+      },
+      components,
+    };
+  }
+
+  generateToFile(rootPath, outputPath) {
+    const bom = this.generate(rootPath);
+    fs.writeFileSync(outputPath, JSON.stringify(bom, null, 2));
+    return bom;
+  }
+
+  /**
+   * Heuristic EU AI Act high-risk readiness. Engineering indicator, not legal
+   * advice. Maps loosely to Articles 9–17 provider obligations.
+   */
+  generateAIActReadiness(rootPath) {
+    const bom = this.generate(rootPath);
+    const aiComponents = bom.components.length;
+    const has = (globs) => fg.sync(globs, { cwd: rootPath, ignore: Array.from(SKIP_DIRS).map((d) => `**/${d}/**`), caseSensitiveMatch: false }).length > 0;
+    const grepAny = (globs, re) => {
+      for (const f of fg.sync(globs, { cwd: rootPath, absolute: true, ignore: Array.from(SKIP_DIRS).map((d) => `**/${d}/**`) }).slice(0, 200)) {
+        try { if (re.test(fs.readFileSync(f, 'utf-8'))) return true; } catch { /* */ }
+      }
+      return false;
+    };
+
+    const checks = [
+      { id: 'art9-risk-mgmt', name: 'Risk management documentation (Art. 9)', pass: has(['**/{RISK,risk,risk-management}*.md', '**/docs/**/risk*.md']) },
+      { id: 'art10-data-gov', name: 'Data governance / dataset documentation (Art. 10)', pass: has(['**/{DATA,DATASET,data-governance,MODEL_CARD,model-card,model_card}*.{md,json}', '**/model-card*']) },
+      { id: 'art11-tech-doc', name: 'Technical documentation (Art. 11)', pass: has(['**/README*', '**/docs/**/*.md']) },
+      { id: 'art12-logging', name: 'Record-keeping / logging (Art. 12)', pass: grepAny(['**/*.{js,ts,py}'], /audit[_-]?log|winston|pino|logging\.getLogger|structlog|opentelemetry/i) },
+      { id: 'art13-transparency', name: 'Transparency / AI disclosure to users (Art. 13)', pass: has(['**/{AI_DISCLOSURE,ai-disclosure,TRANSPARENCY,transparency}*']) || grepAny(['**/*.{md,tsx,jsx,html}'], /AI[- ]generated|powered by (?:AI|GPT|an? LLM)|this (?:assistant|response) (?:is|was) generated/i) },
+      { id: 'art14-human-oversight', name: 'Human oversight / approval gate (Art. 14)', pass: grepAny(['**/*.{js,ts,py,json,md}'], /require[_-]?approval|human[- ]?in[- ]?the[- ]?loop|human[- ]?review|dry[- ]?run|confirm(?:ation)?\s+before/i) },
+      { id: 'art15-accuracy', name: 'Accuracy / robustness testing (Art. 15)', pass: has(['**/*.{test,spec}.{js,ts,py}', '**/tests/**', '**/__tests__/**', '**/eval*/**', '**/benchmark*/**']) },
+      { id: 'art15-cybersecurity', name: 'AI-specific security scanning (Art. 15)', pass: has(['**/.ship-safe*', '**/ship-safe*']) || grepAny(['**/.github/workflows/*.{yml,yaml}'], /ship-safe|semgrep|codeql|trivy/i) },
+    ];
+
+    const passed = checks.filter((c) => c.pass).length;
+    const score = Math.round((passed / checks.length) * 100);
+    const level = score >= 80 ? 'strong' : score >= 50 ? 'partial' : 'weak';
+
+    return {
+      timestamp: new Date().toISOString(),
+      project: bom.metadata.component.name,
+      aiComponents,
+      isLikelyAISystem: aiComponents > 0,
+      score,
+      level,
+      passed,
+      total: checks.length,
+      checks,
+      gaps: checks.filter((c) => !c.pass).map((c) => c.name),
+      disclaimer: 'Heuristic readiness indicator based on repository signals — not legal advice. EU AI Act high-risk obligations (Art. 9–17, 26) bind Aug 2 2026.',
+    };
+  }
+
+  // ── helpers ──────────────────────────────────────────────────────────────────
+
+  _detectDeps(rootPath) {
+    const found = {};
+    const pkgPath = path.join(rootPath, 'package.json');
+    if (fs.existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+        const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+        for (const [name, version] of Object.entries(deps)) {
+          if (AI_SDKS[name]) found[name] = { label: AI_SDKS[name], version: String(version).replace(/^[^\d]*/, '') || 'unknown', ecosystem: 'npm' };
+        }
+      } catch { /* */ }
+    }
+    for (const reqName of ['requirements.txt', 'pyproject.toml', 'Pipfile']) {
+      const reqPath = path.join(rootPath, reqName);
+      if (!fs.existsSync(reqPath)) continue;
+      let text;
+      try { text = fs.readFileSync(reqPath, 'utf-8'); } catch { continue; }
+      for (const name of Object.keys(AI_SDKS)) {
+        const re = new RegExp(`(^|[\\s"'\\[])${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'im');
+        if (re.test(text)) found[name] = { label: AI_SDKS[name], version: 'unknown', ecosystem: 'pypi' };
+      }
+    }
+    return found;
+  }
+
+  _mtime(file) {
+    try { return fs.statSync(file).mtime.toISOString().split('T')[0]; } catch { return 'unknown'; }
+  }
+}
+
+export default AIBOMGenerator;

--- a/cli/agents/index.js
+++ b/cli/agents/index.js
@@ -39,6 +39,7 @@ export { SlopSquatAgent } from './slopsquat-agent.js';
 export { ClickFixAgent } from './clickfix-agent.js';
 export { InstallGuardAgent } from './install-guard-agent.js';
 export { ABOMGenerator } from './abom-generator.js';
+export { AIBOMGenerator } from './aibom-generator.js';
 export { VerifierAgent } from './verifier-agent.js';
 export { DeepAnalyzer } from './deep-analyzer.js';
 export { ScoringEngine, GRADES, CATEGORIES } from './scoring-engine.js';

--- a/cli/bin/ship-safe.js
+++ b/cli/bin/ship-safe.js
@@ -48,6 +48,7 @@ import { openclawCommand } from '../commands/openclaw.js';
 import { scanSkillCommand } from '../commands/scan-skill.js';
 import { scanMcpCommand } from '../commands/scan-mcp.js';
 import { abomCommand } from '../commands/abom.js';
+import { aibomCommand } from '../commands/aibom.js';
 import { updateIntelCommand } from '../commands/update-intel.js';
 import { hooksCommand } from '../commands/hooks.js';
 import { legalCommand } from '../commands/legal.js';
@@ -515,6 +516,17 @@ program
   .option('-o, --output <file>', 'Output file path', 'abom.json')
   .option('--json', 'Output to stdout as JSON')
   .action(abomCommand);
+
+// -----------------------------------------------------------------------------
+// AIBOM COMMAND
+// -----------------------------------------------------------------------------
+program
+  .command('aibom [path]')
+  .description('Generate AI Bill of Materials (models, LLM/ML SDKs, MCP servers, agent configs) + EU AI Act readiness')
+  .option('-o, --output <file>', 'Output file path', 'aibom.json')
+  .option('--ai-act', 'Also print the EU AI Act high-risk readiness report')
+  .option('--json', 'Output to stdout as JSON')
+  .action(aibomCommand);
 
 // -----------------------------------------------------------------------------
 // HOOKS COMMAND (Claude Code PreToolUse / PostToolUse integration)

--- a/cli/commands/aibom.js
+++ b/cli/commands/aibom.js
@@ -1,0 +1,86 @@
+/**
+ * AIBOM Command
+ * =============
+ *
+ * Generate an AI Bill of Materials (models, LLM/ML SDKs, MCP servers, agent
+ * configs) and, optionally, an EU AI Act high-risk readiness report.
+ *
+ * USAGE:
+ *   ship-safe aibom [path]                Generate AIBOM -> aibom.json
+ *   ship-safe aibom . -o ai-bom.json      Custom output path
+ *   ship-safe aibom . --ai-act            Also print the EU AI Act readiness report
+ *   ship-safe aibom . --json              Print AIBOM JSON to stdout
+ */
+
+import path from 'path';
+import chalk from 'chalk';
+import { AIBOMGenerator } from '../agents/aibom-generator.js';
+import * as output from '../utils/output.js';
+
+export async function aibomCommand(targetPath = '.', options = {}) {
+  const absolutePath = path.resolve(targetPath);
+  const generator = new AIBOMGenerator();
+  const bom = generator.generate(absolutePath);
+
+  if (options.json) {
+    console.log(JSON.stringify(bom, null, 2));
+    return;
+  }
+
+  console.log();
+  output.header('Ship Safe — AI Bill of Materials');
+  console.log();
+
+  const outputFile = options.output || 'aibom.json';
+  generator.generateToFile(absolutePath, outputFile);
+
+  const byType = (t) => bom.components.filter((c) => c.properties?.some((p) => p.name === 'ai:type' && p.value === t));
+  const models = byType('model');
+  const sdks = byType('sdk');
+  const mcp = byType('mcp-server');
+  const configs = byType('agent-config');
+  const unsafeModels = models.filter((m) => m.properties?.some((p) => p.name === 'ai:serialization' && /pickle/.test(p.value)));
+
+  console.log(chalk.gray(`  Project: ${bom.metadata.component.name}`));
+  console.log();
+  console.log(`  ${chalk.cyan('Models')}:         ${models.length}${unsafeModels.length ? chalk.red(`  (${unsafeModels.length} pickle-based)`) : ''}`);
+  console.log(`  ${chalk.cyan('AI SDKs')}:        ${sdks.length}`);
+  console.log(`  ${chalk.cyan('MCP Servers')}:    ${mcp.length}`);
+  console.log(`  ${chalk.cyan('Agent Configs')}:  ${configs.length}`);
+  console.log(`  ${chalk.cyan('Total')}:          ${bom.components.length}`);
+  console.log();
+
+  if (sdks.length > 0) {
+    console.log(chalk.white.bold('  AI providers:'));
+    const providers = [...new Set(sdks.map((s) => s.properties?.find((p) => p.name === 'ai:provider')?.value).filter(Boolean))];
+    console.log(chalk.gray(`    ${providers.join(', ')}`));
+    console.log();
+  }
+
+  console.log(chalk.gray(`  Written to ${outputFile}`));
+  console.log();
+
+  if (options.aiAct) {
+    printAIActReadiness(generator.generateAIActReadiness(absolutePath));
+  }
+}
+
+function printAIActReadiness(r) {
+  output.header('EU AI Act — High-Risk Readiness');
+  console.log();
+  const color = r.level === 'strong' ? chalk.green : r.level === 'partial' ? chalk.yellow : chalk.red;
+  console.log(`  Readiness: ${color.bold(`${r.score}%`)} ${color(`(${r.level})`)}  ·  ${r.passed}/${r.total} checks  ·  ${r.aiComponents} AI component(s)`);
+  console.log();
+  for (const c of r.checks) {
+    const mark = c.pass ? chalk.green('✓') : chalk.red('✗');
+    console.log(`  ${mark} ${c.pass ? chalk.gray(c.name) : chalk.white(c.name)}`);
+  }
+  console.log();
+  if (r.gaps.length > 0) {
+    console.log(chalk.yellow.bold('  Gaps to close before Aug 2 2026:'));
+    for (const g of r.gaps) console.log(chalk.yellow(`    · ${g}`));
+    console.log();
+  }
+  console.log(chalk.gray(`  ${r.disclaimer}`));
+  console.log();
+}

--- a/webapp/app/docs/page.tsx
+++ b/webapp/app/docs/page.tsx
@@ -217,6 +217,7 @@ npx ship-safe ci . --threshold 80`}</code></pre>
                     <tr><td><code>doctor</code></td><td>Environment diagnostics</td></tr>
                     <tr><td><code>sbom .</code></td><td>Generate CycloneDX SBOM (CRA-ready)</td></tr>
                     <tr><td><code>abom .</code></td><td>Agent Bill of Materials (CycloneDX 1.5)</td></tr>
+                    <tr><td><code>aibom . --ai-act</code></td><td>AI Bill of Materials (models, LLM/ML SDKs, MCP servers) + EU AI Act readiness report</td></tr>
                     <tr><td><code>policy init</code></td><td>Create policy-as-code config</td></tr>
                     <tr><td><code>guard</code></td><td>Block git push if secrets found</td></tr>
                     <tr><td><code>checklist</code></td><td>Launch-day security checklist</td></tr>


### PR DESCRIPTION
The **P2** enterprise track from the research brief — compliance as a paid-tier pull, timed to the **EU AI Act high-risk deadline (Aug 2 2026)** where ~78% of orgs are unprepared.

## `ship-safe aibom [path]`
An **AI Bill of Materials** (CycloneDX 1.5) inventorying what an SBOM misses:
- **Model weights** — pickle-based (executes on load) vs. safe (safetensors) flagged
- **LLM / ML SDKs & providers** — OpenAI, Anthropic, Gemini, Mistral, Cohere, LangChain, LlamaIndex, PyTorch, Transformers… (npm + PyPI)
- **MCP servers** and **agent instruction files**

## `--ai-act` — EU AI Act readiness
A heuristic high-risk readiness report mapped to provider obligations (Art. 9–17): risk management, data governance, record-keeping/logging, transparency, human oversight, accuracy/robustness testing, and AI-specific security — scored with a prioritized gap list. Explicitly framed as an engineering indicator, **not legal advice**.

```
Readiness: 13% (weak) · 1/8 checks · 6 AI component(s)
✓ Technical documentation (Art. 11)
✗ Risk management documentation (Art. 9)
✗ Human oversight / approval gate (Art. 14)
...
```

## Notes
Generator / post-processor (like SBOM & ABOM) — **not** a scanning agent, so the agent count stays 29. Verified end-to-end via the CLI (inventory + readiness render correctly).

## Verified
**249 tests** (+3), lint 0 errors, webapp tsc clean.

---
**This completes P1 + P2.** v9.5.0 "Trust Boundary" is feature-complete: 24 → 29 agents + AIBOM/AI-Act. Ready to cut the release.