### PR TITLE
Restore the re-engagement send as an admin action

### DIFF
--- a/webapp/app/api/admin/reengage/route.ts
+++ b/webapp/app/api/admin/reengage/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { isAdmin } from '@/lib/is-admin';
+import { reengageEligibleCount, sendReengagementBatch } from '@/lib/lifecycle-emails';
+
+// This route is not under a middleware-protected prefix, so it enforces
+// auth + admin itself. It sends real marketing email — admin only, batched.
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const MAX_BATCH = 50;
+
+async function requireAdmin() {
+  const session = await auth();
+  if (!session?.user?.id) return { error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
+  if (!isAdmin(session.user.email)) return { error: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) };
+  return { error: null };
+}
+
+export async function GET() {
+  const { error } = await requireAdmin();
+  if (error) return error;
+  return NextResponse.json({ eligible: await reengageEligibleCount() });
+}
+
+export async function POST(req: Request) {
+  const { error } = await requireAdmin();
+  if (error) return error;
+
+  let limit = 20;
+  try {
+    const body = await req.json();
+    if (typeof body?.limit === 'number' && Number.isFinite(body.limit)) {
+      limit = Math.min(Math.max(Math.trunc(body.limit), 1), MAX_BATCH);
+    }
+  } catch {
+    // no body → default limit
+  }
+
+  const result = await sendReengagementBatch(limit);
+  const eligible = await reengageEligibleCount();
+  return NextResponse.json({ ...result, eligible });
+}

--- a/webapp/app/app/admin/ReengageBatch.module.css
+++ b/webapp/app/app/admin/ReengageBatch.module.css
@@ -1,0 +1,92 @@
+.panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1.1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  margin-bottom: 1.5rem;
+}
+
+.head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.head h2 {
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+.sub {
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  margin: 0.2rem 0 0;
+}
+
+.badge {
+  flex-shrink: 0;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--cyan);
+  border: 1px solid color-mix(in srgb, var(--cyan) 35%, transparent);
+  border-radius: 999px;
+  padding: 0.25rem 0.7rem;
+  white-space: nowrap;
+}
+
+.controls {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.limit {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.78rem;
+  color: var(--text-dim);
+}
+
+.limit input {
+  width: 5.5rem;
+  padding: 0.5rem 0.6rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md, 8px);
+  color: var(--text);
+  font-size: 0.9rem;
+}
+
+.button {
+  padding: 0.55rem 1.1rem;
+  background: var(--cyan);
+  color: #04141a;
+  border: none;
+  border-radius: var(--radius-md, 8px);
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ok {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--green);
+}
+
+.error {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--red, #f87171);
+}

--- a/webapp/app/app/admin/ReengageBatch.tsx
+++ b/webapp/app/app/admin/ReengageBatch.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState } from 'react';
+import styles from './ReengageBatch.module.css';
+
+/**
+ * One-time re-engagement send to the signup backlog. Idempotent server-side
+ * (EmailEvent guards against re-sends), so re-running only reaches users who
+ * haven't been re-engaged yet. Batched for deliverability on a fresh domain.
+ */
+export default function ReengageBatch({ eligible: initialEligible }: { eligible: number }) {
+  const [eligible, setEligible] = useState(initialEligible);
+  const [limit, setLimit] = useState(20);
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [err, setErr] = useState(false);
+
+  async function send() {
+    if (busy) return;
+    if (!confirm(`Send the re-engagement email to up to ${limit} backlog user(s)? This sends real email.`)) return;
+    setBusy(true);
+    setMsg(null);
+    setErr(false);
+    try {
+      const res = await fetch('/api/admin/reengage', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ limit }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || `Request failed (${res.status})`);
+      setEligible(data.eligible ?? eligible);
+      setMsg(`Sent ${data.sent} of ${data.scanned} scanned. ${data.eligible} still eligible.`);
+    } catch (e) {
+      setErr(true);
+      setMsg(e instanceof Error ? e.message : 'Send failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className={styles.panel}>
+      <div className={styles.head}>
+        <div>
+          <h2>Re-engagement send</h2>
+          <p className={styles.sub}>One-time email to the pre-lifecycle signup backlog.</p>
+        </div>
+        <span className={styles.badge}>{eligible} eligible</span>
+      </div>
+
+      <div className={styles.controls}>
+        <label className={styles.limit}>
+          Batch size
+          <input
+            type="number"
+            min={1}
+            max={50}
+            value={limit}
+            onChange={(e) => setLimit(Math.min(Math.max(Number(e.target.value) || 1, 1), 50))}
+            disabled={busy}
+          />
+        </label>
+        <button onClick={send} disabled={busy || eligible === 0} className={styles.button}>
+          {busy ? 'Sending…' : eligible === 0 ? 'No one eligible' : `Send batch of ${Math.min(limit, eligible)}`}
+        </button>
+      </div>
+
+      {msg && <p className={err ? styles.error : styles.ok}>{msg}</p>}
+    </div>
+  );
+}

--- a/webapp/app/app/admin/page.tsx
+++ b/webapp/app/app/admin/page.tsx
@@ -3,16 +3,13 @@ import { prisma } from '@/lib/prisma';
 import { redirect } from 'next/navigation';
 import styles from './admin.module.css';
 import type { Metadata } from 'next';
+import { isAdmin } from '@/lib/is-admin';
+import { reengageEligibleCount } from '@/lib/lifecycle-emails';
+import ReengageBatch from './ReengageBatch';
 
 export const metadata: Metadata = {
   title: 'Admin — Ship Safe',
 };
-
-function isAdmin(email: string | null | undefined): boolean {
-  if (!email) return false;
-  const admins = (process.env.ADMIN_EMAILS ?? '').split(',').map(e => e.trim().toLowerCase()).filter(Boolean);
-  return admins.includes(email.toLowerCase());
-}
 
 function timeAgo(date: Date) {
   const diff = Date.now() - new Date(date).getTime();
@@ -57,6 +54,7 @@ export default async function AdminPage() {
     signins7d,
     signins30d,
     recentSignins,
+    reengageEligible,
   ] = await Promise.all([
     prisma.user.count(),
     prisma.user.count({ where: { createdAt: { gte: days7ago } } }),
@@ -116,6 +114,7 @@ export default async function AdminPage() {
         user: { select: { name: true, email: true, image: true, plan: true } },
       },
     }),
+    reengageEligibleCount(),
   ]);
 
   const paidRevenue = totalRevenue._sum.amount ?? 0;
