### PR TITLE
Stop ship-safe-ignore from silencing critical findings

### DIFF
--- a/cli/__tests__/suppression-floor.test.js
+++ b/cli/__tests__/suppression-floor.test.js
@@ -1,0 +1,144 @@
+/**
+ * Suppression floor tests
+ * =======================
+ *
+ * `ship-safe-ignore` was designed for a human deciding a finding is a false
+ * positive. The code under scan is now often written by an AI agent, and an
+ * agent that can emit a line of source can emit the suppression comment on the
+ * line that matters — including through our own `ship_safe_suppress_finding`
+ * tool. So critical findings are reported regardless, and every suppression is
+ * counted so a silenced scan can't read as a clean one.
+ *
+ * Run: npm test
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import { BaseAgent, isSuppressible, SUPPRESSION_FLOOR_SEVERITIES } from '../agents/base-agent.js';
+
+const IGNORE = 'ship-safe' + '-ignore'; // split so our own self-scan stays clean
+
+function tempFile(lines) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-suppress-'));
+  const file = path.join(dir, 'sample.js');
+  fs.writeFileSync(file, lines.join('\n'));
+  return { file, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
+}
+
+class ProbeAgent extends BaseAgent {
+  constructor() {
+    super('ProbeAgent', 'test probe', 'test');
+  }
+}
+
+const PATTERNS = [
+  { rule: 'CRIT_SECRET', title: 'Hardcoded key', severity: 'critical', regex: /AKIA[0-9A-Z]{16}/g },
+  { rule: 'HIGH_THING', title: 'High thing', severity: 'high', regex: /highRisk\(/g },
+  { rule: 'LOW_THING', title: 'Low thing', severity: 'low', regex: /lowRisk\(/g },
+];
+
+describe('suppression floor', () => {
+  it('critical severity is not suppressible', () => {
+    assert.equal(isSuppressible('critical'), false);
+    assert.equal(isSuppressible('CRITICAL'), false);
+    assert.ok(SUPPRESSION_FLOOR_SEVERITIES.has('critical'));
+  });
+
+  it('everything below critical stays suppressible', () => {
+    for (const sev of ['high', 'medium', 'low', 'info']) {
+      assert.equal(isSuppressible(sev), true, sev);
+    }
+  });
+
+  it('reports a critical finding even on a suppressed line', () => {
+    const { file, cleanup } = tempFile([`const k = "AKIAIOSFODNN7EXAMPLE"; // ${IGNORE}`]);
+    try {
+      const agent = new ProbeAgent();
+      const findings = agent.scanFileWithPatterns(file, PATTERNS);
+      assert.deepEqual(findings.map(f => f.rule), ['CRIT_SECRET']);
+      assert.equal(agent.floorSuppressionAttempts, 1);
+      assert.equal(agent.suppressedCount, 0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('still suppresses non-critical findings (no behaviour change)', () => {
+    const { file, cleanup } = tempFile([
+      `lowRisk(); // ${IGNORE}`,
+      `highRisk(); // ${IGNORE}`,
+    ]);
+    try {
+      const agent = new ProbeAgent();
+      const findings = agent.scanFileWithPatterns(file, PATTERNS);
+      assert.deepEqual(findings, []);
+      assert.equal(agent.suppressedCount, 2);
+      assert.equal(agent.floorSuppressionAttempts, 0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('an unsuppressed line is unaffected', () => {
+    const { file, cleanup } = tempFile(['lowRisk();', 'const k = "AKIAIOSFODNN7EXAMPLE";']);
+    try {
+      const agent = new ProbeAgent();
+      const findings = agent.scanFileWithPatterns(file, PATTERNS);
+      assert.deepEqual(findings.map(f => f.rule).sort(), ['CRIT_SECRET', 'LOW_THING']);
+      assert.equal(agent.suppressedCount, 0);
+      assert.equal(agent.floorSuppressionAttempts, 0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('counts once per silenced rule, not per pattern checked', () => {
+    // Three patterns are evaluated against this line but only one matches, so
+    // exactly one suppression is recorded.
+    const { file, cleanup } = tempFile([`lowRisk(); // ${IGNORE}`]);
+    try {
+      const agent = new ProbeAgent();
+      agent.scanFileWithPatterns(file, PATTERNS);
+      assert.equal(agent.suppressedCount, 1);
+      assert.equal(agent.floorSuppressionAttempts, 0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('isSuppressed without a severity keeps the pre-floor behaviour', () => {
+    const agent = new ProbeAgent();
+    assert.equal(agent.isSuppressed(`x = 1; // ${IGNORE}`), true);
+    assert.equal(agent.isSuppressed('x = 1;'), false);
+  });
+
+  it('a clean line is never counted as suppressed', () => {
+    const agent = new ProbeAgent();
+    assert.equal(agent.isSuppressed('const safe = 1;', 'critical'), false);
+    assert.equal(agent.floorSuppressionAttempts, 0);
+    assert.equal(agent.suppressedCount, 0);
+  });
+});
+
+describe('agent tool registry', () => {
+  it('exposes no suppression tool to agents', async () => {
+    // An agent holding a suppression tool can silence the findings that cover
+    // its own output. The removed tool was also non-functional (its handler
+    // called an export that never existed).
+    const { HERMES_TOOLS } = await import('../utils/hermes-tool-registry.js');
+    const names = HERMES_TOOLS.map(t => t.name);
+    assert.ok(!names.includes('ship_safe_suppress_finding'), names.join(', '));
+  });
+
+  it('every registered tool matches its integrity hash', async () => {
+    const mod = await import('../utils/hermes-tool-registry.js');
+    const verify = mod.verifyIntegrity || mod.verifyToolIntegrity;
+    if (typeof verify === 'function') {
+      assert.deepEqual(verify(), [], 'tool registry hashes drifted');
+    }
+  });
+});

--- a/cli/agents/agent-config-scanner.js
+++ b/cli/agents/agent-config-scanner.js
@@ -745,8 +745,6 @@ export class AgentConfigScanner extends BaseAgent {
     // Check for large base64 blocks (60+ chars, not in code/URLs)
     const lines = content.split('\n');
     for (let i = 0; i < lines.length; i++) {
-      if (this.isSuppressed(lines[i])) continue;
-
       const b64Match = lines[i].match(/(?<![a-zA-Z0-9+/=])([A-Za-z0-9+/]{60,}={0,2})(?![a-zA-Z0-9+/=])/);
       if (b64Match) {
         // Try to decode and check for injection
@@ -760,6 +758,10 @@ export class AgentConfigScanner extends BaseAgent {
         } catch { /* not valid base64 */ }
 
         const severity = suspicious ? 'critical' : 'high';
