### PR TITLE
Release 9.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,67 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [9.6.0] — 2026-07-26 — Suppression Floor & Pipeline Ingestion
+
+Two changes here alter what existing scans report. Both are deliberate, and
+both can move a score that previously looked clean.
+
+### Changed
+- **`ship-safe-ignore` no longer silences `critical` findings.** The comment
+  was designed for a human deciding a finding is a false positive. That
+  assumption no longer holds on its own: the code being scanned is
+  increasingly written by an AI agent, and an agent that can emit a line of
+  source can emit the suppression comment on the line that matters.
+
+  A file containing a live AWS key and `eval(req.body.x)`, each with the
+  comment appended, previously scored **96.4/A**. It now scores **66.4/C**.
+
+  Everything below `critical` behaves exactly as before, so existing
+  suppressions on medium and high findings keep working. **If you rely on
+  `ship-safe-ignore` for a critical-severity false positive, that finding will
+  come back and your score will drop.**
+- Suppressions are now counted. Agents track how many findings a scan was
+  asked not to report, and the scan result carries a `suppression` summary, so
+  a run that silenced findings can no longer read like one that had none. An
+  attempt to suppress a `critical` is counted separately, since that is a
+  signal rather than a no-op.
+
+### Added
+- **Ungoverned continuous ingestion detection** (CICDScanner). A pipeline that
+  resolves a mutable third-party reference, builds it, and deploys the result
+  with no human gate hands upstream control of production with under a day of
+  latency. Every line of such a workflow is individually benign, so the
+  existing line-by-line rules could not see it; this adds the scanner's first
+  whole-file pass.
+  - `CICD_UNATTENDED_UPSTREAM_DEPLOY` — the full chain. `critical` when it
+    tracks a branch, `high` when it tracks a release.
+  - `CICD_UNPINNED_UPSTREAM_BUILD` — builds unpinned third-party code without
+    shipping it straight out.
+  - `CICD_NO_DEPLOY_APPROVAL` — scheduled production deploy where no job
+    declares an `environment:`, which is where required reviewers live.
+
+  A reference to your own repository never fires, a job that opens a pull
+  request is treated as already gated, non-production targets drop a band, and
+  pinned references are ignored.
+
+### Fixed
+- `GPTRedAgent` ignored `noAi`. It gated its provider on `options.ai === false`
+  only, which the `--no-ai` flag sets, but programmatic callers pass
+  `noAi: true` — so a scan requested as fully local could still send context to
+  a provider.
+- Removed `ship_safe_suppress_finding` from the Hermes tool registry. Its
+  handler called an export that never existed, so every invocation threw; and a
+  tool that writes suppression comments into scanned source hands an agent the
+  means to silence findings about its own output.
+- Pinned `brace-expansion` to 5.0.8 (GHSA-mh99-v99m-4gvg). Dev-only, so it
+  never reached the published package, but it failed the `npm audit` CI gate.
+
+### Tests
+- 284 tests, up from 265. New coverage for the suppression floor, the
+  ingestion chain rules, and their false-positive guards. The ingestion
+  fixtures are this repository's own workflow before and after remediation
+  rather than synthetic YAML.
+
 ## [9.5.2] — 2026-07-16 — Kimi K3 Tool-Call Security
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -222,6 +222,13 @@ No API key required for core scanning. AI classification and `red-team --gpt-red
 password = get_password()  # ship-safe-ignore
 ```
 
