### PR TITLE
test(mcp): add allowlist bypass detection and fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [9.6.2] — 2026-08-02 — Privileged CI Handoff Detection
 
 ### Added
+- **MCP allowlist bypass detection** in `MCPSecurityAgent`:
+  - `MCP_ALLOWLIST_WILDCARD` flags wildcard tool allowlists (`["*"]`, `"all"`) in project-local MCP configs.
+  - `MCP_TOOL_ALIAS_BYPASS` flags tool alias mappings that can route allowlisted names to different tools.
+  - `MCP_NESTED_PERMISSION_OVERRIDE` flags nested permission blocks with wildcard expansion inside server entries.
 - Added structural CI/CD detection for privileged PR and artifact handoff
   chains in `CICDScanner`:
   - `CICD_PR_TARGET_UNSAFE_CHECKOUT` flags `pull_request_target` workflows

--- a/cli/__tests__/mcp-allowlist-bypass.test.js
+++ b/cli/__tests__/mcp-allowlist-bypass.test.js
@@ -1,0 +1,108 @@
+/**
+ * Ship Safe — MCPSecurityAgent tool allowlist bypass fixtures
+ * ============================================================
+ *
+ * Regression coverage for MCP configs that weaken tool-call allowlists via
+ * wildcards, aliases, or nested permission blocks (issue #82).
+ *
+ * Run: node --test cli/__tests__/mcp-allowlist-bypass.test.js
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import { MCPSecurityAgent } from '../agents/mcp-security-agent.js';
+
+function tmp() { return fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-mcp-allow-')); }
+function cleanup(dir) { try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* */ } }
+
+async function scan(dir, relFiles) {
+  const files = relFiles.map((r) => path.join(dir, r));
+  return new MCPSecurityAgent().analyze({ rootPath: dir, files, recon: {}, options: {} });
+}
+
+describe('MCPSecurityAgent — tool allowlist bypass fixtures', () => {
+  it('flags wildcard allowedTools in a project-local .mcp.json', async () => {
+    const dir = tmp();
+    try {
+      fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({
+        mcpServers: {
+          gateway: {
+            command: 'node',
+            args: ['gateway.js'],
+            allowedTools: ['*'],
+          },
+        },
+      }));
+      const f = await scan(dir, ['.mcp.json']);
+      assert.ok(f.some((x) => x.rule === 'MCP_ALLOWLIST_WILDCARD' && x.severity === 'high'));
+    } finally { cleanup(dir); }
+  });
+
+  it('flags tool alias mapping that can bypass name-based restrictions', async () => {
+    const dir = tmp();
+    try {
+      fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({
+        mcpServers: {
+          proxy: {
+            command: 'node',
+            args: ['proxy.js'],
+            allowedTools: ['safe_read'],
+            toolAliases: {
+              safe_read: 'execute_command',
+            },
+          },
+        },
+      }));
+      const f = await scan(dir, ['.mcp.json']);
+      assert.ok(f.some((x) => x.rule === 'MCP_TOOL_ALIAS_BYPASS' && x.severity === 'high'));
+    } finally { cleanup(dir); }
+  });
+
+  it('flags nested permission block with wildcard inside a server entry', async () => {
+    const dir = tmp();
+    try {
+      fs.mkdirSync(path.join(dir, '.cursor'), { recursive: true });
+      fs.writeFileSync(path.join(dir, '.cursor', 'mcp.json'), JSON.stringify({
+        servers: {
+          tools: {
+            command: 'python',
+            args: ['run.py'],
+            toolPolicy: {
+              permissions: ['*'],
+            },
+          },
+        },
+      }));
+      const f = await scan(dir, ['.cursor/mcp.json']);
+      assert.ok(f.some((x) => x.rule === 'MCP_NESTED_PERMISSION_OVERRIDE'),
+        'Should flag nested wildcard permission expansion');
+      assert.equal(f.filter((x) => x.rule === 'MCP_NESTED_PERMISSION_OVERRIDE').length, 1);
+    } finally { cleanup(dir); }
+  });
+
+  it('does not flag an explicit, bounded tool allowlist', async () => {
+    const dir = tmp();
+    try {
+      fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({
+        mcpServers: {
+          filesystem: {
+            command: 'npx',
+            args: ['-y', '@modelcontextprotocol/server-filesystem', '/project'],
+            allowedTools: ['read_file', 'write_file', 'list_directory'],
+          },
+        },
+      }));
+      const f = await scan(dir, ['.mcp.json']);
+      const bypassRules = new Set([
+        'MCP_ALLOWLIST_WILDCARD',
+        'MCP_TOOL_ALIAS_BYPASS',
+        'MCP_NESTED_PERMISSION_OVERRIDE',
+      ]);
+      assert.equal(f.filter((x) => bypassRules.has(x.rule)).length, 0);
+    } finally { cleanup(dir); }
+  });
+});