@@ -187,6 +186,9 @@ export default async function AdminPage() {
           </div>
         ))}
       </div>
+
+      {/* Lifecycle: one-time re-engagement to the signup backlog */}
+      <ReengageBatch eligible={reengageEligible} />
 
       {/* Charts row */}
       <div className={styles.threeCol}>

--- a/webapp/app/app/layout.tsx
+++ b/webapp/app/app/layout.tsx
@@ -10,6 +10,7 @@ import MobileNav from './MobileNav';
 import NavLinks from './NavLinks';
 import { ToastProvider } from './Toast';
 import KeyboardShortcuts from './KeyboardShortcuts';
+import { isAdmin as checkIsAdmin } from '@/lib/is-admin';
 import ActivityInbox from './ActivityInbox';
 
 export const metadata: Metadata = {
@@ -36,8 +37,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   });
 
   const plan = user?.plan ?? 'free';
-  const adminEmails = (process.env.ADMIN_EMAILS ?? '').split(',').map(e => e.trim().toLowerCase()).filter(Boolean);
-  const isAdmin = adminEmails.includes((session.user.email ?? '').toLowerCase());
+  const isAdmin = checkIsAdmin(session.user.email);
 
   return (
     <div className={styles.shell}>

--- a/webapp/lib/is-admin.ts
+++ b/webapp/lib/is-admin.ts
@@ -1,0 +1,13 @@
+/**
+ * Admin gate — an email is an admin iff it appears in the comma-separated
+ * ADMIN_EMAILS env var. Centralized so the dashboard, layout nav, and admin
+ * API routes can't drift apart.
+ */
+export function isAdmin(email: string | null | undefined): boolean {
+  if (!email) return false;
+  const admins = (process.env.ADMIN_EMAILS ?? '')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+  return admins.includes(email.toLowerCase());
+}

--- a/webapp/lib/lifecycle-emails.ts
+++ b/webapp/lib/lifecycle-emails.ts
@@ -177,11 +177,11 @@ ${button(dashboard, 'Open the dashboard →')}
 
     case 'reengage':
       return {
-        subject: 'Ship Safe is active again — v9.4.0',
+        subject: 'Ship Safe is active again — v9.5',
         html: shell(
           `<p style="${P}">Hi ${name},</p>
 <p style="${P}">You signed up for Ship Safe a little while back, and it went quiet for a bit. That's on me — and it's changed: we're shipping again.</p>
-<p style="${P}">The latest release (v9.4.0) adds a 24th agent that catches malicious game-engine supply-chain assets and cross-platform "ClickFix" paste-and-run lures, on top of the existing secrets, injection, and AI/LLM coverage.</p>
+<p style="${P}">The latest releases push into AI-toolchain security: <strong>29 agents</strong> now, including GPT-Red (an AI attacker/defender/judge red-team loop), hallucinated-package detection, ML model supply-chain scanning, and npm install-time worm hardening — on top of the existing secrets, injection, and AI/LLM coverage.</p>
 <p style="margin:0 0 12px;">If you've got a minute, a fresh scan takes one command:</p>
 ${terminal('npx ship-safe audit .')}
 ${button(dashboard, 'Open the dashboard →')}


### PR DESCRIPTION
`sendReengagementBatch()` and `reengageEligibleCount()` lost their only caller when the one-time `/api/dev/reengage` route was removed before launch (5f258b9). Both have been dead code since.

## What this adds

- `GET`/`POST /api/admin/reengage`. Session and admin are checked in the route itself, because `/api/admin/*` is not behind the middleware matcher, and the batch size is capped.
- A `ReengageBatch` panel on `/app/admin` showing the live eligible count and a confirm-gated send.

`EmailEvent` idempotency still guarantees at-most-once per user, so the backlog that already received this send is not re-mailed. Only users who were never reached come back as eligible.

## Also

- Refreshes the re-engagement copy, which still advertised v9.4.0 and 24 agents while we ship 9.5.2 with 29.
- Moves the duplicated `ADMIN_EMAILS` check into `lib/is-admin.ts`. It was inlined in three places.

## Verification

`npx tsc --noEmit` clean in `webapp`.

Note the send itself is unverified end to end — the route and panel are wired and typecheck, but no batch has actually been dispatched. Worth doing a size-1 send to yourself before running a real batch.