### PR TITLE
Fix Hermes image build and track releases instead of upstream main

### DIFF
--- a/.github/workflows/update-hermes-image.yml
+++ b/.github/workflows/update-hermes-image.yml
@@ -19,17 +19,34 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      # ── 1. Get latest commit SHA from NousResearch/hermes-agent ──────────────
-      - name: Get upstream Hermes SHA
+      # ── 1. Resolve the latest tagged Hermes release ──────────────────────────
+      # Deliberately a release, not `main`. This job builds an image that is
+      # rolled straight onto the production VPS, so tracking a moving branch
+      # meant any upstream commit — including a compromised one — reached prod
+      # within 24h with nobody in the loop. A tag is a point upstream chose to
+      # publish, and it gives us something reviewable to pin to.
+      - name: Get upstream Hermes release
         id: upstream
         run: |
-          SHA=$(curl -sf \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/NousResearch/hermes-agent/commits/main \
-            | jq -r '.sha')
+          set -euo pipefail
+          API="https://api.github.com/repos/NousResearch/hermes-agent"
+          H=(-H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28")
+
+          TAG=$(curl -sf "${H[@]}" "$API/releases/latest" | jq -r '.tag_name')
+          if [[ -z "$TAG" || "$TAG" == "null" ]]; then
+            echo "::error::could not resolve latest hermes-agent release"; exit 1
+          fi
+
+          REF=$(curl -sf "${H[@]}" "$API/git/ref/tags/$TAG")
+          SHA=$(jq -r '.object.sha' <<<"$REF")
+          # Annotated tags point at a tag object; dereference to the commit.
+          if [[ "$(jq -r '.object.type' <<<"$REF")" == "tag" ]]; then
+            SHA=$(curl -sf "${H[@]}" "$API/git/tags/$SHA" | jq -r '.object.sha')
+          fi
+
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
-          echo "Upstream SHA: ${SHA}"
+          echo "Upstream release: ${TAG} (${SHA})"
 
       # ── 2. Get SHA baked into the current latest image ────────────────────────
       - name: Get current image SHA
@@ -45,19 +62,19 @@ jobs:
       # ── 3. Build + push only if SHA changed ──────────────────────────────────
       - name: Log in to Docker Hub
         if: steps.upstream.outputs.sha != steps.current.outputs.sha
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         if: steps.upstream.outputs.sha != steps.current.outputs.sha
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build and push
         id: build
         if: steps.upstream.outputs.sha != steps.current.outputs.sha
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./vps
           file: ./vps/agent.Dockerfile
@@ -67,8 +84,10 @@ jobs:
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/hermes-agent:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/hermes-agent:${{ steps.upstream.outputs.sha }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/hermes-agent:${{ steps.upstream.outputs.tag }}
           labels: |
             org.opencontainers.image.revision=${{ steps.upstream.outputs.sha }}
+            org.opencontainers.image.version=${{ steps.upstream.outputs.tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/update-hermes-image.yml
+++ b/.github/workflows/update-hermes-image.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '0 3 * * *'   # 03:00 UTC daily
   workflow_dispatch:       # allow manual trigger
+    inputs:
+      dry_run:
+        description: 'Build only — do not push the image or roll out to the VPS'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -78,7 +83,9 @@ jobs:
         with:
           context: ./vps
           file: ./vps/agent.Dockerfile
-          push: true
+          # Dry run builds the image and throws it away: proves the Dockerfile
+          # on a real runner without publishing or touching production.
+          push: ${{ inputs.dry_run != true }}
           build-args: |
             HERMES_SHA=${{ steps.upstream.outputs.sha }}
           tags: |
@@ -105,7 +112,7 @@ jobs:
   rollout:
     needs: check-and-build
     runs-on: ubuntu-latest
-    if: needs.check-and-build.outputs.rebuilt == 'true'
+    if: needs.check-and-build.outputs.rebuilt == 'true' && inputs.dry_run != true
 
     steps:
       - name: Trigger rolling restart

--- a/vps/agent.Dockerfile
+++ b/vps/agent.Dockerfile
@@ -16,11 +16,28 @@ RUN apt-get update -qq && \
       git curl build-essential && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Hermes agent from GitHub — pinned to HERMES_SHA when provided
+# Install Hermes agent from a pinned source checkout.
+#
+# NOT `pip install git+https://...`: upstream's setup.py raises on any
+# wheel/sdist build outside a Nix sandbox, so that form has been dead since
+# 2026-07-23. Their guard exempts editable installs by design, and the runtime
+# resolves bundled assets (locales, skills, optional-mcps, web_dist, tui_dist,
+# plugin manifests) from the source-checkout layout — so the checkout has to
+# stay on disk rather than being discarded after install.
+#
+# Single-commit fetch rather than a clone: we always build one pinned revision,
+# so there is no reason to carry history. Works for both a full SHA and the
+# `HEAD` default. Git metadata is dropped once the install is done — it is ~82MB
+# and nothing at runtime reads it.
 ARG HERMES_SHA=HEAD
-RUN pip install --no-cache-dir \
-    "git+https://github.com/NousResearch/hermes-agent.git@${HERMES_SHA}" \
-    flask gunicorn
+RUN git init -q /opt/hermes && \
+    cd /opt/hermes && \
+    git remote add origin https://github.com/NousResearch/hermes-agent.git && \
+    git fetch -q --depth 1 origin "${HERMES_SHA}" && \
+    git checkout -q --detach FETCH_HEAD && \
+    pip install --no-cache-dir -e . && \
+    pip install --no-cache-dir flask gunicorn && \
+    rm -rf /opt/hermes/.git
 
 WORKDIR /app
 


### PR DESCRIPTION
The nightly Hermes image build has failed every night since 2026-07-23 (4 consecutive runs). This fixes it, and changes what we track so it doesn't happen the same way again.

## What broke

Upstream landed a guard in `hermes-agent`'s `setup.py` that raises on any wheel or sdist build outside a Nix sandbox. Because this workflow followed `main`, it picked that up the day it merged:

```
RuntimeError: Building wheels or sdists for hermes-agent is not supported.
Hermes is distributed via the shell installer, Docker image, or Nix.
```

The `rollout` job is gated on the build, so it has been skipping. No outage — the VPS kept serving the 07-22 image — but the agent runtime has been frozen for four days and would have stayed frozen silently.

## Two changes, fixing different halves

**Track the latest tagged release instead of `main`.** This job builds an image that rolls straight onto production, so following a branch meant any upstream commit reached the VPS within 24h with nobody in the loop. A release is a point upstream chose to publish.

As it happens the current release (`v2026.7.20`) predates the guard, so this alone unblocks the build today. That's luck, not a fix.

**Install from a pinned single-commit checkout with `pip install -e .`.** The guard is on `main` and will ship in the next release, at which point `pip install git+https://...` breaks again. Upstream exempts editable installs by design, and their runtime resolves bundled assets (locales, skills, optional-mcps, web_dist, tui_dist, plugin manifests) from the source-checkout layout, so the tree has to stay on disk. Git metadata is dropped after install.

Also pins `docker/login-action`, `docker/setup-buildx-action` and `docker/build-push-action` to commit SHAs. `actions/checkout` was already pinned in this file; our own `CICD_UNPINNED_ACTION` rule flagged the other three, in a workflow holding `DOCKERHUB_TOKEN` and `ORCHESTRATOR_SECRET`.

## Dry-run mode

The only way to exercise this workflow was to run it for real, which pushes `latest` and restarts production containers — so a build fix was untestable without deploying it. `workflow_dispatch` now takes a `dry_run` flag that builds the image and discards it, skipping both the push and the rollout. Scheduled runs are unaffected.

## Verification

Dry run on a real runner: https://github.com/asamassekou10/ship-safe/actions/runs/30205647604

```
[3/6] git init /opt/hermes && git fetch --depth 1 origin 3ef6bbd... && pip install -e .
      Building editable for hermes-agent (pyproject.toml): finished with status 'done'
[4/6] WORKDIR /app
[5/6] COPY agent-wrapper.py .
[6/6] RUN useradd ... hermes
```

All six layers built. Push skipped ("Build result will only remain in the build cache"), `rollout` skipped. Release resolution produced `v2026.7.20 (3ef6bbd)` and correctly decided to rebuild against the running image's `3e953ed`.

Isolated A/B against current guarded `main` (`eb52760`), outside Docker:

| method | result |
|---|---|
| `pip install .` | `RuntimeError: Building wheels or sdists ... not supported` — reproduces CI |
| `pip install -e .` | `Successfully installed hermes-agent-0.19.0` |

Also checked `requires-python = ">=3.11,<3.14"` against our `python:3.12-slim` base, and re-scanned the workflow with our own CLI: 88.4/B → 96.4/A, all three `CICD_UNPINNED_ACTION` findings cleared.

## Notes before merging

- The nightly keeps failing until this is on `main` — scheduled runs always use the default branch's workflow file.
- The first real run moves the agent runtime from the 07-22 `main` build to `v2026.7.20`. That's a genuine version change, not just a restore.
- The run warns that all four pinned actions target Node 20, which GitHub is deprecating (it force-ran them on Node 24). That predates this PR, but the majors I pinned are Node 20-based. Worth bumping to `login-action@v4`, `setup-buildx-action@v4`, `build-push-action@v7` separately.
