### PR TITLE
test: add packaged CLI smoke test for npx usage

### DIFF
--- a/cli/__tests__/fixtures/smoke-project/package.json
+++ b/cli/__tests__/fixtures/smoke-project/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "smoke-project",
+  "version": "1.0.0",
+  "private": true
+}

--- a/cli/__tests__/fixtures/smoke-project/src/app.js
+++ b/cli/__tests__/fixtures/smoke-project/src/app.js
@@ -1,0 +1,9 @@
+// Deliberately insecure fixture for the packaged-CLI smoke test.
+// The hardcoded password below must be detected by `ship-safe scan`.
+const DB_PASSWORD = "super-secret-password-123";
+
+function connect(host) {
+  return { host, DB_PASSWORD };
+}
+
+module.exports = { connect };

--- a/cli/__tests__/packaged-cli-smoke.test.js
+++ b/cli/__tests__/packaged-cli-smoke.test.js
@@ -1,0 +1,51 @@
+/**
+ * Ship Safe — packaged CLI smoke test
+ * ===================================
+ *
+ * Issue #83: validates that the CLI entrypoint works the way users
+ * actually run it (`npx ship-safe scan <project>`), instead of importing
+ * internals directly. Uses a small fixture project with one risky pattern
+ * and asserts the command exits successfully while printing the expected
+ * finding and summary line.
+ *
+ * Run: npm test
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const BIN = path.join(ROOT, 'cli', 'bin', 'ship-safe.js');
+const FIXTURE = path.join(ROOT, 'cli', '__tests__', 'fixtures', 'smoke-project');
+
+describe('packaged CLI smoke test (issue #83)', () => {
+  it('runs through the package entrypoint and reports the fixture finding', () => {
+    const res = spawnSync(
+      process.execPath,
+      [BIN, 'scan', FIXTURE, '--no-color', '--no-cache', '--include-tests'],
+      { encoding: 'utf8', timeout: 60_000 },
+    );
+
+    // The CLI is designed to exit 1 when findings exist (CI gate), 0 when clean.
+    // A crash would surface as a different status or a stack trace on stderr,
+    // so status 1 + the expected output below proves the entrypoint ran.
+    assert.strictEqual(
+      res.status,
+      1,
+      `CLI should exit 1 when findings exist\nstdout: ${res.stdout}\nstderr: ${res.stderr}`,
+    );
+    assert.match(
+      res.stdout,
+      /Password Assignment/,
+      'stdout should contain the expected finding from the fixture project',
+    );
+    assert.match(
+      res.stdout,
+      /Found 1 secret/,
+      'stdout should contain the summary line with the finding count',
+    );
+  });
+});


### PR DESCRIPTION
Closes #83

## What
Adds a packaged CLI smoke test that validates the CLI entrypoint works the way users actually run it (`npx ship-safe scan <project>`), instead of importing internals directly.

## Changes
- **`cli/__tests__/packaged-cli-smoke.test.js`** — spawns the real package entrypoint (`cli/bin/ship-safe.js`) against a fixture project and asserts:
  - exit code `1` (the documented CI gate when findings exist — `process.exit(hasFindings ? 1 : 0)`),
  - stdout contains the expected finding (`Password Assignment`),
  - stdout contains the summary line (`Found 1 secret`).
- **`cli/__tests__/fixtures/smoke-project/`** — tiny fixture project (2 files) with one deliberately risky pattern (hardcoded password). Lives under `__tests__/` so it stays excluded from the repo self-scan (`ship-safe scan .`).

Fast and fully offline: no API keys, no network, ~0.3s runtime.

## Verification
| Check | Result |
|---|---|
| `npm test` (full suite, incl. new test) | 296 pass / 0 fail (was 295) |
| New test alone | 1 pass |
| `npm run lint` | 0 errors (only pre-existing warnings) |
| `node cli/bin/ship-safe.js scan .` (self-scan, as CI) | exit 0, no issues |

## Notes
- The previous attempt (#84) only touched `package-lock.json` and did not implement the smoke test; this PR implements the requested change with a real test.
