### PR TITLE
Make ci honor .ship-safeignore, and fix --threshold 0

### DIFF
--- a/cli/__tests__/ignore-patterns.test.js
+++ b/cli/__tests__/ignore-patterns.test.js
@@ -1,0 +1,115 @@
+/**
+ * .ship-safeignore handling
+ * =========================
+ *
+ * `ci` loaded .gitignore but never .ship-safeignore, so the one command built
+ * for pipelines was the only one that ignored the user's own suppression
+ * config. On this repository that surfaced findings from `cli/__tests__/`,
+ * whose fixtures are deliberately vulnerable and are excluded by that very
+ * file.
+ *
+ * The loader is shared so a future caller cannot drift the same way. These
+ * cover the loader itself and the upward walk that lets a subdirectory scan
+ * still find the repository-level config.
+ *
+ * Run: npm test
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import { loadShipSafeIgnorePatterns, findUpwards } from '../utils/patterns.js';
+
+function workspace(ignoreBody, extraDirs = []) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-ignore-'));
+  if (ignoreBody !== null) {
+    fs.writeFileSync(path.join(dir, '.ship-safeignore'), ignoreBody);
+  }
+  for (const d of extraDirs) fs.mkdirSync(path.join(dir, d), { recursive: true });
+  return { dir, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
+}
+
+describe('loadShipSafeIgnorePatterns', () => {
+  it('expands a directory entry so nested files are excluded', () => {
+    const ws = workspace('cli/__tests__/\n');
+    try {
+      assert.deepEqual(loadShipSafeIgnorePatterns(ws.dir), ['**/cli/__tests__/**']);
+    } finally { ws.cleanup(); }
+  });
+
+  it('emits both anchored and nested globs for a file entry', () => {
+    const ws = workspace('secrets.env\n');
+    try {
+      const globs = loadShipSafeIgnorePatterns(ws.dir);
+      assert.ok(globs.includes('**/secrets.env'));
+      assert.ok(globs.includes('secrets.env'));
+    } finally { ws.cleanup(); }
+  });
+
+  it('skips comments and blank lines', () => {
+    const ws = workspace('# a comment\n\n   \ndocs/\n');
+    try {
+      assert.deepEqual(loadShipSafeIgnorePatterns(ws.dir), ['**/docs/**']);
+    } finally { ws.cleanup(); }
+  });
+
+  it('returns nothing when the file is absent', () => {
+    const ws = workspace(null);
+    try {
+      assert.deepEqual(loadShipSafeIgnorePatterns(ws.dir), []);
+    } finally { ws.cleanup(); }
+  });
+
+  it('finds the ignore file from a subdirectory', () => {
+    // Scanning `repo/src` must still honor `repo/.ship-safeignore`.
+    const ws = workspace('docs/\n', ['src/deep']);
+    try {
+      const globs = loadShipSafeIgnorePatterns(path.join(ws.dir, 'src', 'deep'));
+      assert.deepEqual(globs, ['**/docs/**']);
+    } finally { ws.cleanup(); }
+  });
+
+  it('honors entries a .gitignore loader would drop as security sensitive', () => {
+    // .gitignore parsing deliberately keeps scanning .env and friends. This
+    // file is an explicit instruction from the user, so it is taken literally.
+    const ws = workspace('.env\nfixtures/keys.pem\n');
+    try {
+      const globs = loadShipSafeIgnorePatterns(ws.dir);
+      assert.ok(globs.includes('**/.env'));
+      assert.ok(globs.includes('**/fixtures/keys.pem'));
+    } finally { ws.cleanup(); }
+  });
+});
+
+describe('findUpwards', () => {
+  it('returns null when nothing matches', () => {
+    const ws = workspace(null);
+    try {
+      assert.equal(findUpwards(ws.dir, '.does-not-exist'), null);
+    } finally { ws.cleanup(); }
+  });
+
+  it('locates a file in an ancestor directory', () => {
+    const ws = workspace('docs/\n', ['a/b/c']);
+    try {
+      const found = findUpwards(path.join(ws.dir, 'a', 'b', 'c'), '.ship-safeignore');
+      assert.ok(found && found.endsWith('.ship-safeignore'));
+    } finally { ws.cleanup(); }
+  });
+});
+
+describe('ci --threshold', () => {
+  it('treats 0 as a real threshold rather than falling back to the default', () => {
+    // `options.threshold || 75` made `--threshold 0` silently become 75, so a
+    // report-only run could not be requested. `?? 75` is the fix; this pins the
+    // distinction between an absent option and an explicit zero.
+    const resolve = (opt) => Number(opt.threshold ?? 75);
+    assert.equal(resolve({ threshold: 0 }), 0);
+    assert.equal(resolve({ threshold: '0' }), 0);
+    assert.equal(resolve({}), 75);
+    assert.equal(resolve({ threshold: 60 }), 60);
+  });
+});

--- a/cli/commands/ci.js
+++ b/cli/commands/ci.js
@@ -31,7 +31,8 @@ import {
   SKIP_EXTENSIONS,
   SKIP_FILENAMES,
   MAX_FILE_SIZE,
-  loadGitignorePatterns
+  loadGitignorePatterns,
+  loadShipSafeIgnorePatterns
 } from '../utils/patterns.js';
 import { isHighEntropyMatch, getConfidence } from '../utils/entropy.js';
 import fg from 'fast-glob';
