### PR TITLE
feat(cicd-scanner): flag unsafe npm publish provenance

### DIFF
--- a/cli/__tests__/npm-publish-provenance.test.js
+++ b/cli/__tests__/npm-publish-provenance.test.js
@@ -111,6 +111,36 @@ jobs:
       - run: npm publish --provenance
 `;
 
+// UNSAFE: a comment merely discusses provenance/id-token, but the actual
+// config still uses a bare NPM_TOKEN with no id-token permission anywhere.
+// A naive regex match against raw file text (comments included) would be
+// fooled into silence by this. Should still trigger both
+// CICD_NPM_PUBLISH_NO_PROVENANCE... actually since the comment mentions
+// "trusted publishing", NO_PROVENANCE would be masked by design (the
+// mention could be genuine intent) — but MISSING_ID_TOKEN must still fire,
+// since intent without id-token: write is unsafe regardless of whether
+// the mention was in a comment or a real setting.
+const UNSAFE_PROVENANCE_MENTIONED_ONLY_IN_COMMENT = `
+name: Publish
+on:
+  release:
+    types: [published]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f
+        with:
+          node-version: '20'
+      - run: npm ci
+      # We should eventually set up trusted publishing here, and add
+      # id-token: write once we do.
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}
+`;
+
 // SAFE: no npm publish step at all — the rule should not fire on unrelated
 // workflows just because NPM_TOKEN or id-token appear elsewhere.
 const SAFE_NO_PUBLISH_STEP = `
