### PR TITLE
Fix README mojibake + add encoding guard (root cause of the docs corruption)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,9 +104,14 @@ model supply chain.
   an engineering indicator, not legal advice.
 
 ### Fixed
-- Repaired pervasive mojibake (triple-encoded em-dashes and other punctuation)
-  in the documentation page — a pre-existing UTF-8 corruption that rendered as
-  garbled characters. 735+ occurrences corrected.
+- Repaired UTF-8 mojibake (double/triple-encoded punctuation) in the docs page
+  and README that rendered as garbled `Ã‚Â¢`-style characters. Root cause: an
+  in-place `perl -i` edit that inserted a wide character (em-dash) without a
+  UTF-8 I/O layer, re-encoding every pre-existing multibyte character. README
+  was repaired surgically (decoding only the double-encoded runs) to preserve
+  already-clean characters.
+- Added an **encoding-guard test** that fails CI if any tracked text file
+  contains mojibake, preventing recurrence.
 
 ### Tests
 - 23 net new tests (212 → 235): ModelScan payload detection, unsafe-format flagging,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src=".github/assets/ship-safe-logo-2026.png" alt="Ship Safe Logo" width="180" />
 </p>
 <p align="center"><strong>Find risky code, AI-agent vulnerabilities, and supply-chain issues before they ship.</strong></p>
-<p align="center"><a href="https://shipsafecli.com">Website</a> Â· <a href="https://shipsafecli.com/docs">Docs</a> Â· <a href="https://shipsafecli.com/pricing">Pricing</a> Â· <a href="https://shipsafecli.com/blog">Blog</a></p>
+<p align="center"><a href="https://shipsafecli.com">Website</a> · <a href="https://shipsafecli.com/docs">Docs</a> · <a href="https://shipsafecli.com/pricing">Pricing</a> · <a href="https://shipsafecli.com/blog">Blog</a></p>
 
 <p align="center">
   <a href="https://www.npmjs.com/package/ship-safe"><img src="https://badge.fury.io/js/ship-safe.svg" alt="npm version" /></a>
@@ -123,8 +123,8 @@ All agents run in parallel. Each skips irrelevant projects automatically.
 | **GitHistoryScanner** | Secrets | Leaked secrets in git commit history |
 | **CICDScanner** | CI/CD | Pipeline poisoning, unpinned actions, secret logging (OWASP CI/CD Top 10) |
 | **APIFuzzer** | API | Routes without auth, mass assignment, GraphQL introspection, debug endpoints |
-| **ManagedAgentScanner** | AI/LLM | Claude Managed Agent misconfigs: always_allow policies, unrestricted networking (ASI-03âASI-07) |
-| **HermesSecurityAgent** | AI/LLM | Tool registry poisoning, function-call injection, skill permission drift (ASI-01âASI-10) |
+| **ManagedAgentScanner** | AI/LLM | Claude Managed Agent misconfigs: always_allow policies, unrestricted networking (ASI-03–ASI-07) |
+| **HermesSecurityAgent** | AI/LLM | Tool registry poisoning, function-call injection, skill permission drift (ASI-01–ASI-10) |
 | **AgentAttestationAgent** | Supply Chain | Unpinned agent versions, missing integrity hashes, unsigned manifests (ASI-10, SLSA L0) |
 | **AgenticSupplyChainAgent** | Supply Chain | Over-privileged AI CI actions, OAuth scope creep, unsigned AI webhook receivers (ASI-02, ASI-06) |
 | **RobloxSecurityAgent** | Supply Chain | Malicious Roblox/Luau Toolbox assets (runtime asset injection, `rbxassetid://` loaders, `HttpEnabled`, payloads hidden in instance attributes) |
@@ -134,7 +134,7 @@ All agents run in parallel. Each skips irrelevant projects automatically.
 | **ClickFixAgent** | Supply Chain | ClickFix / fake-CAPTCHA paste-and-run lures (fake error + Win+R/Ctrl+V/command-bar keystrokes, PowerShell cradles) and fake-installer npm lifecycle scripts (CWE-1357, CWE-506) |
 | **InstallGuardAgent** | Supply Chain | npm worm behaviors in lifecycle scripts (credential harvesting, env exfiltration, destructive `rm -rf`, obfuscated `node -e`) and weaponized `binding.gyp` node-gyp actions (CWE-506, CWE-829) |
 
-**Post-processors:** ScoringEngine Â· VerifierAgent (secrets liveness) Â· DeepAnalyzer (LLM taint analysis)
+**Post-processors:** ScoringEngine · VerifierAgent (secrets liveness) · DeepAnalyzer (LLM taint analysis)
 
 ---
 
@@ -143,14 +143,14 @@ All agents run in parallel. Each skips irrelevant projects automatically.
 ```
 $ ship-safe
 
-  âââââââââââ  âââââââââââââ     ââââââââ ââââââ ââââââââââââââââ
+  ███████╗██╗  ██╗██╗██████╗     ███████╗ █████╗ ███████╗███████╗
   ...
 
-  v9.4.1  Â·  DeepSeek  Â·  ~/my-project
+  v9.4.1  ·  DeepSeek  ·  ~/my-project
 
-  /scan to find issues  Â·  /agent to fix them  Â·  /help for more
+  /scan to find issues  ·  /agent to fix them  ·  /help for more
 
-shipsafe âº
+shipsafe ›
 ```
 
 | Command | What it does |
@@ -193,9 +193,9 @@ jobs:
 
 ## LLM Support
 
