### PR TITLE
Bump pinned actions to their Node 24 native majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
         node-version: [18.x, 20.x, 22.x]
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -53,10 +53,10 @@ jobs:
     needs: test
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Use Node.js 20.x
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 20.x
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,10 @@ jobs:
     environment: npm-publish
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 20.x
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/update-hermes-image.yml
+++ b/.github/workflows/update-hermes-image.yml
@@ -22,7 +22,7 @@ jobs:
       sha: ${{ steps.upstream.outputs.sha }}
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       # ── 1. Resolve the latest tagged Hermes release ──────────────────────────
       # Deliberately a release, not `main`. This job builds an image that is
@@ -67,19 +67,19 @@ jobs:
       # ── 3. Build + push only if SHA changed ──────────────────────────────────
       - name: Log in to Docker Hub
         if: steps.upstream.outputs.sha != steps.current.outputs.sha
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         if: steps.upstream.outputs.sha != steps.current.outputs.sha
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Build and push
         id: build
         if: steps.upstream.outputs.sha != steps.current.outputs.sha
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ./vps
           file: ./vps/agent.Dockerfile


### PR DESCRIPTION
Every action in these workflows targeted Node 20, which GitHub is deprecating. Runs already warn that they are being forced onto Node 24:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout, docker/build-push-action, docker/login-action, docker/setup-buildx-action

Pinning them to SHAs last week locked in the Node 20 line, so this moves the pins forward rather than leaving them to break on a future runner change.

```
actions/checkout           v4 -> v5
actions/setup-node         v4 -> v5
docker/login-action        v3 -> v4
docker/setup-buildx-action v3 -> v4
docker/build-push-action   v6 -> v7
```

Still pinned to commit SHAs with the tag in a trailing comment.

These are major bumps, so they get verified rather than assumed: `ci.yml` and `publish.yml` changes are exercised by this PR's own checks, and the Hermes workflow gets a `dry_run` on this branch — building the image on a real runner without pushing or deploying.