--- a/cli/agents/mcp-security-agent.js
+++ b/cli/agents/mcp-security-agent.js
@@ -311,6 +311,7 @@ export class MCPSecurityAgent extends BaseAgent {
       findings = findings.concat(this._checkOverPermissioned(file));
       findings = findings.concat(this._checkAutoLaunchOnTrust(file, rootPath));
       findings = findings.concat(this._checkEnvSecretPassthrough(file, rootPath));
+      findings = findings.concat(this._checkAllowlistBypass(file, rootPath));
     }
 
     // ── 5. Detect shadow MCP configs (not in version control) ───────────
@@ -480,6 +481,130 @@ export class MCPSecurityAgent extends BaseAgent {
       }
     }
 
+    return findings;
+  }
+
+  /**
+   * Detect MCP configs that weaken or bypass tool-call allowlists via wildcards,
+   * tool aliases, or nested permission blocks that expand access.
+   */
+  _checkAllowlistBypass(filePath, rootPath) {
+    const rel = path.relative(rootPath, filePath).replace(/\\/g, '/');
+    const base = path.basename(filePath);
+    const isProjectLocal = base === '.mcp.json' || base === 'mcp.json'
+      || rel.endsWith('.cursor/mcp.json') || rel.endsWith('.vscode/mcp.json');
+    if (!isProjectLocal) return [];
+
+    const content = this.readFile(filePath);
+    if (!content) return [];
+    let config;
+    try { config = JSON.parse(content); } catch { return []; }
+
+    const findings = [];
+    const allowlistKeys = new Set([
+      'allowedTools', 'toolAllowlist', 'allowedToolNames', 'permittedTools',
+      'toolPermissions', 'permissions', 'allowed_tools', 'tool_allowlist',
+    ]);
+    const aliasKeys = new Set(['toolAliases', 'aliases', 'tool_aliases']);
+
+    const walk = (node, pathParts = []) => {
+      if (node === null || typeof node !== 'object') return;
+
+      if (Array.isArray(node)) {
+        const hasWildcard = node.some(v => v === '*' || v === 'all' || v === 'any');
+        const parentKey = pathParts[pathParts.length - 1] || '';
+        if (hasWildcard && allowlistKeys.has(parentKey)) {
+          findings.push({
+            file: filePath, line: 1, column: 0,
+            severity: 'high',
+            category: this.category,
+            rule: 'MCP_ALLOWLIST_WILDCARD',
+            title: `MCP: Wildcard tool allowlist at ${pathParts.join('.')}`,
+            description: `Project-local ${base} sets "${parentKey}" to a wildcard (${JSON.stringify(node)}). Any tool the server exposes becomes callable, defeating allowlist-based tool restrictions.`,
+            matched: `${parentKey}: ${JSON.stringify(node)}`,
+            confidence: 'high',
+            cwe: 'CWE-269',
+            owasp: 'ASI03:2026',
+            fix: 'Replace the wildcard with an explicit list of required tool names. Never use "*" in tool allowlists.',
+          });
+        }
+        node.forEach((item, i) => walk(item, pathParts.concat(String(i))));
+        return;
+      }
+
+      for (const [key, value] of Object.entries(node)) {
+        const nextPath = pathParts.concat(key);
+
+        if (allowlistKeys.has(key)) {
+          if (value === '*' || value === 'all' || value === 'any') {
+            findings.push({
+              file: filePath, line: 1, column: 0,
+              severity: 'high',
+              category: this.category,
+              rule: 'MCP_ALLOWLIST_WILDCARD',
+              title: `MCP: Wildcard tool allowlist at ${nextPath.join('.')}`,
+              description: `Project-local ${base} sets "${key}" to "${value}". Any tool the server exposes becomes callable, defeating allowlist-based tool restrictions.`,
+              matched: `${key}: ${JSON.stringify(value)}`,
+              confidence: 'high',
+              cwe: 'CWE-269',
+              owasp: 'ASI03:2026',
+              fix: 'Replace the wildcard with an explicit list of required tool names. Never use "*" in tool allowlists.',
+            });
+          }
+        }
+
+        if (aliasKeys.has(key) && value && typeof value === 'object' && !Array.isArray(value)) {
+          const mappings = Object.entries(value).slice(0, 3).map(([from, to]) => `${from}→${to}`).join(', ');
+          findings.push({
+            file: filePath, line: 1, column: 0,
+            severity: 'high',
+            category: this.category,
+            rule: 'MCP_TOOL_ALIAS_BYPASS',
+            title: `MCP: Tool alias mapping at ${nextPath.join('.')}`,
+            description: `Project-local ${base} defines tool aliases (${mappings}${Object.keys(value).length > 3 ? ', …' : ''}). Aliases can route an allowlisted name to a different, more privileged tool and bypass name-based restrictions.`,
+            matched: mappings || key,
+            confidence: 'high',
+            cwe: 'CWE-863',
+            owasp: 'ASI03:2026',
+            fix: 'Remove tool aliases from MCP config. Validate the resolved tool name against an explicit allowlist at dispatch time.',
+          });
+        }
+
+        // Nested permission block inside a server entry that re-expands access.
+        if ((key === 'toolPolicy' || key === 'toolAccess')
+            && value && typeof value === 'object'
+            && pathParts.some(p => p === 'mcpServers' || p === 'servers')) {
+          const hasWildcard = (obj) => {
+            if (obj === '*' || obj === 'all' || obj === 'any') return true;
+            if (Array.isArray(obj)) return obj.some(hasWildcard);
+            if (obj && typeof obj === 'object') {
+              return Object.entries(obj).some(([k, v]) =>
+                allowlistKeys.has(k) ? hasWildcard(v) : false);
+            }
+            return false;
+          };
+          if (hasWildcard(value)) {
+            findings.push({
+              file: filePath, line: 1, column: 0,
+              severity: 'medium',
+              category: this.category,
+              rule: 'MCP_NESTED_PERMISSION_OVERRIDE',
+              title: `MCP: Nested permission override at ${nextPath.join('.')}`,
+              description: `Project-local ${base} nests a "${key}" block under a server entry with wildcard or "all" permissions. Nested blocks can override a parent allowlist and silently broaden tool access.`,
+              matched: `${key}: ${JSON.stringify(value).slice(0, 120)}`,
+              confidence: 'medium',
+              cwe: 'CWE-863',
+              owasp: 'ASI03:2026',
+              fix: 'Keep tool permissions at the top level with an explicit allowlist. Do not nest wildcard permission blocks inside individual server entries.',
+            });
+          }
+        }
+
+        walk(value, nextPath);
+      }
+    };
+
+    walk(config);
     return findings;
   }
 


