### PR TITLE
docs: add changelog entries for MCP env passthrough and Kimi K3 fixture coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Added
+- **MCP env passthrough detection** — repo-local MCP configs that pass secret-like
+  environment variables (e.g. `OPENAI_API_KEY`, `AWS_ACCESS_KEY_ID`) directly
+  to MCP server processes are now flagged with `MCP_ENV_SECRET_PASSTHROUGH`.
+  Existing rules already covered token forwarding over non-localhost URLs; this
+  fills the gap for configs that stay local but still leak credentials.
+- **Kimi K3 tool-call fixture coverage** — regression tests now exercise Kimi K3
+  / OpenAI-compatible tool-call payloads end-to-end. Existing rules were only
+  validated against synthetic fixtures; these come from real payloads.
+
+### Fixed
+- None.
+
+---
+
+
 ## [9.6.0] — 2026-07-26 — Suppression Floor & Pipeline Ingestion
 
 Two changes here alter what existing scans report. Both are deliberate, and


### PR DESCRIPTION
Fixes #79

Adds `[Unreleased]` section with two entries:
- MCP env passthrough detection (`MCP_ENV_SECRET_PASSTHROUGH`)
- Kimi K3 tool-call fixture coverage

Wording kept user-facing and concrete per issue guidance.