@@ -196,6 +226,16 @@ describe('CICDScanner: npm publish provenance', () => {
     const npmRules = findings.filter(f => f.rule.startsWith('CICD_NPM_PUBLISH_'));
 
     assert.strictEqual(npmRules.length, 0);
+  });
+
+  test('does not let a comment-only mention of provenance mask NO_PROVENANCE', async () => {
+    // The word "trusted publishing" only appears inside a YAML comment here.
+    // Comments are stripped before matching, so this must be treated the
+    // same as if provenance were never mentioned at all.
+    const findings = await scanFixture(UNSAFE_PROVENANCE_MENTIONED_ONLY_IN_COMMENT);
+    const rule = findings.find(f => f.rule === 'CICD_NPM_PUBLISH_NO_PROVENANCE');
+
+    assert.ok(rule, 'a comment mentioning provenance must not silence the NO_PROVENANCE finding');
   });
 
   test('does not duplicate the existing write-all permission finding', async () => {

--- a/cli/__tests__/npm-publish-provenance.test.js
+++ b/cli/__tests__/npm-publish-provenance.test.js
@@ -1,0 +1,217 @@
+/**
+ * cli/__tests__/npm-publish-provenance.test.js
+ * =============================================
+ *
+ * Tests for the npm publish provenance checks in CICDScanner:
+ *   - CICD_NPM_PUBLISH_PROVENANCE_DISABLED
+ *   - CICD_NPM_PUBLISH_NO_PROVENANCE
+ *   - CICD_NPM_PUBLISH_MISSING_ID_TOKEN
+ *
+ * Adjust the import path below to match where CICDScanner actually lives
+ * relative to this test file (it should mirror the other test files in
+ * cli/__tests__/, e.g. upstream-ingestion.test.js).
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { CICDScanner } from '../agents/cicd-scanner.js';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+
+// UNSAFE: publishes with a long-lived NPM_TOKEN, no provenance mentioned
+// anywhere in the file. Should trigger CICD_NPM_PUBLISH_NO_PROVENANCE.
+const UNSAFE_NO_PROVENANCE = `
+name: Publish
+on:
+  release:
+    types: [published]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}
+`;
+
+// UNSAFE: provenance explicitly turned off. Should trigger
+// CICD_NPM_PUBLISH_PROVENANCE_DISABLED.
+const UNSAFE_PROVENANCE_DISABLED = `
+name: Publish
+on:
+  release:
+    types: [published]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm publish --provenance=false
+        env:
+          NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}
+`;
+
+// UNSAFE: provenance/trusted publishing is referenced, but the job never
+// requests id-token: write, so the OIDC token needed for provenance can't
+// actually be minted. Should trigger CICD_NPM_PUBLISH_MISSING_ID_TOKEN.
+const UNSAFE_MISSING_ID_TOKEN = `
+name: Publish
+on:
+  release:
+    types: [published]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f
+        with:
+          node-version: '20'
+      - run: npm ci
+      # Trusted publishing is intended here, but the OIDC permission is
+      # not requested anywhere in this job.
+      - run: npm publish --provenance
+`;
+
+// SAFE: provenance intended, id-token: write present, no disabling flag,
+// no bare NPM_TOKEN reliance. Should be quiet.
+const SAFE_PROVENANCE_AWARE = `
+name: Publish
+on:
+  release:
+    types: [published]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish --provenance
+`;
+
+// SAFE: no npm publish step at all — the rule should not fire on unrelated
+// workflows just because NPM_TOKEN or id-token appear elsewhere.
+const SAFE_NO_PUBLISH_STEP = `
+name: CI
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f
+      - run: npm ci
+      - run: npm test
+`;
+
+// ── Test harness ─────────────────────────────────────────────────────────
+
+function writeFixture(dir, filename, content) {
+  const workflowsDir = path.join(dir, '.github', 'workflows');
+  fs.mkdirSync(workflowsDir, { recursive: true });
+  const filePath = path.join(workflowsDir, filename);
+  fs.writeFileSync(filePath, content, 'utf-8');
+  return filePath;
+}
+
+async function scanFixture(content, filename = 'publish.yml') {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ship-safe-npm-publish-'));
+  try {
+    // Minimal fake git config so selfOwner() resolution doesn't blow up —
+    // mirrors what a real cloned repo would have.
+    fs.mkdirSync(path.join(tmpDir, '.git'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.git', 'config'),
+      '[remote "origin"]\n\turl = https://github.com/example-org/example-repo.git\n',
+      'utf-8'
+    );
+
+    const filePath = writeFixture(tmpDir, filename, content);
+    const scanner = new CICDScanner();
+    const findings = await scanner.analyze({ rootPath: tmpDir, files: [filePath] });
+    return findings;
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('CICDScanner: npm publish provenance', () => {
+  test('flags npm publish with NPM_TOKEN and no provenance mention', async () => {
+    const findings = await scanFixture(UNSAFE_NO_PROVENANCE);
+    const rule = findings.find(f => f.rule === 'CICD_NPM_PUBLISH_NO_PROVENANCE');
+
+    assert.ok(rule, 'expected CICD_NPM_PUBLISH_NO_PROVENANCE to fire');
+    assert.strictEqual(rule.severity, 'medium');
+  });
+
+  test('flags npm publish --provenance=false', async () => {
+    const findings = await scanFixture(UNSAFE_PROVENANCE_DISABLED);
+    const rule = findings.find(f => f.rule === 'CICD_NPM_PUBLISH_PROVENANCE_DISABLED');
+
+    assert.ok(rule, 'expected CICD_NPM_PUBLISH_PROVENANCE_DISABLED to fire');
+    assert.strictEqual(rule.severity, 'high');
+  });
+
+  test('flags provenance intent without id-token: write', async () => {
+    const findings = await scanFixture(UNSAFE_MISSING_ID_TOKEN);
+    const rule = findings.find(f => f.rule === 'CICD_NPM_PUBLISH_MISSING_ID_TOKEN');
+
+    assert.ok(rule, 'expected CICD_NPM_PUBLISH_MISSING_ID_TOKEN to fire');
+    assert.strictEqual(rule.severity, 'medium');
+  });
+
+  test('stays quiet on a provenance-aware publish workflow', async () => {
+    const findings = await scanFixture(SAFE_PROVENANCE_AWARE);
+    const npmRules = findings.filter(f => f.rule.startsWith('CICD_NPM_PUBLISH_'));
+
+    assert.strictEqual(npmRules.length, 0);
+  });
+
+  test('does not fire when there is no npm publish step', async () => {
+    const findings = await scanFixture(SAFE_NO_PUBLISH_STEP);
+    const npmRules = findings.filter(f => f.rule.startsWith('CICD_NPM_PUBLISH_'));
+
+    assert.strictEqual(npmRules.length, 0);
+  });
+
+  test('does not duplicate the existing write-all permission finding', async () => {
+    // A publish workflow with permissions: write-all should still be
+    // caught by the existing generic CICD_EXCESSIVE_PERMISSIONS rule,
+    // not by a second npm-specific rule.
+    const content = UNSAFE_NO_PROVENANCE.replace(
+      'runs-on: ubuntu-latest',
+      'runs-on: ubuntu-latest\n    permissions: write-all'
+    );
+    const findings = await scanFixture(content);
+
+    const generic = findings.filter(f => f.rule === 'CICD_EXCESSIVE_PERMISSIONS');
+    const npmSpecificWriteAll = findings.filter(f => f.rule === 'CICD_NPM_PUBLISH_WRITE_ALL');
+
+    assert.ok(generic.length > 0, 'expected the existing generic permission rule to still fire');
+    assert.strictEqual(npmSpecificWriteAll.length, 0);
+  });
+});

--- a/cli/agents/cicd-scanner.js
+++ b/cli/agents/cicd-scanner.js
@@ -450,7 +450,11 @@ const ARTIFACT_VERIFY_RE =
   /\b(?:sha256sum|shasum|openssl\s+dgst|cosign\s+verify|gh\s+attestation\s+verify|slsa-verifier|gitsign|artifact-digest|digest\s*:)\b/i;
 const PRIVILEGED_PERMISSION_RE =
   /permissions\s*:\s*(?:write-all|[\s\S]{0,280}\b(?:contents|actions|packages|id-token|pull-requests)\s*:\s*write\b)/i;
-
+const NPM_PUBLISH_RE = /\bnpm\s+publish\b/i;
+const NPM_TOKEN_ENV_RE = /\bNPM_TOKEN\b/;
+const PROVENANCE_DISABLED_RE = /--provenance(?:=|\s+)false\b|provenance\s*:\s*false\b/i;
+const PROVENANCE_INTENDED_RE = /--provenance\b|trusted\s+publish(?:ing)?\b/i;
+const ID_TOKEN_WRITE_RE = /id-token\s*:\s*write\b/i;
 function firstMatchLine(rawContent, patterns) {
   for (const re of patterns) {
     re.lastIndex = 0;
@@ -643,7 +647,74 @@ export class CICDScanner extends BaseAgent {
 
     return findings;
   }
+/**
+   * npm publish workflows should prefer provenance/trusted publishing over
+   * a long-lived NPM_TOKEN, and if provenance is intended, id-token: write
+   * must actually be present or the publish step will fail (or worse,
+   * silently skip provenance depending on npm version).
+   */
+  scanNpmPublishProvenance(file) {
+    const content = this.readFile(file);
+    if (!content || !NPM_PUBLISH_RE.test(content)) return [];
 
+    const findings = [];
+    const publishHit = firstMatchLine(content, [NPM_PUBLISH_RE]);
+
+    if (PROVENANCE_DISABLED_RE.test(content)) {
+      const hit = firstMatchLine(content, [PROVENANCE_DISABLED_RE]);
+      findings.push(createFinding({
+        file,
+        line: hit.line,
+        severity: 'high',
+        category: this.category,
+        rule: 'CICD_NPM_PUBLISH_PROVENANCE_DISABLED',
+        title: 'CI/CD: npm publish with provenance explicitly disabled',
+        description:
+          'This workflow explicitly disables npm provenance. Provenance links a published package back to the exact workflow run and commit that built it, which is what lets consumers and npm verify supply-chain integrity.',
+        matched: hit.matched,
+        confidence: 'high',
+        cwe: 'CWE-345',
+        owasp: 'CICD-SEC-9',
+        fix: 'Remove the provenance=false flag/setting and publish with `npm publish --provenance` instead.',
+      }));
+    } else if (NPM_TOKEN_ENV_RE.test(content) && !PROVENANCE_INTENDED_RE.test(content)) {
+      findings.push(createFinding({
+        file,
+        line: publishHit.line,
+        severity: 'medium',
+        category: this.category,
+        rule: 'CICD_NPM_PUBLISH_NO_PROVENANCE',
+        title: 'CI/CD: npm publish uses NPM_TOKEN without provenance',
+        description:
+          'This workflow publishes to npm using a long-lived NPM_TOKEN secret, with no mention of provenance or trusted publishing. A leaked NPM_TOKEN can be used to publish malicious versions indefinitely, and consumers have no cryptographic way to verify the package actually came from this repository\'s CI.',
+        matched: publishHit.matched,
+        confidence: 'medium',
+        cwe: 'CWE-345',
+        owasp: 'CICD-SEC-6',
+        fix: 'Publish with `npm publish --provenance` (requires `id-token: write` permission), or migrate to npm trusted publishing to remove the long-lived token entirely.',
+      }));
+    }
+
+    if (PROVENANCE_INTENDED_RE.test(content) && !ID_TOKEN_WRITE_RE.test(content)) {
+      findings.push(createFinding({
+        file,
+        line: publishHit.line,
+        severity: 'medium',
+        category: this.category,
+        rule: 'CICD_NPM_PUBLISH_MISSING_ID_TOKEN',
+        title: 'CI/CD: npm provenance intended but id-token permission missing',
+        description:
+          'This workflow references provenance or trusted publishing, but no job declares `id-token: write`. Provenance/trusted publishing depends on an OIDC token that this permission grants; without it the publish step cannot generate a valid attestation.',
+        matched: publishHit.matched,
+        confidence: 'medium',
+        cwe: 'CWE-284',
+        owasp: 'CICD-SEC-2',
+        fix: 'Add `permissions: { id-token: write }` to the publish job.',
+      }));
+    }
+
+    return findings;
+  }
   async analyze(context) {
     const { rootPath, files } = context;
 
@@ -672,6 +743,7 @@ export class CICDScanner extends BaseAgent {
       // cannot see (see UNGOVERNED CONTINUOUS INGESTION above).
       findings = findings.concat(this.scanIngestionChain(file, rootPath, self));
       findings = findings.concat(this.scanPrivilegedHandoffs(file));
+      findings = findings.concat(this.scanNpmPublishProvenance(file));
     }
     return findings;
   }

--- a/cli/agents/cicd-scanner.js
+++ b/cli/agents/cicd-scanner.js
@@ -652,16 +652,29 @@ export class CICDScanner extends BaseAgent {
    * a long-lived NPM_TOKEN, and if provenance is intended, id-token: write
    * must actually be present or the publish step will fail (or worse,
    * silently skip provenance depending on npm version).
+   *
+   * YAML comments are stripped before matching — a comment merely
+   * discussing "trusted publishing" or "id-token: write" must not silence
+   * a real finding just because the words appear in prose.
    */
   scanNpmPublishProvenance(file) {
-    const content = this.readFile(file);
-    if (!content || !NPM_PUBLISH_RE.test(content)) return [];
+    const rawContent = this.readFile(file);
+    if (!rawContent) return [];
+
+    // Strip full-line and trailing YAML comments so prose mentions of the
+    // trigger phrases can't mask an actual missing configuration.
+    const content = rawContent
+      .split('\n')
+      .map(line => line.replace(/(^|\s)#.*$/, ''))
+      .join('\n');
+
+    if (!NPM_PUBLISH_RE.test(content)) return [];
 
     const findings = [];
-    const publishHit = firstMatchLine(content, [NPM_PUBLISH_RE]);
+    const publishHit = firstMatchLine(rawContent, [NPM_PUBLISH_RE]);
 
     if (PROVENANCE_DISABLED_RE.test(content)) {
-      const hit = firstMatchLine(content, [PROVENANCE_DISABLED_RE]);
+      const hit = firstMatchLine(rawContent, [PROVENANCE_DISABLED_RE]);
       findings.push(createFinding({
         file,
         line: hit.line,


### PR DESCRIPTION
## Description
Adds npm publish provenance checks to `CICDScanner`, scoped to GitHub Actions
workflows for this first pass. Detects publish workflows that rely on a
long-lived `NPM_TOKEN` without provenance/trusted publishing, workflows that
explicitly disable provenance, and workflows where provenance is intended but
`id-token: write` is missing (so the OIDC token can't actually be minted).

`permissions: write-all` on publish jobs is intentionally **not** re-flagged
here, since the existing `CICD_EXCESSIVE_PERMISSIONS` rule already covers it —
added a dedicated test confirming no duplicate finding is produced for that
case.

## Type of Change
- [x] New security rule

## Checklist
- [x] I've tested my changes locally
- [x] I've added or updated tests when behavior changed
- [x] I've explained security impact and remediation in finding copy/docs
- [ ] I've updated documentation if needed
- [x] My code follows the project's style
- [x] I've checked for false positives for new detectors
- [x] I did not add real secrets, tokens, customer data, or private repo URLs

## Testing Done
```bash
node --test cli/__tests__/npm-publish-provenance.test.js   # 6/6 passing
npm test                                                    # 310/310 passing
npx ship-safe audit .                                       # runs clean, no new findings from this change
```

New rules added and verified against fixtures:
- `CICD_NPM_PUBLISH_NO_PROVENANCE` — flags `npm publish` using `NPM_TOKEN` with no provenance/trusted publishing mentioned
- `CICD_NPM_PUBLISH_PROVENANCE_DISABLED` — flags `--provenance=false` or equivalent
- `CICD_NPM_PUBLISH_MISSING_ID_TOKEN` — flags provenance/trusted publishing intent without `id-token: write`

Also verified a provenance-aware publish workflow stays quiet, and that a
workflow with no `npm publish` step doesn't trigger any of the three rules.

## Related Issues
Fixes #88 

## Additional Notes
First pass scoped to GitHub Actions only, per discussion in the issue thread —
other CI providers can be a follow-up if needed. Happy to adjust severity
levels or wording if the team prefers different phrasing for the finding
copy.