### PR TITLE
Make the fork CI approval gate visible

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,3 +40,10 @@ Fixes #(issue number)
 ## Additional Notes
 
 Any other context for reviewers.
+
+---
+
+> **First time contributing?** Workflows on fork pull requests wait for a
+> maintainer to approve them, so you may see no checks here at first. That is
+> expected and there is nothing you need to do. See
+> [CONTRIBUTING.md](../CONTRIBUTING.md#ci-on-your-pull-request).

--- a/.github/workflows/pending-ci-notice.yml
+++ b/.github/workflows/pending-ci-notice.yml
@@ -1,0 +1,81 @@
+name: Pending CI notice
+
+# Workflows on pull requests from forks wait for a maintainer to approve them.
+# Nothing surfaces that to either side: the contributor sees a pull request with
+# no checks and no explanation, and the held run is absent from the default runs
+# listing, so a maintainer only finds it by querying with an explicit status
+# filter. This posts a one-time comment on any pull request in that state, so the
+# contributor knows why it is quiet and the maintainer gets a notification.
+#
+# Runs on a schedule rather than on the pull request itself. A trigger that fires
+# for fork pull requests without approval would run in the base repository's
+# context with its secrets, which is the exact pattern this project's own
+# CI rules flag. A scheduled job needs no such privilege.
+
+on:
+  schedule:
+    - cron: '*/20 * * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: read          # list runs awaiting approval
+  pull-requests: write   # post the notice
+
+concurrency:
+  group: pending-ci-notice
+  cancel-in-progress: false
+
+jobs:
+  notice:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Comment on pull requests whose CI is awaiting approval
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          MARKER='<!-- pending-ci-notice -->'
+
+          # Runs held for approval do not appear in the default listing; the
+          # status filter is the only way to see them.
+          SHAS="$(gh api "repos/$REPO/actions/runs?status=action_required&per_page=50" \
+                    --jq '.workflow_runs[].head_sha' | sort -u || true)"
+
+          if [ -z "$SHAS" ]; then
+            echo "No runs are awaiting approval."
+            exit 0
+          fi
+
+          for SHA in $SHAS; do
+            PR="$(gh api "repos/$REPO/commits/$SHA/pulls" \
+                    --jq '[.[] | select(.state == "open")][0].number // empty' 2>/dev/null || true)"
+
+            if [ -z "$PR" ]; then
+              echo "No open pull request for $SHA, skipping."
+              continue
+            fi
+
+            # One notice per pull request, however many runs are queued for it.
+            if gh api "repos/$REPO/issues/$PR/comments" --paginate --jq '.[].body' \
+                 | grep -qF "$MARKER"; then
+              echo "PR #$PR already has a notice."
+              continue
+            fi
+
+            echo "Notifying PR #$PR"
+            gh pr comment "$PR" --repo "$REPO" --body "$MARKER
+          Heads up: CI on this pull request is waiting for a maintainer to approve it.
+
+          That is the default for pull requests from forks and it is not a problem with your branch. There is nothing you need to do, and the checks will appear once a maintainer approves the run.
+
+          If you want to check your work in the meantime:
+
+          \`\`\`bash
+          node --test cli/__tests__/*.test.js
+          npx eslint cli/
+          \`\`\`"
+          done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,25 @@ node cli/bin/ship-safe.js init
 npm run ship-safe scan .
 ```
 
+## CI on Your Pull Request
+
+Workflows on pull requests from forks wait for a maintainer to approve them
+before they run. On your first pull request you will usually see no checks at
+all for a while. That is expected, it is not a problem with your branch, and
+there is nothing you need to do.
+
+This repository builds a security scanner, so running code from a fork
+automatically is a risk we would rather not take. The approval is a deliberate
+gate, not an oversight.
+
+Once approved you get the full matrix: Node 18, 20, and 22, plus the
+integration suite. Before pushing you can run the same checks locally:
+
+```bash
+node --test cli/__tests__/*.test.js
+npx eslint cli/
+```
+
 ## Community
 
 - Be respectful and inclusive

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ship-safe",
   "version": "9.6.2",
-  "description": "AI-powered multi-agent security platform. 29 agents scan 80+ attack classes including AI integration supply chain (Vercel-class attacks), Hermes Agent deployments (ASI-01–ASI-10), tool registry poisoning, function-call injection, skill permission drift, and agent attestation. Ship Safe × Hermes Agent.",
+  "description": "AI-powered multi-agent security platform. 29 agents scan 80+ attack classes including AI integration supply chain (Vercel-class attacks), Hermes Agent deployments (ASI-01\u2013ASI-10), tool registry poisoning, function-call injection, skill permission drift, and agent attestation. Ship Safe \u00d7 Hermes Agent.",
   "main": "cli/index.js",
   "bin": {
     "ship-safe": "cli/bin/ship-safe.js"
@@ -13,7 +13,8 @@
     "benchmark:corpus:write": "node benchmarks/run.mjs --write",
     "lint": "eslint cli/",
     "lint:fix": "eslint cli/ --fix",
-    "ship-safe": "node cli/bin/ship-safe.js"
+    "ship-safe": "node cli/bin/ship-safe.js",
+    "ci:pending": "gh api \"repos/asamassekou10/ship-safe/actions/runs?status=action_required&per_page=50\" --jq '.workflow_runs[] | \"\\(.created_at[0:16])  \\(.name)  [\\(.head_branch)]  run=\\(.id)  approve: gh api --method POST repos/asamassekou10/ship-safe/actions/runs/\\(.id)/approve\"'"
   },
   "keywords": [
     "security",


### PR DESCRIPTION
Workflows on fork pull requests wait for maintainer approval, and nothing surfaces that to either side.

- **The contributor** sees a pull request with no checks and no explanation, which reads as being ignored.
- **The maintainer** sees nothing at all. Runs held for approval are absent from the default runs listing, so finding them needs an explicit `?status=action_required` filter that nobody would guess.

Two runs on #74 sat unnoticed from 1 to 2 August. My own first check for them looked in the wrong place and reported none, which is the clearest evidence the current state is not discoverable.

## Three layers

**Docs** in `CONTRIBUTING.md` and the PR template, including that the gate is deliberate rather than an oversight: this repository builds a security scanner, and running fork code automatically is a risk worth declining. Also lists the local commands that reproduce CI so a contributor can self-check while waiting.

**`npm run ci:pending`** lists runs awaiting approval and prints the approve command next to each.

**A scheduled notifier** (`.github/workflows/pending-ci-notice.yml`) that finds held runs and posts a one-time comment on the pull request. Docs only help contributors who read them, and neither docs nor a script give the maintainer anything to react to. This closes the loop from the other side.

## Why scheduled, not triggered by the pull request

The trigger that fires for fork pull requests without approval runs in the base repository's context with its secrets. Our own `CICD_PR_TARGET_CHECKOUT` rule flags any use of it at critical severity, and shipping a pattern our scanner condemns is not a trade worth making. A scheduled job needs no such privilege.

The workflow avoids naming that trigger even in its comments, since the rule matches the bare string. Worth knowing if anyone edits it later.

## Verification

- `CICDScanner` on the new workflow: **0 findings**
- All three logic paths exercised against the live API: empty result, closed-pull-request skip, and marker idempotency
- One comment per pull request however many runs are queued, enforced by a hidden marker
- Only open pull requests are notified
- 315/315 tests, `eslint` clean, release self-scan gate still exits 0
