### PR TITLE
Pin brace-expansion to 5.0.8 to clear the npm audit gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -340,16 +340,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {

--- a/package.json
+++ b/package.json
@@ -74,5 +74,8 @@
     "@eslint/js": "^10.0.1",
     "eslint": "^10.3.0",
     "globals": "^17.6.0"
+  },
+  "overrides": {
+    "brace-expansion": "^5.0.8"
   }
 }


### PR DESCRIPTION
CI has been failing on every branch since GHSA-mh99-v99m-4gvg was published against `brace-expansion <=5.0.7`. We resolve exactly 5.0.7 through `eslint -> minimatch`, and the `Check for security vulnerabilities` step runs `npm audit --audit-level=high`. Main's last green run was 2026-07-23.

**The exposure is nil.** `brace-expansion` is dev-only — `npm ls brace-expansion --omit=dev` is empty — and the published package ships only `cli/`, `checklists/`, `configs/`, `snippets/` and `ai-defense/`. It never reaches a user. This is a CI stop, not a product vulnerability.

`npm audit fix` can't lift it on its own because the vulnerable version sits deep in eslint's tree, so this adds an `overrides` entry, the same mechanism `webapp/package.json` already uses for postcss.

After the change:

- `npm ls brace-expansion` -> `5.0.8`
- `npm audit --audit-level=high` -> found 0 vulnerabilities
- `npx eslint cli/` -> 0 errors
- `node --test cli/__tests__/*.test.js` -> 265 passed, 0 failed

Worth merging before #62, which is currently red for this reason alone.