-Works with any provider â auto-detected from environment variables. Use `--provider <name>` to override.
+Works with any provider — auto-detected from environment variables. Use `--provider <name>` to override.
 
-Anthropic Â· OpenAI Â· Google Â· DeepSeek Â· Groq Â· Together Â· Mistral Â· xAI Â· Perplexity Â· Ollama Â· LM Studio Â· any OpenAI-compatible endpoint
+Anthropic · OpenAI · Google · DeepSeek · Groq · Together · Mistral · xAI · Perplexity · Ollama · LM Studio · any OpenAI-compatible endpoint
 
 No API key required for scanning. AI is optional.
 
@@ -225,7 +225,7 @@ docs/
 
 ## Contributing
 
-1. Fork Â· add your pattern, agent, or config Â· open a PR
+1. Fork · add your pattern, agent, or config · open a PR
 2. See [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ---
@@ -248,4 +248,4 @@ Ship Safe is MIT-licensed and free forever.
 
 ---
 
-**Ship fast. Ship safe.** â [shipsafecli.com](https://shipsafecli.com)
+**Ship fast. Ship safe.** — [shipsafecli.com](https://shipsafecli.com)

--- a/cli/__tests__/encoding-guard.test.js
+++ b/cli/__tests__/encoding-guard.test.js
@@ -1,0 +1,58 @@
+/**
+ * Ship Safe — encoding guard
+ * ===========================
+ *
+ * Regression guard against UTF-8 mojibake (double/triple-encoded punctuation)
+ * in tracked text files. This class of corruption was introduced once by an
+ * in-place `perl -i -pe` edit that inserted a wide character (an em-dash)
+ * without a UTF-8 I/O layer, which re-encoded every pre-existing multibyte
+ * character in the file. It renders as garbled `Ã‚Â¢`-style text.
+ *
+ * If this test fails: do NOT edit text content with `perl -i`/`sed` using
+ * non-ASCII characters. Use the editor's UTF-8-safe write path (or Node with
+ * explicit 'utf8'), and repair the file with the double-decode fix.
+ *
+ * Run: npm test
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+
+// Byte signatures of double-encoded UTF-8 punctuation/emoji. These do not occur
+// in correctly-encoded UTF-8 text.
+const SIGNATURES = [
+  Buffer.from([0xc3, 0x83, 0xc2]), // Ã‚… (em/en-dash, quotes double-encoded)
+  Buffer.from([0xc3, 0x82, 0xc2]), // Â…
+  Buffer.from([0xc3, 0xa2, 0xc2]), // â… (e2-lead char double-encoded)
+];
+
+const BINARY_EXT = /\.(png|jpe?g|gif|webp|ico|icns|woff2?|ttf|eot|otf|mp3|mp4|mov|webm|pdf|zip|gz|tar|wasm|node)$/i;
+
+function trackedTextFiles() {
+  return execSync('git ls-files', { maxBuffer: 1 << 26 })
+    .toString().trim().split('\n')
+    .filter((f) => f && !BINARY_EXT.test(f));
+}
+
+describe('encoding guard', () => {
+  it('has no mojibake (double-encoded UTF-8) in tracked text files', () => {
+    const offenders = [];
+    for (const file of trackedTextFiles()) {
+      let buf;
+      try { buf = fs.readFileSync(file); } catch { continue; }
+      if (buf.length > 5_000_000) continue;
+      let count = 0;
+      for (const sig of SIGNATURES) {
+        let i = 0;
+        while ((i = buf.indexOf(sig, i)) !== -1) { count++; i += sig.length; }
+      }
+      if (count > 0) offenders.push(`${file} (${count})`);
+    }
+    assert.deepEqual(
+      offenders, [],
+      `Mojibake found in:\n  ${offenders.join('\n  ')}\nRepair with a double-decode fix; do not edit non-ASCII text via perl -i/sed.`,
+    );
+  });
+});


### PR DESCRIPTION
## Root cause found

The docs/README mojibake traces to an in-place **`perl -i -pe`** catalog-row edit that inserted a wide character (an em-dash / `\x{2014}`) **without a UTF-8 I/O layer**. Inserting a codepoint > 255 makes perl "upgrade" the whole in-memory string; printing it without an `:encoding(UTF-8)` layer then re-encodes **every pre-existing multibyte character** in the file — double-encoding all existing em-dashes and emoji. That's the `Wide character in print` warning that appeared during the count-bump steps.

Bisected to commit `716a3aa` (#45): README mojibake count jumped **0 → 81** there. Only files that received a wide-char `perl` insertion were affected — **README** and the **docs page** (the latter already fixed in #48). Digit-only count-bump substitutions were byte-safe.

## The fix
- **README repaired surgically** — decode only the double-encoded `c2`/`c3` runs, leaving genuine UTF-8 intact. This matters because README was in a *mixed* state: the em-dashes perl inserted are clean `e2 80 94`, while pre-existing content was double-encoded. A naive global decode fixes the latter but **destroys** the former (verified). Surgical fix keeps `slopsquatting) — bare` intact. 0 mojibake remaining.
- **Encoding guard test** (`cli/__tests__/encoding-guard.test.js`) scans every tracked text file for mojibake byte signatures and fails CI on any hit. Proven to catch injected corruption and pass on the clean tree.

## Prevention going forward
Don't edit non-ASCII text content with `perl -i`/`sed`; use a UTF-8-safe write path. The guard test now enforces this automatically.

## Verified
**251 tests** (+1 guard), lint 0 errors. Repo-wide scan: 0 mojibake in text files.