+`critical` findings are always reported. An inline comment cannot hide one, and
+an attempt to suppress one is recorded in the scan. The comment is meant for a
+human ruling out a false positive, and anything that can write a line of your
+source — including an AI agent — can write the comment too, so the highest
+severities do not honor it. Every suppression is counted, so a scan that
+silenced findings never reads like one that had none.
+
 ```gitignore
 # .ship-safeignore
 tests/fixtures/

--- a/cli/utils/output.js
+++ b/cli/utils/output.js
@@ -178,6 +178,7 @@ export function vulnRecommendations() {
   console.log();
   console.log(chalk.white('1.') + ' Fix the flagged code patterns (see "Why" descriptions above)');
   console.log(chalk.white('2.') + ' Use  # ship-safe-ignore  on lines that are safe (e.g. internal tools, controlled input)');
+  console.log(chalk.gray('    Critical findings are always reported — a suppression comment cannot hide one.'));
   console.log(chalk.white('3.') + ' Run  npx ship-safe checklist  for a full launch-day security review');
   console.log();
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-safe",
-  "version": "9.5.2",
+  "version": "9.6.0",
   "description": "AI-powered multi-agent security platform. 29 agents scan 80+ attack classes including AI integration supply chain (Vercel-class attacks), Hermes Agent deployments (ASI-01–ASI-10), tool registry poisoning, function-call injection, skill permission drift, and agent attestation. Ship Safe × Hermes Agent.",
   "main": "cli/index.js",
   "bin": {

--- a/webapp/app/docs/page.tsx
+++ b/webapp/app/docs/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
     canonical: 'https://www.shipsafecli.com/docs',
   },
   openGraph: {
-    title: 'Ship Safe CLI Documentation — v9.5.2',
+    title: 'Ship Safe CLI Documentation — v9.6.0',
     description: 'Every command, agent, and flag. LLM vulnerability CLI, MCP security configuration, RAG poisoning detection, CI/CD integration, and API reference.',
     type: 'website',
     url: 'https://www.shipsafecli.com/docs',
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Ship Safe CLI Documentation — v9.5.2',
+    title: 'Ship Safe CLI Documentation — v9.6.0',
     description: 'Every command, agent, and flag. LLM vulnerability CLI, MCP security configuration, RAG poisoning detection, CI/CD integration, and API reference.',
     images: [ogImage],
   },
@@ -431,6 +431,13 @@ jobs:
               <h2>Suppressing Findings</h2>
               <p><strong>Inline:</strong> Add <code># ship-safe-ignore</code> on any line:</p>
               <pre><code>{`password = get_password()  # ship-safe-ignore`}</code></pre>
+              <p>
+                <strong>Critical findings are always reported.</strong> An inline comment cannot hide one,
+                and an attempt to suppress one is recorded in the scan. The comment exists for a human
+                ruling out a false positive, and anything that can write a line of your source &mdash;
+                including an AI agent &mdash; can write the comment too. Every suppression is counted,
+                so a scan that silenced findings never reads like one that had none.
+              </p>
               <p><strong>File-level:</strong> Create <code>.ship-safeignore</code> (gitignore syntax):</p>
               <pre><code>{`# Exclude test fixtures
 tests/fixtures/

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-safe-webapp",
-  "version": "9.5.2",
+  "version": "9.6.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Minor rather than patch: two changes in this release alter what existing scans report, and both can move a score that previously looked clean.

## Why this needs saying loudly

**The suppression floor (#64) is a breaking change in practice.** Anyone relying on `ship-safe-ignore` for a critical-severity false positive will see that finding return and their score drop. The changelog leads with that rather than burying it under "Added".

A file with a live AWS key and `eval(req.body.x)`, each carrying the comment, went from **96.4/A** to **66.4/C**.

## Docs corrected

Three places described `ship-safe-ignore` as unconditional, and all three were wrong as of #64:

- `README.md` — the "Suppress False Positives" section
- `webapp/app/docs/page.tsx` — the Suppressing Findings section
- `cli/utils/output.js` — the CLI's own remediation output, which tells users to reach for the comment

Each now states that critical findings cannot be suppressed and that suppressions are counted. Also bumps the stale `v9.5.2` strings in the docs page OG metadata.

## Version

`package.json` and `webapp/package.json` to 9.6.0. The CLI reports its version from `package.json`, so `ship-safe --version` follows automatically.

**`webapp`'s `ship-safe` dependency deliberately stays at `^9.5.2`.** 9.6.0 is not on npm yet, and widening the range before publishing would break the webapp build.

## Verification

284 tests pass, `eslint` clean, `npm audit` clean, `tsc --noEmit` clean, `ship-safe --version` reports 9.6.0.