+        // Checked here, not at the top of the loop: severity depends on what
+        // the block decodes to, and the suppression floor keys off severity.
+        if (this.isSuppressed(lines[i], severity)) continue;
+
         const desc = suspicious
           ? `Large base64-encoded block that decodes to suspicious content: "${decoded.substring(0, 80)}..."`
           : 'Large base64-encoded block in agent config file. May hide obfuscated instructions.';

--- a/cli/agents/agentic-security-agent.js
+++ b/cli/agents/agentic-security-agent.js
@@ -368,7 +368,7 @@ export class AgenticSecurityAgent extends BaseAgent {
       const line = this.findLine(content, rule);
       const lines = content.split('\n');
       const matched = lines[line - 1] || '';
-      if (this.isSuppressed(matched)) continue;
+      if (this.isSuppressed(matched, rule.severity)) continue;
 
       const finding = createFinding({
         file,

--- a/cli/agents/base-agent.js
+++ b/cli/agents/base-agent.js
@@ -60,6 +60,35 @@ export function createFinding({
 }
 
 // =============================================================================
+// SUPPRESSION FLOOR
+// =============================================================================
+
+/**
+ * Severities an inline `ship-safe-ignore` comment cannot silence.
+ *
+ * The comment was designed for a human deciding a finding is a false positive.
+ * That assumption no longer holds on its own: the code under scan is often
+ * written by an AI agent, and an agent that can emit a line of source can emit
+ * `// ship-safe-ignore` on the line that matters — including via our own
+ * `ship_safe_suppress_finding` tool. Suppression is therefore attacker-writable
+ * for anything an agent touches.
+ *
+ * Critical findings (hardcoded secrets, RCE, confirmed injection) are the ones
+ * where a silent suppression is indistinguishable from a clean scan, so they
+ * are reported regardless. Everything below critical keeps working exactly as
+ * before, so existing suppressions are unaffected.
+ *
+ * An attempt to suppress a floor finding is itself recorded — someone marking a
+ * critical finding as safe is a signal, not a no-op.
+ */
+export const SUPPRESSION_FLOOR_SEVERITIES = new Set(['critical']);
+
+/** Whether a finding of this severity may be silenced by an inline comment. */
+export function isSuppressible(severity) {
+  return !SUPPRESSION_FLOOR_SEVERITIES.has(String(severity || '').toLowerCase());
+}
+
+// =============================================================================
 // BASE AGENT CLASS
 // =============================================================================
 
@@ -73,6 +102,10 @@ export class BaseAgent {
     this.name = name;
     this.description = description;
     this.category = category;
+    // Suppression accounting. A scan that silenced findings must never read
+    // the same as a scan that had none to report.
+    this.suppressedCount = 0;
+    this.floorSuppressionAttempts = 0;
   }
 
   /**
@@ -201,9 +234,25 @@ export class BaseAgent {
 
   /**
    * Check if a line has the ship-safe-ignore suppression comment.
+   *
+   * Pass the severity of the finding being considered so the floor can apply:
+   * a critical finding is reported even on a suppressed line (see
+   * SUPPRESSION_FLOOR_SEVERITIES). Called without a severity, behaviour is
+   * unchanged from before the floor existed.
+   *
+   * Either way the outcome is counted, so a report can state how much it was
+   * asked not to say.
    */
-  isSuppressed(line) {
-    return /ship-safe-ignore/i.test(line);
+  isSuppressed(line, severity = null) {
+    if (!/ship-safe-ignore/i.test(line)) return false;
+
+    if (severity !== null && !isSuppressible(severity)) {
+      this.floorSuppressionAttempts++;
+      return false;
+    }
+
+    this.suppressedCount++;
+    return true;
   }
 
   /**
@@ -219,17 +268,33 @@ export class BaseAgent {
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
-      if (this.isSuppressed(line)) continue;
+      // Suppression is decided per pattern, not per line: the floor depends on
+      // the severity of the specific finding, which isn't known until we know
+      // which pattern matched.
+      const lineMarked = /ship-safe-ignore/i.test(line);
 
       for (const p of patterns) {
+        const severity = p.severity || 'medium';
+
+        // Collect matches first. Suppression is only meaningful for a pattern
+        // that actually fired, and it counts once per (line, rule) rather than
+        // once per match, so the tally reflects findings silenced.
         p.regex.lastIndex = 0;
-        let match;
-        while ((match = p.regex.exec(line)) !== null) {
+        const matches = [];
+        let m;
+        while ((m = p.regex.exec(line)) !== null) {
+          matches.push(m);
+          if (!p.regex.global) break;
+        }
+        if (matches.length === 0) continue;
+        if (lineMarked && this.isSuppressed(line, severity)) continue;
+
+        for (const match of matches) {
           const finding = createFinding({
             file: filePath,
             line: i + 1,
             column: match.index + 1,
-            severity: p.severity || 'medium',
+            severity,
             category: this.category,
             rule: p.rule,
             title: p.title,

--- a/cli/agents/config-auditor.js
+++ b/cli/agents/config-auditor.js
@@ -619,7 +619,7 @@ export class ConfigAuditor extends BaseAgent {
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
-      if (this.isSuppressed(line)) continue;
+      if (this.isSuppressed(line, 'critical')) continue;
 
       // Match: FROM docker:<version> or engine version references in comments/labels
       const versionMatch = line.match(/(?:docker|moby)[:\s]+(\d+)\.(\d+)\.(\d+)/i);
@@ -663,7 +663,7 @@ export class ConfigAuditor extends BaseAgent {
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
-      if (this.isSuppressed(line)) continue;
+      if (this.isSuppressed(line, 'high')) continue;
 
       // Detect S3 Files / S3 NFS mount references
       const isS3Mount = /(?:s3[_-]?files|s3.*(?:nfs|mount|filesystem)|file_system_id.*s3|efs.*s3|mount.*s3:\/\/)/i.test(line);

--- a/cli/agents/gpt-red-agent.js
+++ b/cli/agents/gpt-red-agent.js
@@ -293,12 +293,14 @@ export class GPTRedAgent extends BaseAgent {
 
       const lines = content.split('\n');
       const line = firstMatchLine(lines, hasHiddenInstruction ? HIDDEN_TEXT_RE : UNTRUSTED_TEXT_RE);
-      if (this.isSuppressed(lines[line - 1] || '')) continue;
 
       const capabilities = collectCapabilities(content);
       const rel = path.relative(rootPath, file).replace(/\\/g, '/');
       const attackPath = describeAttackPath(rel, capabilities);
       const severity = severityFor(capabilities, hasHiddenInstruction);
+      // After severityFor(): the suppression floor keys off severity, and this
+      // one is derived from the file's capabilities rather than fixed.
+      if (this.isSuppressed(lines[line - 1] || '', severity)) continue;
 
       const finding = createFinding({
         file,

--- a/cli/agents/gpt-red-agent.js
+++ b/cli/agents/gpt-red-agent.js
@@ -244,7 +244,10 @@ export class GPTRedAgent extends BaseAgent {
 
   async analyze(context) {
     const { rootPath, files, options = {}, sharedFindings = [] } = context;
-    const provider = options.ai === false ? null : resolveProvider(rootPath, options);
+    // Both flags mean "stay local": `--no-ai` sets `ai: false` via commander,
+    // while programmatic callers (webapp scan + cron) pass `noAi: true`.
+    const offlineOnly = options.ai === false || options.noAi === true;
+    const provider = offlineOnly ? null : resolveProvider(rootPath, options);
     const useK3LongContext = options.k3LongContext === true && isKimiK3Provider(provider);
     const candidates = files.filter(file => useK3LongContext ? isK3ContextFile(rootPath, file) : isCandidateFile(rootPath, file));
     const offlineFindings = this.runOfflineChecks(rootPath, candidates);

--- a/cli/agents/mcp-security-agent.js
+++ b/cli/agents/mcp-security-agent.js
@@ -331,7 +331,7 @@ export class MCPSecurityAgent extends BaseAgent {
     const secretPatterns = /(?:password|secret|token|apiKey|api_key)\s*[:=]\s*["'][^"']{8,}["']/gi;
     const lines = content.split('\n');
     for (let i = 0; i < lines.length; i++) {
-      if (this.isSuppressed(lines[i])) continue;
+      if (this.isSuppressed(lines[i], 'critical')) continue;
       secretPatterns.lastIndex = 0;
       if (secretPatterns.test(lines[i])) {
         findings.push({

--- a/cli/agents/memory-poisoning-agent.js
+++ b/cli/agents/memory-poisoning-agent.js
@@ -247,7 +247,7 @@ export class MemoryPoisoningAgent extends BaseAgent {
     for (const pattern of INJECTION_PATTERNS) {
       for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
-        if (this.isSuppressed(line)) continue;
+        if (this.isSuppressed(line, pattern.severity)) continue;
 
         pattern.regex.lastIndex = 0;
         const match = pattern.regex.exec(line);

--- a/cli/agents/orchestrator.js
+++ b/cli/agents/orchestrator.js
@@ -151,6 +151,10 @@ export class Orchestrator {
             agent: agent.name,
             category: agent.category,
             findingCount: findings.length,
+            // How much this agent was asked not to report. A scan that silenced
+            // findings must not read like a scan that had none.
+            suppressedCount: agent.suppressedCount || 0,
+            floorSuppressionAttempts: agent.floorSuppressionAttempts || 0,
             success: true,
           });
           allFindings = allFindings.concat(findings);
@@ -267,7 +271,14 @@ export class Orchestrator {
       (sevOrder[a.severity] ?? 4) - (sevOrder[b.severity] ?? 4)
     );
 
-    return { recon, findings: allFindings, agentResults };
+    // Roll the suppression tally up to the scan level so callers (CLI output,
+    // JSON, CI gates) can show it without walking agentResults.
+    const suppression = {
+      suppressed: agentResults.reduce((n, a) => n + (a.suppressedCount || 0), 0),
+      floorAttempts: agentResults.reduce((n, a) => n + (a.floorSuppressionAttempts || 0), 0),
+    };
+
+    return { recon, findings: allFindings, agentResults, suppression };
   }
 
   /**

--- a/cli/agents/roblox-security-agent.js
+++ b/cli/agents/roblox-security-agent.js
@@ -175,9 +175,10 @@ export class RobloxSecurityAgent extends BaseAgent {
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
-      if (this.isSuppressed(line)) continue;
 
       for (const p of LUAU_PATTERNS) {
+        // Per pattern, so the suppression floor sees the real severity.
+        if (this.isSuppressed(line, p.severity)) continue;
         p.regex.lastIndex = 0;
         let match;
         while ((match = p.regex.exec(line)) !== null) {

--- a/cli/commands/audit.js
+++ b/cli/commands/audit.js
@@ -20,6 +20,7 @@ import fg from 'fast-glob';
 import { buildOrchestrator, buildOrchestratorAsync } from '../agents/index.js';
 import { LegalRiskAgent } from '../agents/legal-risk-agent.js';
 import { ScoringEngine } from '../agents/scoring-engine.js';
+import { isSuppressible } from '../agents/base-agent.js';
 import { PolicyEngine } from '../agents/policy-engine.js';
 import { HTMLReporter } from '../agents/html-reporter.js';
 import { SBOMGenerator } from '../agents/sbom-generator.js';
@@ -977,8 +978,12 @@ function scanFileForSecrets(filePath) {
     const lines = content.split('\n');
     for (let lineNum = 0; lineNum < lines.length; lineNum++) {
       const line = lines[lineNum];
-      if (/ship-safe-ignore/i.test(line)) continue;
+      // Suppression is decided per pattern so the floor can key off severity:
+      // a critical secret is reported even on a suppressed line, because the
+      // comment is writable by the same agent that wrote the leak.
+      const lineMarked = /ship-safe-ignore/i.test(line);
       for (const pattern of SECRET_PATTERNS) {
+        if (lineMarked && isSuppressible(pattern.severity)) continue;
         pattern.pattern.lastIndex = 0;
         let match;
         while ((match = pattern.pattern.exec(line)) !== null) {

--- a/cli/utils/hermes-tool-registry.js
+++ b/cli/utils/hermes-tool-registry.js
@@ -119,36 +119,19 @@ export const HERMES_TOOLS = [
     },
   },
 
-  {
-    name: 'ship_safe_suppress_finding',
-    description:
-      'Suppress a known-safe finding by inserting an inline ship-safe-ignore comment ' +
-      'in the source file before the flagged line. Use only when the finding is a ' +
-      'confirmed false positive and you can document why it is safe.',
-    parameters: {
-      type: 'object',
-      properties: {
-        file: {
-          type: 'string',
-          description: 'Absolute path to the source file containing the finding.',
-        },
-        line: {
-          type: 'number',
-          description: 'Line number of the finding (1-based).',
-        },
-        reason: {
-          type: 'string',
-          description: 'Human-readable explanation of why this finding is safe to suppress.',
-        },
-      },
-      required: ['file', 'line', 'reason'],
-      additionalProperties: false,
-    },
-    handler: async ({ file, line, reason }) => {
-      const { mcpSuppressFinding } = await import('../commands/mcp.js');
-      return mcpSuppressFinding({ file, line, reason });
-    },
-  },
+  // NOTE: `ship_safe_suppress_finding` was removed.
+  //
+  // Its handler called `mcpSuppressFinding`, which mcp.js never exported, so
+  // every invocation threw — the tool was advertised to agents but had never
+  // worked. Rather than implement it, it is gone: suppression is written into
+  // the scanned source as an inline comment, which means an agent holding this
+  // tool can silence the findings covering its own output. That is the exact
+  // path the suppression floor in base-agent.js exists to constrain (critical
+  // findings are reported regardless, and suppressions are counted).
+  //
+  // If agent-driven suppression is wanted later, build it deliberately: scoped
+  // to non-critical findings, recorded in security memory rather than source,
+  // and attributable to the run that requested it.
 
   {
     name: 'ship_safe_memory_list',
@@ -187,7 +170,6 @@ const KNOWN_HASHES = {
   ship_safe_audit:             '4d282d29e44fcc01',
   ship_safe_scan_mcp:          'f967aea9626ca840',
   ship_safe_get_findings:      'c09c9447efd574b3',
-  ship_safe_suppress_finding:  '3b7339419fe52ac7',
   ship_safe_memory_list:       'c71c996716d1805b',
 };
 


### PR DESCRIPTION
`ship-safe-ignore` was designed for a human deciding a finding is a false positive. That assumption no longer holds on its own: the code we scan is increasingly written by an AI agent, and an agent that can emit a line of source can emit the suppression comment on the line that matters.

## The problem, demonstrated

Three lines, each with the comment appended, which is exactly what an agent would produce:

```js
const key = "AKIAIOSFODNN7EXAMPLE"; // ship-safe-ignore
const pw  = "hunter2hunter2";       // ship-safe-ignore
eval(req.body.x);                   // ship-safe-ignore
```

| | Score | Findings | Secrets | Injection |
|---|---|---|---|---|
| before | **96.4 / A** | 2 | 0 | 0 |
| after | **66.4 / C** | 5 | 1 critical | 2 critical |

A live AWS key and an `eval()` on request body earned a clean bill of health.

## What changed

**Critical severity can no longer be silenced by an inline comment.** Everything below critical behaves exactly as before, so existing suppressions keep working. The floor is deliberately narrow — I didn't want to invalidate legitimate suppressions on medium findings.

**Suppressions are counted.** Agents track `suppressedCount`, the orchestrator rolls it up into a scan-level `suppression: { suppressed, floorAttempts }`. A run that silenced 40 findings can no longer read like one that had none. An *attempt* to suppress a critical is counted separately, because that is a signal rather than a no-op.

**Suppression is decided per matched rule instead of per line.** The floor keys off severity, which isn't known until a pattern actually fires. Agents that derive severity dynamically (`gpt-red-agent`, `agent-config-scanner`) check after computing it.

**The secrets scanner in `audit.js` is covered too.** It had its own inline check that never went through `BaseAgent` — my first pass still reported `secrets: 0` because the highest-value case was on a path I hadn't touched.

## Removes `ship_safe_suppress_finding`

Its handler called `mcpSuppressFinding`, which `mcp.js` has never exported, so every invocation threw:

```
HANDLER THROWS: mcpSuppressFinding is not a function
```

The tool was advertised to agents but had never worked. Rather than implement it, it's gone — a tool that writes suppression comments into scanned source hands an agent the means to silence findings about its own output, which is the thing this floor exists to constrain. Registry integrity hashes updated and verifying clean.

If agent-driven suppression is wanted later it should be built deliberately: scoped to non-critical findings, recorded in security memory rather than in source, and attributable to the run that asked for it.

## Also included

A separate commit fixes `GPTRedAgent` ignoring `noAi`. It gated its provider on `options.ai === false` only — commander sets that from `--no-ai`, but the webapp scan route and the cron both pass `noAi: true`, so a scan requested as fully local could still send context to a provider.

## Verification

- 275 tests pass (was 265), 10 new in `cli/__tests__/suppression-floor.test.js`
- `npm audit` clean, `eslint cli/` 0 errors
- Before/after measured on a real `audit` run with the cache cleared between

## Worth knowing before merging

This is a **visible behaviour change**. Anyone relying on `ship-safe-ignore` for a critical-severity false positive will see that finding come back and their score drop. That is the intent, but it belongs in the changelog and argues for a minor version bump rather than a patch.
