### PR TITLE
Fix the rollout job never firing

### DIFF
--- a/.github/workflows/update-hermes-image.yml
+++ b/.github/workflows/update-hermes-image.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      rebuilt: ${{ steps.build.outputs.rebuilt }}
+      rebuilt: ${{ steps.set-rebuilt.outputs.rebuilt }}
       sha: ${{ steps.upstream.outputs.sha }}
 
     steps:


### PR DESCRIPTION
The `rollout` job has never run. Not once.

```yaml
outputs:
  rebuilt: ${{ steps.build.outputs.rebuilt }}   # reads step id "build"
...
  - name: Set rebuilt output
    id: set-rebuilt                              # but it is set here
```

`steps.build` is the docker/build-push-action step, which has no `rebuilt` output, so the job output resolved to an empty string and `needs.check-and-build.outputs.rebuilt == 'true'` was never satisfied.

This morning's scheduled run makes it plain — the SHAs differed, the step logged `rebuilt=true`, and `rollout` was still skipped:

```
Upstream release:  v2026.7.20 (3ef6bbd…)
Current image SHA: 3e953ed…          ← different
Set rebuilt output: echo "rebuilt=true"
rollout: skipped
```

Consequence: images build and push to Docker Hub correctly, but the VPS is never told to restart, so containers keep running whatever they last pulled. The workflow's own fallback — "containers will update on next redeploy" — has been the only path the whole time, which is why this never looked broken.

Pre-existing; predates the recent changes to this file.

## Before merging

This makes the rollout real. The next scheduled run will actually POST to the orchestrator and restart production containers onto `v2026.7.20`. That is the intended behaviour and the reason the workflow exists, but it will be the first time it has ever happened — worth being around for.