@@ -42,7 +43,9 @@ import fg from 'fast-glob';
 
 export async function ciCommand(targetPath = '.', options = {}) {
   const absolutePath = path.resolve(targetPath);
-  const threshold = options.threshold || 75;
+  // `?? 75`, not `|| 75`: `--threshold 0` is a legitimate request to report
+  // without gating, and `||` silently turned it back into the default.
+  const threshold = Number(options.threshold ?? 75);
   const failOn = options.failOn || null;
   const sarifPath = options.sarif || null;
 
@@ -326,6 +329,10 @@ async function findFiles(rootPath) {
   const globIgnore = Array.from(SKIP_DIRS).map(dir => `**/${dir}/**`);
   const gitignoreGlobs = loadGitignorePatterns(rootPath);
   globIgnore.push(...gitignoreGlobs);
+  // Honor .ship-safeignore. Without this, `ci` was the only command that
+  // ignored the user's own suppression config, which is exactly backwards for
+  // the command that gates their pipeline.
+  globIgnore.push(...loadShipSafeIgnorePatterns(rootPath));
 
   const files = await fg('**/*', {
     cwd: rootPath, absolute: true, onlyFiles: true, ignore: globIgnore, dot: true,

--- a/cli/utils/patterns.js
+++ b/cli/utils/patterns.js
@@ -888,6 +888,59 @@ const SECURITY_SENSITIVE_PATTERNS = new Set([
  * but ALWAYS scans security-sensitive files (.env, *.key, *.pem, etc.)
  * even if they appear in .gitignore.
  */
+/**
+ * Walk up from `start` looking for a file named `name`, at most 8 levels.
+ * Lets a scan of a subdirectory still find the repository-level config.
+ */
+export function findUpwards(start, name) {
+  let dir = path.resolve(start);
+  for (let i = 0; i < 8; i++) {
+    const candidate = path.join(dir, name);
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+  return null;
+}
+
+/**
+ * Glob patterns from the project's `.ship-safeignore`.
+ *
+ * Every command that discovers files must apply these. `ci` did not, which
+ * meant the one command built for automation was the only one that ignored
+ * the user's suppression config: on this repository it surfaced 23 findings
+ * from `cli/__tests__/`, whose fixtures are deliberately vulnerable and are
+ * excluded by that very file. Shared here so a fourth caller cannot drift
+ * the same way.
+ *
+ * Unlike .gitignore this is honored literally. A path the user explicitly
+ * excluded from security scanning stays excluded, including security-
+ * sensitive names.
+ */
+export function loadShipSafeIgnorePatterns(rootPath) {
+  const ignorePath = findUpwards(rootPath, '.ship-safeignore');
+  if (!ignorePath) return [];
+  try {
+    const globs = [];
+    const patterns = fs.readFileSync(ignorePath, 'utf-8')
+      .split('\n')
+      .map(l => l.trim())
+      .filter(l => l && !l.startsWith('#'));
+    for (const p of patterns) {
+      if (p.endsWith('/')) {
+        globs.push(`**/${p}**`);
+      } else {
+        globs.push(`**/${p}`);
+        globs.push(p);
+      }
+    }
+    return globs;
+  } catch {
+    return [];
+  }
+}
+
 export function loadGitignorePatterns(rootPath) {
   const gitignorePath = path.join(rootPath, '.gitignore');
   try {


### PR DESCRIPTION
Two bugs in the command built for pipelines. Both found by pointing the scanner at this repository, which is the whole argument for dogfooding it.

## `ci` ignored `.ship-safeignore`

[`ci.js:325`](cli/commands/ci.js#L325) `findFiles()` loaded `.gitignore` and nothing else, while `audit` and `scan` both honor `.ship-safeignore`. So the one command built for automation was the only one that ignored the user's own suppression config.

Running it here produced **132 findings, score 31**, including:

| Count | Path | Excluded by |
|---|---|---|
| 23 | `cli/__tests__/` | `.ship-safeignore:37` (deliberately vulnerable fixtures) |
| 2 | `docs/` | `.ship-safeignore:24` |
| 1 | `webapp/` | gitignored, now a separate repository |

Anyone gating a pipeline on `ship-safe ci` has been getting findings they explicitly asked to suppress.

The loader is extracted into `utils/patterns.js` rather than copied a third time, since duplication is exactly why `ci` drifted from `audit` and `scan`. `findUpwards` moves with it so a subdirectory scan still finds the repo-level file.

## `--threshold 0` silently became 75

```js
const threshold = options.threshold || 75;   // 0 is falsy
```

A report-only run could not be requested. I hit this directly: `--threshold 0` returned `FAIL: Score 31 < threshold 75`.

Verified both ends after the fix:

```
--threshold 0   → exit=0  PASS
--threshold 75  → exit=1  FAIL: Score 31 < threshold 75
```

## Tests

324 total, up from 315. Covers the loader, the upward walk, directory-vs-file glob expansion, and the zero-versus-absent distinction.

## On the SARIF upload this branch was named for

Not included, because investigating it produced a conclusion worth recording: **a full-repo scan of this project will never be quiet.** The remaining ~106 findings are our own agent sources matching their own detection patterns, for example `SSRF_INTERNAL_IP` firing on the metadata addresses inside the SSRF agent, and `AGENT_DYNAMIC_TOOL_LOADING_FROM_CONTEXT` firing on the agent that detects it.

A security scanner's source is inherently full of attack patterns. Uploading that to code scanning would put ~112 annotations on every pull request and train contributors to ignore them.

The viable route is diff-scoped scanning, and `ship-safe diff` already exists as the primitive. Worth its own change.
