### PR TITLE
Detect ungoverned continuous ingestion in CI pipelines

### DIFF
--- a/cli/__tests__/fixtures/hermes-workflow-after.yml
+++ b/cli/__tests__/fixtures/hermes-workflow-after.yml
@@ -1,0 +1,126 @@
+name: Update Hermes Agent Image
+
+on:
+  schedule:
+    - cron: '0 3 * * *'   # 03:00 UTC daily
+  workflow_dispatch:       # allow manual trigger
+    inputs:
+      dry_run:
+        description: 'Build only — do not push the image or roll out to the VPS'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  check-and-build:
+    runs-on: ubuntu-latest
+
+    outputs:
+      rebuilt: ${{ steps.build.outputs.rebuilt }}
+      sha: ${{ steps.upstream.outputs.sha }}
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      # ── 1. Resolve the latest tagged Hermes release ──────────────────────────
+      # Deliberately a release, not `main`. This job builds an image that is
+      # rolled straight onto the production VPS, so tracking a moving branch
+      # meant any upstream commit — including a compromised one — reached prod
+      # within 24h with nobody in the loop. A tag is a point upstream chose to
+      # publish, and it gives us something reviewable to pin to.
+      - name: Get upstream Hermes release
+        id: upstream
+        run: |
+          set -euo pipefail
+          API="https://api.github.com/repos/NousResearch/hermes-agent"
+          H=(-H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28")
+
+          TAG=$(curl -sf "${H[@]}" "$API/releases/latest" | jq -r '.tag_name')
+          if [[ -z "$TAG" || "$TAG" == "null" ]]; then
+            echo "::error::could not resolve latest hermes-agent release"; exit 1
+          fi
+
+          REF=$(curl -sf "${H[@]}" "$API/git/ref/tags/$TAG")
+          SHA=$(jq -r '.object.sha' <<<"$REF")
+          # Annotated tags point at a tag object; dereference to the commit.
+          if [[ "$(jq -r '.object.type' <<<"$REF")" == "tag" ]]; then
+            SHA=$(curl -sf "${H[@]}" "$API/git/tags/$SHA" | jq -r '.object.sha')
+          fi
+
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "Upstream release: ${TAG} (${SHA})"
+
+      # ── 2. Get SHA baked into the current latest image ────────────────────────
+      - name: Get current image SHA
+        id: current
+        run: |
+          CURRENT=$(docker run --rm --entrypoint="" \
+            ${{ secrets.DOCKERHUB_USERNAME }}/hermes-agent:latest \
+            sh -c 'echo $HERMES_UPSTREAM_SHA' 2>/dev/null || echo "none")
+          echo "sha=${CURRENT}" >> "$GITHUB_OUTPUT"
+          echo "Current image SHA: ${CURRENT}"
+        continue-on-error: true   # first build — image may not exist yet
+
+      # ── 3. Build + push only if SHA changed ──────────────────────────────────
+      - name: Log in to Docker Hub
+        if: steps.upstream.outputs.sha != steps.current.outputs.sha
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.upstream.outputs.sha != steps.current.outputs.sha
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Build and push
+        id: build
+        if: steps.upstream.outputs.sha != steps.current.outputs.sha
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: ./vps
+          file: ./vps/agent.Dockerfile
+          # Dry run builds the image and throws it away: proves the Dockerfile
+          # on a real runner without publishing or touching production.
+          push: ${{ inputs.dry_run != true }}
+          build-args: |
+            HERMES_SHA=${{ steps.upstream.outputs.sha }}
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/hermes-agent:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/hermes-agent:${{ steps.upstream.outputs.sha }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/hermes-agent:${{ steps.upstream.outputs.tag }}
+          labels: |
+            org.opencontainers.image.revision=${{ steps.upstream.outputs.sha }}
+            org.opencontainers.image.version=${{ steps.upstream.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Set rebuilt output
+        id: set-rebuilt
+        run: |
+          if [[ "${{ steps.upstream.outputs.sha }}" != "${{ steps.current.outputs.sha }}" ]]; then
+            echo "rebuilt=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "rebuilt=false" >> "$GITHUB_OUTPUT"
+            echo "Image is already up to date — skipping rollout."
+          fi
+
+  # ── 4. Rolling restart on the VPS ──────────────────────────────────────────
+  rollout:
+    needs: check-and-build
+    runs-on: ubuntu-latest
+    if: needs.check-and-build.outputs.rebuilt == 'true' && inputs.dry_run != true
+
+    steps:
+      - name: Trigger rolling restart
+        run: |
+          curl -sf -X POST \
+            -H "Authorization: Bearer ${{ secrets.ORCHESTRATOR_SECRET }}" \
+            -H "Content-Type: application/json" \
+            "${{ secrets.ORCHESTRATOR_URL }}/update-image" \
+            -d '{"image": "${{ secrets.DOCKERHUB_USERNAME }}/hermes-agent:latest"}' \
+          && echo "Rolling restart triggered." \
+          || echo "WARNING: orchestrator unreachable — containers will update on next redeploy."

--- a/cli/__tests__/fixtures/hermes-workflow-before.yml
+++ b/cli/__tests__/fixtures/hermes-workflow-before.yml
@@ -1,0 +1,100 @@
+name: Update Hermes Agent Image
+
+on:
+  schedule:
+    - cron: '0 3 * * *'   # 03:00 UTC daily
+  workflow_dispatch:       # allow manual trigger
+
+permissions:
+  contents: read
+
+jobs:
+  check-and-build:
+    runs-on: ubuntu-latest
+
+    outputs:
+      rebuilt: ${{ steps.build.outputs.rebuilt }}
+      sha: ${{ steps.upstream.outputs.sha }}
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      # ── 1. Get latest commit SHA from NousResearch/hermes-agent ──────────────
+      - name: Get upstream Hermes SHA
+        id: upstream
+        run: |
+          SHA=$(curl -sf \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/NousResearch/hermes-agent/commits/main \
+            | jq -r '.sha')
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "Upstream SHA: ${SHA}"
+
+      # ── 2. Get SHA baked into the current latest image ────────────────────────
+      - name: Get current image SHA
+        id: current
+        run: |
+          CURRENT=$(docker run --rm --entrypoint="" \
+            ${{ secrets.DOCKERHUB_USERNAME }}/hermes-agent:latest \
+            sh -c 'echo $HERMES_UPSTREAM_SHA' 2>/dev/null || echo "none")
+          echo "sha=${CURRENT}" >> "$GITHUB_OUTPUT"
+          echo "Current image SHA: ${CURRENT}"
+        continue-on-error: true   # first build — image may not exist yet
+
+      # ── 3. Build + push only if SHA changed ──────────────────────────────────
+      - name: Log in to Docker Hub
+        if: steps.upstream.outputs.sha != steps.current.outputs.sha
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.upstream.outputs.sha != steps.current.outputs.sha
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        id: build
+        if: steps.upstream.outputs.sha != steps.current.outputs.sha
+        uses: docker/build-push-action@v6
+        with:
+          context: ./vps
+          file: ./vps/agent.Dockerfile
+          push: true
+          build-args: |
+            HERMES_SHA=${{ steps.upstream.outputs.sha }}
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/hermes-agent:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/hermes-agent:${{ steps.upstream.outputs.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ steps.upstream.outputs.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Set rebuilt output
+        id: set-rebuilt
+        run: |
+          if [[ "${{ steps.upstream.outputs.sha }}" != "${{ steps.current.outputs.sha }}" ]]; then
+            echo "rebuilt=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "rebuilt=false" >> "$GITHUB_OUTPUT"
+            echo "Image is already up to date — skipping rollout."
+          fi
+
+  # ── 4. Rolling restart on the VPS ──────────────────────────────────────────
+  rollout:
+    needs: check-and-build
+    runs-on: ubuntu-latest
+    if: needs.check-and-build.outputs.rebuilt == 'true'
+
+    steps:
+      - name: Trigger rolling restart
+        run: |
+          curl -sf -X POST \
+            -H "Authorization: Bearer ${{ secrets.ORCHESTRATOR_SECRET }}" \
+            -H "Content-Type: application/json" \
+            "${{ secrets.ORCHESTRATOR_URL }}/update-image" \
+            -d '{"image": "${{ secrets.DOCKERHUB_USERNAME }}/hermes-agent:latest"}' \
+          && echo "Rolling restart triggered." \
+          || echo "WARNING: orchestrator unreachable — containers will update on next redeploy."

--- a/cli/__tests__/upstream-ingestion.test.js
+++ b/cli/__tests__/upstream-ingestion.test.js
@@ -21,8 +21,13 @@ import assert from 'node:assert/strict';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { fileURLToPath } from 'url';
 
 import { CICDScanner } from '../agents/cicd-scanner.js';
+
+// Not `import.meta.dirname` — that landed in Node 20.11 and this package
+// supports >=18, so it is undefined on the oldest version CI runs.
+const HERE = path.dirname(fileURLToPath(import.meta.url));
 
 const CHAIN_RULES = /^(CICD_UNATTENDED_UPSTREAM_DEPLOY|CICD_UNPINNED_UPSTREAM_BUILD|CICD_NO_DEPLOY_APPROVAL)$/;
 
@@ -51,7 +56,7 @@ async function chainFindings(yaml, owner) {
 }
 
 function readFixture(name) {
-  return fs.readFileSync(path.join(import.meta.dirname, 'fixtures', name), 'utf-8');
+  return fs.readFileSync(path.join(HERE, 'fixtures', name), 'utf-8');
 }
 
 describe('ungoverned continuous ingestion — real workflows', () => {

--- a/cli/__tests__/upstream-ingestion.test.js
+++ b/cli/__tests__/upstream-ingestion.test.js
@@ -1,0 +1,181 @@
+/**
+ * Ungoverned continuous ingestion tests
+ * =====================================
+ *
+ * A pipeline that resolves a mutable third-party reference, builds it, and
+ * deploys it with no human gate hands upstream control of production. No line
+ * of such a workflow is dangerous alone, so the line-by-line CI rules cannot
+ * see it — these cover the whole-file chain analysis that can.
+ *
+ * The positive fixtures are this repository's own `update-hermes-image.yml`,
+ * before and after it was fixed. Real files rather than invented ones: the
+ * first draft of these rules passed on synthetic YAML and missed both real
+ * cases, because the actual workflow builds its API URL from a shell variable
+ * and wraps its deploy command across lines.
+ *
+ * Run: npm test
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import { CICDScanner } from '../agents/cicd-scanner.js';
+
+const CHAIN_RULES = /^(CICD_UNATTENDED_UPSTREAM_DEPLOY|CICD_UNPINNED_UPSTREAM_BUILD|CICD_NO_DEPLOY_APPROVAL)$/;
+
+/** Build a throwaway repo containing one workflow, owned by `owner`. */
+function workspace(yaml, owner = 'someone-else') {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-ingest-'));
+  fs.mkdirSync(path.join(dir, '.github', 'workflows'), { recursive: true });
+  fs.mkdirSync(path.join(dir, '.git'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, '.git', 'config'),
+    `[remote "origin"]\n\turl = https://github.com/${owner}/its-repo.git\n`,
+  );
+  const file = path.join(dir, '.github', 'workflows', 'w.yml');
+  fs.writeFileSync(file, yaml);
+  return { dir, file, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
+}
+
+async function chainFindings(yaml, owner) {
+  const ws = workspace(yaml, owner);
+  try {
+    const findings = await new CICDScanner().analyze({ rootPath: ws.dir, files: [ws.file] });
+    return findings.filter(f => CHAIN_RULES.test(f.rule));
+  } finally {
+    ws.cleanup();
+  }
+}
+
+function readFixture(name) {
+  return fs.readFileSync(path.join(import.meta.dirname, 'fixtures', name), 'utf-8');
+}
+
+describe('ungoverned continuous ingestion — real workflows', () => {
+  it('flags tracking an upstream branch straight to production as critical', async () => {
+    const found = await chainFindings(readFixture('hermes-workflow-before.yml'));
+    const deploy = found.find(f => f.rule === 'CICD_UNATTENDED_UPSTREAM_DEPLOY');
+    assert.ok(deploy, 'the full chain should be reported');
+    assert.equal(deploy.severity, 'critical');
+    assert.match(deploy.matched, /commits\/main/);
+  });
+
+  it('still flags tracking an upstream release, one band lower', async () => {
+    // The remediated workflow tracks a published release instead of a branch.
+    // That is better, not safe: it still deploys unattended with no approval,
+    // so it must not come back clean.
+    const found = await chainFindings(readFixture('hermes-workflow-after.yml'));
+    const deploy = found.find(f => f.rule === 'CICD_UNATTENDED_UPSTREAM_DEPLOY');
+    assert.ok(deploy, 'release tracking is still ungoverned ingestion');
+    assert.equal(deploy.severity, 'high');
+    assert.match(deploy.matched, /releases\/latest/);
+  });
+
+  it('reports the missing approval gate independently', async () => {
+    const found = await chainFindings(readFixture('hermes-workflow-before.yml'));
+    assert.ok(found.some(f => f.rule === 'CICD_NO_DEPLOY_APPROVAL'));
+  });
+});
+
+describe('ungoverned continuous ingestion — must not fire', () => {
+  it('ignores a workflow building its own repository', async () => {
+    const yaml = `
+on:
+  schedule:
+    - cron: '0 3 * * *'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          SHA=$(curl -s https://api.github.com/repos/acme/its-repo/commits/main | jq -r .sha)
+          docker build --build-arg SHA=$SHA .
+      - uses: docker/build-push-action@v6
+        with:
+          push: true
+`;
+    assert.deepEqual(await chainFindings(yaml, 'acme'), []);
+  });
+
+  it('ignores an auto-update job that opens a pull request', async () => {
+    // Opening a PR *is* the human gate.
+    const yaml = `
+on:
+  schedule:
+    - cron: '0 3 * * *'
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl -s https://api.github.com/repos/upstream/dep/releases/latest
+      - uses: peter-evans/create-pull-request@v6
+`;
+    assert.deepEqual(await chainFindings(yaml), []);
+  });
+
+  it('downgrades a deploy to a non-production environment', async () => {
+    const yaml = `
+on:
+  schedule:
+    - cron: '0 3 * * *'
+jobs:
+  ship:
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - run: curl -s https://api.github.com/repos/upstream/dep/commits/main
+      - run: kubectl rollout restart deploy/api
+`;
+    const found = await chainFindings(yaml);
+    assert.ok(!found.some(f => f.severity === 'critical'), 'staging must not be critical');
+  });
+
+  it('ignores a pinned upstream reference', async () => {
+    const yaml = `
+on:
+  schedule:
+    - cron: '0 3 * * *'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: git clone --branch v1.4.2 https://github.com/upstream/dep
+      - uses: docker/build-push-action@v6
+        with:
+          push: true
+`;
+    assert.deepEqual(await chainFindings(yaml), []);
+  });
+
+  it('ignores an ordinary test workflow', async () => {
+    const yaml = `
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci && npm test
+`;
+    assert.deepEqual(await chainFindings(yaml), []);
+  });
+
+  it('ignores a manually triggered deploy', async () => {
+    // No schedule means a human started it.
+    const yaml = `
+on:
+  workflow_dispatch:
+jobs:
+  ship:
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl -s https://api.github.com/repos/upstream/dep/commits/main
+      - run: kubectl rollout restart deploy/api
+`;
+    const found = await chainFindings(yaml);
+    assert.ok(!found.some(f => f.rule === 'CICD_UNATTENDED_UPSTREAM_DEPLOY'));
+  });
+});

--- a/cli/agents/cicd-scanner.js
+++ b/cli/agents/cicd-scanner.js
@@ -9,8 +9,9 @@
  *        Bitbucket Pipelines, Azure DevOps.
  */
 
+import fs from 'fs';
 import path from 'path';
-import { BaseAgent } from './base-agent.js';
+import { BaseAgent, createFinding } from './base-agent.js';
 
 const PATTERNS = [
   // ── CICD-SEC-4: Poisoned Pipeline Execution ────────────────────────────────
@@ -265,9 +266,255 @@ const PATTERNS = [
   },
 ];
 
+// =============================================================================
+// UNGOVERNED CONTINUOUS INGESTION
+//
+// A pipeline that resolves a mutable third-party reference, builds it, and
+// deploys the result to running infrastructure with no human gate hands
+// upstream control of your production with under a day of latency.
+//
+// None of those steps is dangerous alone, which is why the line-by-line rules
+// above cannot see it: the finding is the *combination*, spread across a file.
+// This section extracts signals per workflow and scores the chain.
+// =============================================================================
+
+// (A) Mutable references. `branch` tracks a moving branch — anything upstream
+// merges ships. `release` tracks the newest published release, which still
+// auto-ingests but has a human publish step upstream, so it scores lower.
+// GitHub repo references, from either the API host or the web host, so the
+// owner can be identified wherever the URL is assembled.
+const GH_REPO_RE = /github\.com[/:](?:repos\/)?([\w.-]+)\/([\w.-]+)/gi;
+
+// Endpoints that name a moving target. Matched independently of the repo URL
+// because pipelines routinely build the URL from a variable
+// (`API="https://api.github.com/repos/o/r"` … `"$API/releases/latest"`), and a
+// regex expecting one contiguous string silently misses every such workflow.
+const MUTABLE_ENDPOINT_SIGNALS = [
+  { kind: 'branch',  re: /\/commits\/(?:main|master|HEAD)\b/gi },
+  { kind: 'release', re: /\/releases\/latest\b/gi },
+];
+
+// Mutable references that stand alone, with no GitHub repo URL involved.
+const MUTABLE_REF_SIGNALS = [
+  { kind: 'branch',  re: /\bgit\s+clone\b(?![^\n]*--branch\s+v?\d)[^\n]*github\.com\/([\w.-]+)\/([\w.-]+)/gi, owner: 1 },
+  { kind: 'branch',  re: /\bpip\s+install\b[^\n]*git\+https?:\/\/github\.com\/([\w.-]+)\/([\w.-]+?)(?:\.git)?(?:@(?:HEAD|main|master))?["'\s]/gi, owner: 1 },
+  { kind: 'branch',  re: /^\s*FROM\s+(?!scratch)([\w./-]+):latest\b/gim, owner: null },
+  { kind: 'branch',  re: /\bdocker\s+pull\b[^\n]*:latest\b/gi, owner: null },
+  { kind: 'branch',  re: /\bnpm\s+(?:i|install)\b[^\n]*@latest\b/gi, owner: null },
+];
+
+// (C) The artifact leaves CI and reaches something that serves traffic.
+const DEPLOY_SIGNALS = [
+  // `push: true`, and also `push: ${{ ... }}` — a push guarded by an
+  // expression still pushes on the default path. Only a literal `false` is
+  // conclusively not a publish.
+  /\bpush:\s*(?!false\b)(?:true\b|\$\{\{)/i,
+  /\bdocker\s+push\b/i,
+  /\bnpm\s+publish\b/i,
+  /\bkubectl\s+(?:apply|rollout|set\s+image)\b/i,
+  /\baws\s+ecs\s+update-service\b/i,
+  /\b(?:flyctl|fly)\s+deploy\b/i,
+  /\bvercel\b[^\n]*--prod\b/i,
+  /\b(?:ssh|scp)\s+[^\n]*@/i,
+  // A POST to something named like a deploy hook. Deliberately narrow: an
+  // arbitrary curl to an arbitrary host is not evidence of a deploy, and
+  // guessing costs more in false positives than it buys in coverage.
+  /\bcurl\b[^\n]*-X\s*POST[^\n]*(?:deploy|rollout|update-image|restart|release)\b/i,
+];
+
+// (D) Signals that a human stands between the build and production.
+const GATE_SIGNALS = [
+  /^\s*environment:\s*\S/im,          // GitHub environment — where approval rules live
+  /\bpeter-evans\/create-pull-request\b/i,
+  /\bgh\s+pr\s+create\b/i,
+  /\bcreate-pull-request\b/i,
+];
+
+// Targets that are not production. Deliberately anchored to places a target is
+// actually named — an `environment:`, an image tag, a job id. Matching these
+// words anywhere in the file is useless: `2>/dev/null` alone would downgrade a
+// genuine production deploy.
+const NON_PROD_SIGNALS = [
+  /^\s*environment:\s*['"]?(?:staging|dev|development|preview|sandbox|qa)\b/im,
+  /:(?:staging|dev|development|preview|sandbox|qa)\b(?![\w/-])/i,
+  /^\s*(?:deploy[-_])?(?:staging|dev|preview)\s*:\s*$/im,
+];
+
+/** Owner of the repo being scanned, so a workflow tracking its *own* HEAD is
+ *  not mistaken for third-party ingestion. Best-effort: absent this we treat
+ *  refs as third-party, which is the safe direction for a security check. */
+function selfOwner(rootPath) {
+  try {
+    const cfg = fs.readFileSync(path.join(rootPath, '.git', 'config'), 'utf-8');
+    const m = cfg.match(/url\s*=\s*[^\n]*github\.com[/:]([\w.-]+)\//i);
+    return m ? m[1].toLowerCase() : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Extract the chain signals from one workflow file. */
+function extractChainSignals(rawContent, self) {
+  // Shell steps wrap long commands across lines with a trailing backslash, so
+  // a `curl ... \` and the URL it posts to land on different lines. Join those
+  // continuations first: without this, every multi-line deploy command is
+  // invisible to a single-line pattern. Line numbers are computed against the
+  // original text so findings still point at the real line.
+  const content = rawContent.replace(/\\\r?\n\s*/g, ' ');
+  const lineOf = (idx) => rawContent.slice(0, Math.min(idx, rawContent.length)).split('\n').length;
+  const refs = [];
+
+  // Which third-party repositories does this workflow talk to at all?
+  const thirdPartyRepos = [];
+  GH_REPO_RE.lastIndex = 0;
+  let r;
+  while ((r = GH_REPO_RE.exec(content)) !== null) {
+    const owner = (r[1] || '').toLowerCase();
+    // Tracking your own repository is ordinary; the risk is ingesting
+    // someone else's code. `actions/*` are handled by the pinning rules.
+    if (!owner || owner === self || owner === 'actions') continue;
+    thirdPartyRepos.push({ owner, repo: r[2], line: lineOf(r.index) });
+  }
+
+  // Pair a third-party repo with any moving-target endpoint in the same file.
+  // File-scoped rather than line-scoped so a URL split across a variable
+  // assignment and its use is still seen.
+  if (thirdPartyRepos.length > 0) {
+    for (const sig of MUTABLE_ENDPOINT_SIGNALS) {
+      sig.re.lastIndex = 0;
+      let m;
+      while ((m = sig.re.exec(content)) !== null) {
+        const repo = thirdPartyRepos[0];
+        refs.push({
+          kind: sig.kind,
+          owner: repo.owner,
+          line: lineOf(m.index),
+          matched: `${repo.owner}/${repo.repo}${m[0].trim()}`.slice(0, 160),
+        });
+      }
+    }
+  }
+
+  for (const sig of MUTABLE_REF_SIGNALS) {
+    sig.re.lastIndex = 0;
+    let m;
+    while ((m = sig.re.exec(content)) !== null) {
+      const owner = sig.owner ? (m[sig.owner] || '').toLowerCase() : null;
+      if (owner && self && owner === self) continue;
+      refs.push({ kind: sig.kind, owner, line: lineOf(m.index), matched: m[0].trim().slice(0, 160) });
+      if (!sig.re.global) break;
+    }
+  }
+
+  const deploys = [];
+  for (const re of DEPLOY_SIGNALS) {
+    const m = re.exec(content);
+    if (m) deploys.push({ line: content.slice(0, m.index).split('\n').length, matched: m[0].trim().slice(0, 160) });
+  }
+
+  return {
+    refs,
+    deploys,
+    scheduled: /^\s*schedule:/m.test(content) || /^\s*on:\s*\n(?:[^\n]*\n)*?\s*schedule:/m.test(content),
+    gated: GATE_SIGNALS.some(re => re.test(content)),
+    nonProd: NON_PROD_SIGNALS.some(re => re.test(content)),
+  };
+}
+
 export class CICDScanner extends BaseAgent {
   constructor() {
     super('CICDScanner', 'Detect CI/CD pipeline security issues (OWASP CI/CD Top 10)', 'cicd');
+  }
+
+  /**
+   * Score the ingestion chain for one workflow. Severity rises with how much
+   * of the chain is present, and drops when a human is in the loop or the
+   * target is not production.
+   */
+  scanIngestionChain(file, rootPath, self) {
+    const content = this.readFile(file);
+    if (!content) return [];
+
+    const s = extractChainSignals(content, self);
+    if (s.refs.length === 0) return [];
+
+    const findings = [];
+    const worst = s.refs.some(r => r.kind === 'branch') ? 'branch' : 'release';
+    const ref = s.refs.find(r => r.kind === worst);
+    const deploying = s.deploys.length > 0;
+    const unattended = s.scheduled && !s.gated;
+
+    if (deploying && unattended) {
+      // The full chain. A branch ref means any upstream merge reaches
+      // production; a release ref means any upstream publish does.
+      let severity = worst === 'branch' ? 'critical' : 'high';
+      if (s.nonProd) severity = severity === 'critical' ? 'high' : 'medium';
+
+      findings.push(createFinding({
+        file,
+        line: ref.line,
+        severity,
+        category: this.category,
+        rule: 'CICD_UNATTENDED_UPSTREAM_DEPLOY',
+        title: `Unattended deploy of a mutable ${worst === 'branch' ? 'upstream branch' : 'upstream release'}`,
+        description:
+          `This workflow resolves a mutable third-party reference (${ref.matched}), builds it, and ` +
+          `deploys the result on a schedule with no approval gate. Whatever upstream ${worst === 'branch' ? 'merges' : 'publishes'} ` +
+          `reaches production within one scheduled interval, with nobody reviewing it. A compromise of the ` +
+          `upstream repository is a compromise of your production.`,
+        matched: ref.matched,
+        confidence: 'medium',
+        cwe: 'CWE-1357',
+        owasp: 'CICD-SEC-3',
+        fix:
+          'Pin the upstream reference to a specific version or commit and update it deliberately. ' +
+          'If it must stay automatic, put the deploying job behind a GitHub `environment:` with required ' +
+          'reviewers so a human approves the rollout.',
+      }));
+    } else if (!s.gated) {
+      // Built but not shipped straight to production: lower stakes, still
+      // building code nobody pinned.
+      findings.push(createFinding({
+        file,
+        line: ref.line,
+        severity: worst === 'branch' ? 'medium' : 'low',
+        category: this.category,
+        rule: 'CICD_UNPINNED_UPSTREAM_BUILD',
+        title: `CI builds an unpinned third-party ${worst === 'branch' ? 'branch' : 'release'}`,
+        description:
+          `This workflow builds from a mutable third-party reference (${ref.matched}). The code being built ` +
+          `can change without any change on your side, so a passing build today says nothing about what runs tomorrow.`,
+        matched: ref.matched,
+        confidence: 'medium',
+        cwe: 'CWE-1357',
+        owasp: 'CICD-SEC-3',
+        fix: 'Pin the reference to a specific version or commit SHA and bump it deliberately.',
+      }));
+    }
+
+    // Independently useful: shipping to production on a schedule with nobody
+    // able to stop it, whatever the source of the artifact.
+    if (deploying && s.scheduled && !s.gated && !s.nonProd) {
+      const d = s.deploys[0];
+      findings.push(createFinding({
+        file,
+        line: d.line,
+        severity: 'medium',
+        category: this.category,
+        rule: 'CICD_NO_DEPLOY_APPROVAL',
+        title: 'Scheduled production deploy with no approval gate',
+        description:
+          'This workflow deploys on a schedule and no job declares a GitHub `environment:`, which is where ' +
+          'required reviewers and wait timers are configured. Every rollout is unattended.',
+        matched: d.matched,
+        confidence: 'medium',
+        cwe: 'CWE-284',
+        owasp: 'CICD-SEC-1',
+        fix: 'Add an `environment:` with required reviewers to the deploying job, or trigger rollout manually.',
+      }));
+    }
+
+    return findings;
   }
 
   async analyze(context) {
@@ -289,9 +536,14 @@ export class CICDScanner extends BaseAgent {
 
     if (ciFiles.length === 0) return [];
 
+    const self = selfOwner(rootPath);
+
     let findings = [];
     for (const file of ciFiles) {
       findings = findings.concat(this.scanFileWithPatterns(file, PATTERNS));
+      // Whole-file pass: catches combinations the line rules structurally
+      // cannot see (see UNGOVERNED CONTINUOUS INGESTION above).
+      findings = findings.concat(this.scanIngestionChain(file, rootPath, self));
     }
     return findings;
   }


### PR DESCRIPTION
Closes the gap that produced #62.

## The gap

Our own Hermes workflow resolved `commits/main` from a third-party repo, built it, pushed it, and POSTed a rolling restart to production — nightly, unattended. We scanned it and gave it **88.4/B**, flagging only unpinned actions.

That wasn't an oversight, it was structural. The chain looked like this:

```
curl api.github.com/.../commits/main    ← mutable third-party ref
docker build --build-arg SHA=$SHA       ← built into an artifact
push: true                              ← published
curl -X POST $ORCHESTRATOR/update-image ← rolled to production
on: schedule                            ← unattended
```

Every line is individually benign, and `CICDScanner` was 300 lines of pure single-line regex. `CICD_UNPINNED_ACTION` covers the actions a workflow *runs*; nothing covered the payload it *ships*.

## What this adds

The scanner's first whole-file pass, scoring the combination rather than the lines:

| rule | when | severity |
|---|---|---|
| `CICD_UNATTENDED_UPSTREAM_DEPLOY` | full chain, tracking a branch | critical |
| | full chain, tracking a release | high |
| `CICD_UNPINNED_UPSTREAM_BUILD` | builds unpinned third-party code, doesn't ship it | medium / low |
| `CICD_NO_DEPLOY_APPROVAL` | scheduled prod deploy, no `environment:` gate | medium |

Mapped to CICD-SEC-3 (Dependency Chain Abuse) and CICD-SEC-1, CWE-1357.

## False-positive guards

This is the part that decides whether the rule survives contact with real repos:

- **A reference to your own repository never fires.** Building your own HEAD is ordinary; the risk is ingesting someone else's code. Owner is resolved from `.git/config`.
- **A job that opens a pull request is already gated** — that PR *is* the human step.
- **Non-production targets drop a band**, detected from `environment:` values and image tags rather than loose word matching.
- **Pinned refs are ignored.**

Scanning our three real workflows: `ci.yml` and `publish.yml` come back clean, and only `update-hermes-image.yml` reports — the one that genuinely still auto-deploys.

## Fixtures are real, and that mattered

The positive fixtures are this repository's own workflow before and after #62, not invented YAML. The first draft of these rules passed on synthetic input and **missed both real cases**:

- the real workflow builds its API URL from a shell variable (`API="…"` then `"$API/releases/latest"`), so a regex expecting one contiguous URL saw nothing;
- its deploy command wraps across lines with backslashes, so `curl … -X POST` and the URL it posts to are on different lines.

Handling those two shapes is most of what makes this work. A synthetic corpus would have shipped a rule that fires on nothing.

An earlier draft also downgraded a genuine production deploy to non-prod because `\bdev\b` matched `2>/dev/null`.

## Note on the current workflow

`update-hermes-image.yml` after #62 reports **high**, not clean. Tracking `releases/latest` and deploying on a schedule with no approval gate is still ungoverned ingestion — better than tracking a branch, not safe. Clearing it fully means pinning a version or putting the rollout behind an `environment:` with required reviewers. That's a real decision, not a rule bug.

## Verification

- 274 tests pass (was 265): 3 positives, 6 negatives
- `eslint` clean
- Dogfooded on all three real workflows