### PR TITLE
fix(mcp): detect secret env passthrough in project-local configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,10 @@ model supply chain.
   agentic editor. A malicious repo weaponizes this to run code on the trust
   prompt (Adversa, 2026). Excludes remote-only servers and the global
   `claude_desktop_config.json`. Maps to CWE-829, ASI06:2026.
+- **MCPSecurityAgent**: new `MCP_ENV_SECRET_PASSTHROUGH` (high) — a repo-local
+  MCP config passes secret-like environment variables (e.g. `OPENAI_API_KEY`,
+  `AWS_SECRET_ACCESS_KEY`) into a tool process. Benign operational vars like
+  `LOG_LEVEL` are excluded. Maps to CWE-200, ASI06:2026.
 
 ### Changed
 - Agent count 24 → 29 across CLI, README, docs, and marketing site.

--- a/cli/__tests__/mcp-env-passthrough.test.js
+++ b/cli/__tests__/mcp-env-passthrough.test.js
@@ -1,0 +1,131 @@
+/**
+ * Ship Safe — MCPSecurityAgent env secret passthrough
+ * ===================================================
+ *
+ * Verifies MCP_ENV_SECRET_PASSTHROUGH fires on repo-local project MCP configs
+ * that pass secret-like env vars into tool processes.
+ *
+ * Run: npm test
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import { MCPSecurityAgent } from '../agents/mcp-security-agent.js';
+
+function tmp() { return fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-mcp-env-')); }
+function cleanup(dir) { try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* */ } }
+
+async function scan(dir, relFiles) {
+  const files = relFiles.map((r) => path.join(dir, r));
+  return new MCPSecurityAgent().analyze({ rootPath: dir, files, recon: {}, options: {} });
+}
+
+describe('MCPSecurityAgent — env secret passthrough', () => {
+  it('flags secret-like env vars in a project-local .mcp.json', async () => {
+    const dir = tmp();
+    try {
+      fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({
+        mcpServers: {
+          example: {
+            command: 'node',
+            args: ['server.js'],
+            env: {
+              OPENAI_API_KEY: '${OPENAI_API_KEY}',
+              AWS_SECRET_ACCESS_KEY: '${AWS_SECRET_ACCESS_KEY}',
+            },
+          },
+        },
+      }));
+      const f = await scan(dir, ['.mcp.json']);
+      const hits = f.filter((x) => x.rule === 'MCP_ENV_SECRET_PASSTHROUGH');
+      assert.equal(hits.length, 2);
+      assert.ok(hits.every((x) => x.severity === 'high'));
+      assert.ok(hits.some((x) => x.matched === 'OPENAI_API_KEY'));
+      assert.ok(hits.some((x) => x.matched === 'AWS_SECRET_ACCESS_KEY'));
+    } finally { cleanup(dir); }
+  });
+
+  it('does not flag benign operational env vars', async () => {
+    const dir = tmp();
+    try {
+      fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({
+        mcpServers: {
+          example: {
+            command: 'node',
+            args: ['server.js'],
+            env: { LOG_LEVEL: 'info', NODE_ENV: 'production' },
+          },
+        },
+      }));
+      const f = await scan(dir, ['.mcp.json']);
+      assert.equal(f.filter((x) => x.rule === 'MCP_ENV_SECRET_PASSTHROUGH').length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('does not flag tokenizer or token-limit env names', async () => {
+    const dir = tmp();
+    try {
+      fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({
+        mcpServers: {
+          example: {
+            command: 'node',
+            args: ['server.js'],
+            env: { MAX_TOKENS: '4096', TOKENIZER_MODEL: 'gpt-4' },
+          },
+        },
+      }));
+      const f = await scan(dir, ['.mcp.json']);
+      assert.equal(f.filter((x) => x.rule === 'MCP_ENV_SECRET_PASSTHROUGH').length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('flags secret env vars in .cursor/mcp.json', async () => {
+    const dir = tmp();
+    try {
+      fs.mkdirSync(path.join(dir, '.cursor'), { recursive: true });
+      fs.writeFileSync(path.join(dir, '.cursor', 'mcp.json'), JSON.stringify({
+        servers: {
+          example: {
+            command: 'node',
+            args: ['server.js'],
+            env: { GITHUB_TOKEN: '${GITHUB_TOKEN}' },
+          },
+        },
+      }));
+      const f = await scan(dir, ['.cursor/mcp.json']);
+      assert.ok(f.some((x) => x.rule === 'MCP_ENV_SECRET_PASSTHROUGH' && x.matched === 'GITHUB_TOKEN'));
+    } finally { cleanup(dir); }
+  });
+
+  it('does not flag the global claude_desktop_config.json', async () => {
+    const dir = tmp();
+    try {
+      fs.writeFileSync(path.join(dir, 'claude_desktop_config.json'), JSON.stringify({
+        mcpServers: {
+          example: {
+            command: 'node',
+            args: ['server.js'],
+            env: { OPENAI_API_KEY: '${OPENAI_API_KEY}' },
+          },
+        },
+      }));
+      const f = await scan(dir, ['claude_desktop_config.json']);
+      assert.equal(f.filter((x) => x.rule === 'MCP_ENV_SECRET_PASSTHROUGH').length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('does not flag remote servers without an env block', async () => {
+    const dir = tmp();
+    try {
+      fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({
+        mcpServers: { remote: { url: 'https://mcp.example.com/sse' } },
+      }));
+      const f = await scan(dir, ['.mcp.json']);
+      assert.equal(f.filter((x) => x.rule === 'MCP_ENV_SECRET_PASSTHROUGH').length, 0);
+    } finally { cleanup(dir); }
+  });
+});

--- a/cli/agents/mcp-security-agent.js
+++ b/cli/agents/mcp-security-agent.js
@@ -310,6 +310,7 @@ export class MCPSecurityAgent extends BaseAgent {
       findings = findings.concat(this._checkMcpTyposquatting(file));
       findings = findings.concat(this._checkOverPermissioned(file));
       findings = findings.concat(this._checkAutoLaunchOnTrust(file, rootPath));
+      findings = findings.concat(this._checkEnvSecretPassthrough(file, rootPath));
     }
 
     // ── 5. Detect shadow MCP configs (not in version control) ───────────
@@ -427,6 +428,58 @@ export class MCPSecurityAgent extends BaseAgent {
         fix: 'Do not ship auto-launching MCP servers in a repo. Review the command, require explicit per-server approval, and never trust a repo-supplied server definition without inspecting what it runs.',
       });
     }
+    return findings;
+  }
+
+  /**
+   * Detect project-local MCP configs that pass secret-like environment variables
+   * into a tool process. A malicious or compromised server can read credentials
+   * that were never meant for it.
+   */
+  _checkEnvSecretPassthrough(filePath, rootPath) {
+    const rel = path.relative(rootPath, filePath).replace(/\\/g, '/');
+    const base = path.basename(filePath);
+    const isProjectLocal = base === '.mcp.json' || base === 'mcp.json'
+      || rel.endsWith('.cursor/mcp.json') || rel.endsWith('.vscode/mcp.json');
+    if (!isProjectLocal) return [];
+
+    const content = this.readFile(filePath);
+    if (!content) return [];
+    let config;
+    try { config = JSON.parse(content); } catch { return []; }
+
+    const servers = config.mcpServers || config.servers || (config.mcp && config.mcp.servers) || {};
+    const findings = [];
+    const operationalEnvNames = new Set([
+      'LOG_LEVEL', 'NODE_ENV', 'PORT', 'DEBUG', 'PATH', 'HOME', 'LANG', 'TZ',
+      'CI', 'TERM', 'SHELL', 'USER', 'TMPDIR', 'TMP', 'TEMP',
+    ]);
+    const secretEnvNameRe = /(?:^|_)(?:API[_-]?KEY|ACCESS[_-]?KEY|SECRET[_-]?ACCESS[_-]?KEY|AUTH[_-]?TOKEN|ACCESS[_-]?TOKEN|CLIENT[_-]?SECRET|PRIVATE[_-]?KEY|PASSWORD|PASSWD|CREDENTIAL|CREDENTIALS|PAT|GH_PAT|SECRET|TOKEN|PASSWORD|CREDENTIAL)(?:_|$)/i;
+
+    for (const [name, server] of Object.entries(servers)) {
+      const env = server?.env;
+      if (!env || typeof env !== 'object' || Array.isArray(env)) continue;
+
+      for (const key of Object.keys(env)) {
+        if (operationalEnvNames.has(key)) continue;
+        if (!secretEnvNameRe.test(key)) continue;
+
+        findings.push({
+          file: filePath, line: 1, column: 0,
+          severity: 'high',
+          category: this.category,
+          rule: 'MCP_ENV_SECRET_PASSTHROUGH',
+          title: `MCP: Server "${name}" passes secret env "${key}"`,
+          description: `Project-local ${base} passes "${key}" into the "${name}" MCP server process. A malicious or compromised server can read credentials that were never meant for the tool.`,
+          matched: key,
+          confidence: 'high',
+          cwe: 'CWE-200',
+          owasp: 'ASI06:2026',
+          fix: 'Remove secret env vars from MCP server config. Pass only operational settings (e.g. LOG_LEVEL). Use scoped, server-specific credentials if absolutely required.',
+        });
+      }
+    }
+
     return findings;
   }
 


### PR DESCRIPTION
## Summary

Adds the `MCP_ENV_SECRET_PASSTHROUGH` rule to `MCPSecurityAgent`, flagging project-local MCP configs that pass secret-like environment variable names into tool server processes.

## Motivation

MCP servers often launch local commands. If a repo ships a project-local config that forwards credentials (e.g. `OPENAI_API_KEY`, `AWS_SECRET_ACCESS_KEY`) into an untrusted tool process, a malicious or compromised server can read secrets that were never meant for it.

Fixes #54

## Changes

- Add `_checkEnvSecretPassthrough()` in `cli/agents/mcp-security-agent.js`
- Scope to project-local configs (`.mcp.json`, `mcp.json`, `.cursor/mcp.json`, `.vscode/mcp.json`) — same gate as `MCP_AUTO_LAUNCH_ON_TRUST`
- Flag env keys matching secret-like patterns; exclude operational names like `LOG_LEVEL`, `NODE_ENV`, `PORT`
- Use boundary-aware matching so names like `MAX_TOKENS` are not flagged
- Report only env var **names** in findings (`matched`), never values
- Add `cli/__tests__/mcp-env-passthrough.test.js` with positive/negative regressions
- Document in `CHANGELOG.md`

## Tests

```bash
npm test
node --test cli/__tests__/mcp-env-passthrough.test.js
```

All tests pass locally (full suite: 0 failures).

## Notes

- Intentionally does not flag global `claude_desktop_config.json` (user-owned config, not repo-supplied)
- Does not yet cover connection-string style names like `DATABASE_URL` — can follow up if desired