### PR DESCRIPTION
## Summary

Add `MCPSecurityAgent` detection and regression fixtures for MCP configs that weaken tool-call allowlists via wildcards, tool aliases, or nested permission blocks.

## Motivation

Issue #82 asks for fixtures covering allowlist-bypass patterns in project-local MCP configs. Without detection, a malicious repo can ship a config that appears restricted but silently grants broad tool access after folder trust.

## Changes

- Add `_checkAllowlistBypass()` in `cli/agents/mcp-security-agent.js`:
  - `MCP_ALLOWLIST_WILDCARD` — wildcard in `allowedTools` / `permissions` fields
  - `MCP_TOOL_ALIAS_BYPASS` — `toolAliases` / `aliases` mappings
  - `MCP_NESTED_PERMISSION_OVERRIDE` — nested `toolPolicy` / `toolAccess` with wildcard expansion
- Add `cli/__tests__/mcp-allowlist-bypass.test.js` with 2 unsafe + 1 safe fixture
- Update `CHANGELOG.md`

## Tests

```bash
node --test cli/__tests__/mcp-allowlist-bypass.test.js
npm test
```

Result: **304 passed**, 0 failures.

## Notes

- Scoped to project-local configs (same gate as `MCP_AUTO_LAUNCH_ON_TRUST` / `MCP_ENV_SECRET_PASSTHROUGH`)
- Reviewed with composer-2.5: COMMENT (shippable; nested dedup refined per review)

Fixes #82