### PR TITLE
Fix: ASCII-only mojibake examples so encoding guard passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@ model supply chain.
 
 ### Fixed
 - Repaired UTF-8 mojibake (double/triple-encoded punctuation) in the docs page
-  and README that rendered as garbled `Ã‚Â¢`-style characters. Root cause: an
+  and README that rendered as garbled, double-encoded characters. Root cause: an
   in-place `perl -i` edit that inserted a wide character (em-dash) without a
   UTF-8 I/O layer, re-encoding every pre-existing multibyte character. README
   was repaired surgically (decoding only the double-encoded runs) to preserve

--- a/cli/__tests__/encoding-guard.test.js
+++ b/cli/__tests__/encoding-guard.test.js
@@ -6,7 +6,7 @@
  * in tracked text files. This class of corruption was introduced once by an
  * in-place `perl -i -pe` edit that inserted a wide character (an em-dash)
  * without a UTF-8 I/O layer, which re-encoded every pre-existing multibyte
- * character in the file. It renders as garbled `Ã‚Â¢`-style text.
+ * character in the file. It renders as garbled, double-encoded text.
  *
  * If this test fails: do NOT edit text content with `perl -i`/`sed` using
  * non-ASCII characters. Use the editor's UTF-8-safe write path (or Node with


### PR DESCRIPTION
The encoding guard added in #50 flagged the literal `Ã‚Â¢` example strings I'd embedded in the CHANGELOG and the guard's own docstring — those were real double-encoded bytes, so the guard was correct and main's CI went red. Replaced the examples with plain-ASCII descriptions. Guard + full suite green.