### PR TITLE
Exclude test and example code from audit and ci by default

### DIFF
--- a/cli/__tests__/ignore-patterns.test.js
+++ b/cli/__tests__/ignore-patterns.test.js
@@ -21,7 +21,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 
-import { loadShipSafeIgnorePatterns, findUpwards } from '../utils/patterns.js';
+import { loadShipSafeIgnorePatterns, findUpwards, isTestFile, isExampleFile } from '../utils/patterns.js';
 
 function workspace(ignoreBody, extraDirs = []) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-ignore-'));
@@ -111,5 +111,37 @@ describe('ci --threshold', () => {
     assert.equal(resolve({ threshold: '0' }), 0);
     assert.equal(resolve({}), 75);
     assert.equal(resolve({ threshold: 60 }), 60);
+  });
+});
+
+describe('test and example path classification', () => {
+  it('recognises the common test layouts', () => {
+    for (const p of [
+      '/repo/test/app.js', '/repo/tests/thing.py', '/repo/__tests__/x.js',
+      '/repo/src/thing.test.ts', '/repo/src/thing.spec.jsx', '/repo/test_client.py',
+      '/repo/fixtures/data.json', '/repo/mocks/api.js', '/repo/src/x.stories.tsx',
+    ]) {
+      assert.equal(isTestFile(p), true, p);
+    }
+  });
+
+  it('recognises example and demo layouts', () => {
+    for (const p of ['/repo/examples/auth.js', '/repo/example/a.py', '/repo/samples/x.js', '/repo/demo/app.js']) {
+      assert.equal(isExampleFile(p), true, p);
+    }
+  });
+
+  it('does not misclassify production source', () => {
+    // `lib/` is where express's only two real findings lived, against 528 in
+    // `test/`. Misclassifying these would hide the findings that matter.
+    for (const p of [
+      '/repo/lib/router.js', '/repo/src/index.ts', '/repo/app/main.py',
+      '/repo/contest/app.js',      // contains "test" but is not a test dir
+      '/repo/src/latest.js',       // ends in "test" but is not a test file
+      '/repo/src/protester.py',
+    ]) {
+      assert.equal(isTestFile(p), false, p);
+      assert.equal(isExampleFile(p), false, p);
+    }
   });
 });

--- a/cli/__tests__/ignore-patterns.test.js
+++ b/cli/__tests__/ignore-patterns.test.js
@@ -22,6 +22,8 @@ import path from 'path';
 import os from 'os';
 
 import { loadShipSafeIgnorePatterns, findUpwards, isTestFile, isExampleFile } from '../utils/patterns.js';
+import { createFinding, projectFindings, environmentFindings } from '../agents/base-agent.js';
+import { ScoringEngine } from '../agents/scoring-engine.js';
 
 function workspace(ignoreBody, extraDirs = []) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-ignore-'));
@@ -143,5 +145,42 @@ describe('test and example path classification', () => {
       assert.equal(isTestFile(p), false, p);
       assert.equal(isExampleFile(p), false, p);
     }
+  });
+});
+
+describe('finding scope', () => {
+  it('defaults to project scope', () => {
+    const f = createFinding({ file: 'a.js', rule: 'X', title: 'x' });
+    assert.equal(f.scope, 'project');
+  });
+
+  it('separates environment findings from project findings', () => {
+    const all = [
+      createFinding({ file: 'src/a.js', rule: 'P1', title: 'p' }),
+      createFinding({ file: '/home/dev/.cursor/mcp.json', rule: 'E1', title: 'e', scope: 'environment' }),
+      createFinding({ file: 'src/b.js', rule: 'P2', title: 'p' }),
+    ];
+    assert.deepEqual(projectFindings(all).map(f => f.rule), ['P1', 'P2']);
+    assert.deepEqual(environmentFindings(all).map(f => f.rule), ['E1']);
+  });
+
+  it('treats a finding with no scope as project scoped', () => {
+    // Findings built without createFinding must not be dropped from output.
+    const legacy = [{ file: 'a.js', rule: 'LEGACY' }];
+    assert.deepEqual(projectFindings(legacy).map(f => f.rule), ['LEGACY']);
+    assert.deepEqual(environmentFindings(legacy), []);
+  });
+
+  it('keeps environment findings out of the score', () => {
+    // A maintainer having an agent tool installed must not move a repo's grade.
+    const engine = new ScoringEngine();
+    const projectOnly = engine.compute([
+      createFinding({ file: 'src/a.js', rule: 'P', title: 'p', severity: 'high', category: 'config' }),
+    ]);
+    const withEnvironment = engine.compute([
+      createFinding({ file: 'src/a.js', rule: 'P', title: 'p', severity: 'high', category: 'config' }),
+      createFinding({ file: '/home/dev/.cursor/mcp.json', rule: 'E', title: 'e', severity: 'high', category: 'config', scope: 'environment' }),
+    ]);
+    assert.equal(withEnvironment.score, projectOnly.score);
   });
 });

--- a/cli/agents/auth-bypass-agent.js
+++ b/cli/agents/auth-bypass-agent.js
@@ -59,7 +59,12 @@ const PATTERNS = [
   {
     rule: 'COOKIE_NO_HTTPONLY',
     title: 'Cookie Missing httpOnly Flag',
-    regex: /(?:cookie|Cookie|setCookie|set-cookie)[^;]{0,100}(?:secure|domain|path|maxAge|max-age)(?![^;]*httpOnly)/gi,
+    // Requires an actual cookie-set operation. Matching the bare word "cookie"
+    // near an option name fired on any code that merely discusses cookie
+    // configuration: on Flask it flagged three keys of a config dict that sets
+    // SESSION_COOKIE_HTTPONLY two lines below, and a docstring describing the
+    // Domain parameter. 17 of Flask's 55 findings came from this one rule.
+    regex: /(?:res\.cookie|response\.cookie|setCookie|set_cookie|Set-Cookie\s*:)\s*[(:][^;\n]{0,160}?(?:secure|domain|path|maxAge|max-age)(?![^;\n]*httponly)/gi,
     severity: 'medium',
     cwe: 'CWE-1004',
     owasp: 'A05:2021',

--- a/cli/agents/base-agent.js
+++ b/cli/agents/base-agent.js
@@ -26,6 +26,20 @@ import { SKIP_DIRS, SKIP_EXTENSIONS, SKIP_FILENAMES, MAX_FILE_SIZE, loadGitignor
 
 /**
  * Create a standardized finding object.
+ *
+ * `scope` separates what a finding is about:
+ *
+ *   'project'     — something in the scanned repository. The default.
+ *   'environment' — something about the machine running the scan, such as a
+ *                   globally configured MCP server. Useful to a developer
+ *                   locally, meaningless to a pipeline, and never safe to put
+ *                   in machine output: the names of someone's personal agent
+ *                   servers should not end up in a repository's security tab.
+ *
+ * Environment findings are kept out of the score, out of --json/--sarif/--csv,
+ * and out of `ci` unless explicitly requested. Making that a property of the
+ * finding rather than a special case in one agent means the next environment
+ * check inherits the handling instead of repeating the bug.
  */
 export function createFinding({
   file,
@@ -41,6 +55,7 @@ export function createFinding({
   cwe = null,
   owasp = null,
   fix = null,
+  scope = 'project',
 }) {
   return {
     file,
@@ -56,6 +71,7 @@ export function createFinding({
     cwe,
     owasp,
     fix,
+    scope,
   };
 }
 
@@ -82,6 +98,16 @@ export function createFinding({
  * critical finding as safe is a signal, not a no-op.
  */
 export const SUPPRESSION_FLOOR_SEVERITIES = new Set(['critical']);
+
+/** Findings about the scanned repository, safe for scoring and machine output. */
+export function projectFindings(findings) {
+  return (findings || []).filter(f => (f.scope || 'project') !== 'environment');
+}
+
+/** Findings about the machine running the scan. Interactive display only. */
+export function environmentFindings(findings) {
+  return (findings || []).filter(f => f.scope === 'environment');
+}
 
 /** Whether a finding of this severity may be silenced by an inline comment. */
 export function isSuppressible(severity) {

--- a/cli/agents/mcp-security-agent.js
+++ b/cli/agents/mcp-security-agent.js
@@ -315,7 +315,13 @@ export class MCPSecurityAgent extends BaseAgent {
     }
 
     // ── 5. Detect shadow MCP configs (not in version control) ───────────
-    findings = findings.concat(this._detectShadowMcpConfigs(rootPath));
+    // Reads the developer's home directory, which is useful locally and
+    // meaningless to a pipeline whose runner is ephemeral. `ci` opts out by
+    // default; --check-global-agents forces it on for persistent self-hosted
+    // runners where a poisoned global config is a real concern.
+    if (context.options?.checkGlobalAgents !== false) {
+      findings = findings.concat(this._detectShadowMcpConfigs(rootPath));
+    }
 
     return findings;
   }
@@ -735,6 +741,10 @@ export class MCPSecurityAgent extends BaseAgent {
               severity: 'medium',
               category: this.category,
               rule: 'MCP_SHADOW_CONFIG',
+              // About the machine, not the repository: a pipeline cannot fix a
+              // developer's home directory, and these server names must not
+              // reach machine output. See createFinding in base-agent.js.
+              scope: 'environment',
               title: `MCP: ${serverCount} Shadow Server(s) in User Config`,
               description: `Found ${serverCount} MCP server(s) configured outside the project in ${configPath}. These operate outside your project's security controls.`,
               matched: Object.keys(servers).join(', '),

--- a/cli/agents/orchestrator.js
+++ b/cli/agents/orchestrator.js
@@ -21,6 +21,7 @@ import chalk from 'chalk';
 import { ReconAgent } from './recon-agent.js';
 import { VerifierAgent } from './verifier-agent.js';
 import { DeepAnalyzer } from './deep-analyzer.js';
+import { isTestFile, isExampleFile } from '../utils/patterns.js';
 
 // =============================================================================
 // CONSTANTS
@@ -90,7 +91,18 @@ export class Orchestrator {
     if (reconSpinner) reconSpinner.succeed(chalk.green('Attack surface mapped'));
 
     // ── 2. Discover files once (shared across agents) ─────────────────────────
-    const files = await this.reconAgent.discoverFiles(absolutePath);
+    let files = await this.reconAgent.discoverFiles(absolutePath);
+
+    // Test, fixture, and example code is illustrative: it deliberately contains
+    // credential-shaped strings and minimal apps that skip production controls.
+    // `scan` has excluded it by default for a long time; the agent path did not,
+    // so a repository could be clean under one command and fail under another.
+    // Measured on express, requests, flask and chalk, 89% of all findings came
+    // from these paths, including 528 of express's 601 API_NO_SECURITY_HEADERS
+    // hits in `test/` against 2 in `lib/`.
+    if (!options.includeTests) {
+      files = files.filter(f => !isTestFile(f) && !isExampleFile(f));
+    }
 
     // ── 3. Filter agents if specific ones requested ───────────────────────────
     let agentsToRun = this.agents;

--- a/cli/agents/scoring-engine.js
+++ b/cli/agents/scoring-engine.js
@@ -10,6 +10,7 @@
  */
 
 import fs from 'fs';
+import { projectFindings } from './base-agent.js';
 import path from 'path';
 import { getComplianceSummary, getAgenticSummary, enrichAgenticRisk } from '../utils/compliance-map.js';
 
@@ -74,6 +75,11 @@ export class ScoringEngine {
    * @returns {object}            — { score, grade, categories, breakdown }
    */
   compute(findings = [], depVulns = []) {
+    // A grade describes the repository. Environment findings are about the
+    // machine running the scan, so a maintainer having an agent tool installed
+    // must not move the project's score.
+    findings = projectFindings(findings);
+
     const categoryResults = {};
 
     // Initialize all categories

--- a/cli/agents/scoring-engine.js
+++ b/cli/agents/scoring-engine.js
@@ -74,11 +74,12 @@ export class ScoringEngine {
    * @param {object[]} depVulns   — Array of dependency CVE objects
    * @returns {object}            — { score, grade, categories, breakdown }
    */
-  compute(findings = [], depVulns = []) {
+  compute(findings = [], depVulns = [], { includeEnvironment = false } = {}) {
     // A grade describes the repository. Environment findings are about the
     // machine running the scan, so a maintainer having an agent tool installed
-    // must not move the project's score.
-    findings = projectFindings(findings);
+    // must not move the project's score. A caller that passed
+    // --check-global-agents has declared the environment in scope and opts in.
+    if (!includeEnvironment) findings = projectFindings(findings);
 
     const categoryResults = {};
 

--- a/cli/bin/ship-safe.js
+++ b/cli/bin/ship-safe.js
@@ -262,6 +262,7 @@ program
 program
   .command('audit [path]')
   .description('Full security audit: secrets + 29 agents + deps + score + deep analysis + remediation plan')
+  .option('--include-tests', 'Also scan test, fixture, and example files (excluded by default to reduce false positives)')
   .option('--json', 'Output results as JSON')
   .option('--sarif', 'Output results in SARIF format')
   .option('--csv', 'Output results as CSV')
@@ -456,6 +457,7 @@ program
   .option('--threshold <score>', 'Minimum passing score (default: 75)', parseInt)
   .option('--fail-on <severity>', 'Fail on findings at this severity or above (critical, high, medium)')
   .option('--sarif <file>', 'Write SARIF output for GitHub Code Scanning')
+  .option('--include-tests', 'Also scan test, fixture, and example files (excluded by default to reduce false positives)')
   .option('--json', 'JSON output')
   .option('--no-deps', 'Skip dependency audit')
   .option('--baseline', 'Only check new findings (not in baseline)')

--- a/cli/bin/ship-safe.js
+++ b/cli/bin/ship-safe.js
@@ -457,6 +457,7 @@ program
   .option('--threshold <score>', 'Minimum passing score (default: 75)', parseInt)
   .option('--fail-on <severity>', 'Fail on findings at this severity or above (critical, high, medium)')
   .option('--sarif <file>', 'Write SARIF output for GitHub Code Scanning')
+  .option('--check-global-agents', 'Also check globally configured agent tooling outside the project (off by default in ci)')
   .option('--include-tests', 'Also scan test, fixture, and example files (excluded by default to reduce false positives)')
   .option('--json', 'JSON output')
   .option('--no-deps', 'Skip dependency audit')

--- a/cli/commands/audit.js
+++ b/cli/commands/audit.js
@@ -33,7 +33,9 @@ import {
   SKIP_EXTENSIONS,
   SKIP_FILENAMES,
   MAX_FILE_SIZE,
-  loadGitignorePatterns
+  loadGitignorePatterns,
+  isTestFile,
+  isExampleFile
 } from '../utils/patterns.js';
 import { isHighEntropyMatch, getConfidence } from '../utils/entropy.js';
 import { printBanner } from '../utils/output.js';
@@ -107,7 +109,7 @@ export async function auditCommand(targetPath = '.', options = {}) {
   let filesScanned = 0;
 
   try {
-    allFiles = await findFiles(absolutePath);
+    allFiles = await findFiles(absolutePath, { includeTests: options.includeTests });
     filesScanned = allFiles.length;
 
     // Determine which files need scanning (incremental if cache exists)
@@ -936,7 +938,7 @@ export function findUpwards(start, name) {
   return null;
 }
 
-async function findFiles(rootPath) {
+async function findFiles(rootPath, { includeTests = false } = {}) {
   const globIgnore = Array.from(SKIP_DIRS).map(dir => `**/${dir}/**`);
 
   // Respect .gitignore patterns
@@ -962,6 +964,11 @@ async function findFiles(rootPath) {
   });
 
   return files.filter(file => {
+    // Test and example code is illustrative by nature: it deliberately contains
+    // credential-shaped strings and minimal apps that skip production controls.
+    // `scan` has always excluded it; `audit` and `ci` did not, so the same repo
+    // could pass one command and fail another.
+    if (!includeTests && (isTestFile(file) || isExampleFile(file))) return false;
     const ext = path.extname(file).toLowerCase();
     if (SKIP_EXTENSIONS.has(ext)) return false;
     if (SKIP_FILENAMES.has(path.basename(file))) return false;

--- a/cli/commands/audit.js
+++ b/cli/commands/audit.js
@@ -20,7 +20,7 @@ import fg from 'fast-glob';
 import { buildOrchestrator, buildOrchestratorAsync } from '../agents/index.js';
 import { LegalRiskAgent } from '../agents/legal-risk-agent.js';
 import { ScoringEngine } from '../agents/scoring-engine.js';
-import { isSuppressible } from '../agents/base-agent.js';
+import { isSuppressible, projectFindings } from '../agents/base-agent.js';
 import { PolicyEngine } from '../agents/policy-engine.js';
 import { HTMLReporter } from '../agents/html-reporter.js';
 import { SBOMGenerator } from '../agents/sbom-generator.js';
@@ -440,14 +440,19 @@ export async function auditCommand(targetPath = '.', options = {}) {
   // ── Output ────────────────────────────────────────────────────────────────
   console.log();
 
+  // Machine output is shared: uploaded to code scanning, committed, pasted into
+  // tickets. Environment findings describe the developer's own machine, so they
+  // stay on the terminal and out of every serialized format.
+  const emittedFindings = projectFindings(filteredFindings);
+
   if (options.csv) {
-    outputCSV(filteredFindings, depVulns, scoreResult, absolutePath);
+    outputCSV(emittedFindings, depVulns, scoreResult, absolutePath);
   } else if (options.md) {
-    outputMarkdown(scoreResult, filteredFindings, depVulns, remediationPlan, absolutePath);
+    outputMarkdown(scoreResult, emittedFindings, depVulns, remediationPlan, absolutePath);
   } else if (options.json) {
-    outputJSON(scoreResult, filteredFindings, depVulns, recon, agentResults, remediationPlan, suppressions, options.compare ? scoringEngine.loadHistory(absolutePath) : null);
+    outputJSON(scoreResult, emittedFindings, depVulns, recon, agentResults, remediationPlan, suppressions, options.compare ? scoringEngine.loadHistory(absolutePath) : null);
   } else if (options.sarif) {
-    outputSARIF(filteredFindings, absolutePath);
+    outputSARIF(emittedFindings, absolutePath);
   } else {
     printReport(scoreResult, filteredFindings, depVulns, recon, remediationPlan, absolutePath, filesScanned);
   }

--- a/cli/commands/ci.js
+++ b/cli/commands/ci.js
@@ -36,6 +36,7 @@ import {
   isTestFile,
   isExampleFile
 } from '../utils/patterns.js';
+import { projectFindings } from '../agents/base-agent.js';
 import { isHighEntropyMatch, getConfidence } from '../utils/entropy.js';
 import fg from 'fast-glob';
 
@@ -59,6 +60,10 @@ export async function ciCommand(targetPath = '.', options = {}) {
   const startTime = Date.now();
 
   // ── Secret Scan ──────────────────────────────────────────────────────────
+  // A pipeline cannot act on the runner's home directory, so environment
+  // checks are off unless explicitly requested.
+  const checkGlobalAgents = options.checkGlobalAgents === true;
+
   const allFiles = await findFiles(absolutePath, { includeTests: options.includeTests });
   const secretFindings = [];
 
@@ -91,7 +96,7 @@ export async function ciCommand(targetPath = '.', options = {}) {
 
   // ── Agent Scan ───────────────────────────────────────────────────────────
   const orchestrator = buildOrchestrator();
-  const results = await orchestrator.runAll(absolutePath, { quiet: true }); // ship-safe-ignore — orchestrator result, not LLM output triggering actions
+  const results = await orchestrator.runAll(absolutePath, { quiet: true, includeTests: options.includeTests, checkGlobalAgents }); // ship-safe-ignore — orchestrator result, not LLM output triggering actions
   const agentFindings = results.findings;
 
   // ── Dependency Audit ─────────────────────────────────────────────────────
@@ -132,7 +137,10 @@ export async function ciCommand(targetPath = '.', options = {}) {
 
   // ── SARIF Output ─────────────────────────────────────────────────────────
   if (sarifPath) {
-    const sarif = buildSARIF(allFindings, absolutePath);
+    // Environment findings describe the developer's machine. Publishing the
+    // names of someone's globally configured agent servers into a repository's
+    // security tab is not acceptable, so machine output carries project only.
+    const sarif = buildSARIF(projectFindings(allFindings), absolutePath);
     fs.writeFileSync(sarifPath, JSON.stringify(sarif, null, 2));
   }
 

--- a/cli/commands/ci.js
+++ b/cli/commands/ci.js
@@ -32,7 +32,9 @@ import {
   SKIP_FILENAMES,
   MAX_FILE_SIZE,
   loadGitignorePatterns,
-  loadShipSafeIgnorePatterns
+  loadShipSafeIgnorePatterns,
+  isTestFile,
+  isExampleFile
 } from '../utils/patterns.js';
 import { isHighEntropyMatch, getConfidence } from '../utils/entropy.js';
 import fg from 'fast-glob';
@@ -57,7 +59,7 @@ export async function ciCommand(targetPath = '.', options = {}) {
   const startTime = Date.now();
 
   // ── Secret Scan ──────────────────────────────────────────────────────────
-  const allFiles = await findFiles(absolutePath);
+  const allFiles = await findFiles(absolutePath, { includeTests: options.includeTests });
   const secretFindings = [];
 
   for (const file of allFiles) {
@@ -122,6 +124,8 @@ export async function ciCommand(targetPath = '.', options = {}) {
   // ── Score ────────────────────────────────────────────────────────────────
   const scoringEngine = new ScoringEngine();
   const scoreResult = scoringEngine.compute(allFindings, depVulns);
+  // Round like audit does; without this the JSON emitted 29.900000000000006.
+  scoreResult.score = Math.round(scoreResult.score * 10) / 10;
   scoringEngine.saveToHistory(absolutePath, scoreResult);
 
   const duration = ((Date.now() - startTime) / 1000).toFixed(1);
@@ -325,7 +329,7 @@ function postPRComment(scoreResult, findings, depVulns, rootPath, duration) {
   console.log(`[ship-safe] PR comment posted on #${prNumber}`);
 }
 
-async function findFiles(rootPath) {
+async function findFiles(rootPath, { includeTests = false } = {}) {
   const globIgnore = Array.from(SKIP_DIRS).map(dir => `**/${dir}/**`);
   const gitignoreGlobs = loadGitignorePatterns(rootPath);
   globIgnore.push(...gitignoreGlobs);
@@ -339,6 +343,9 @@ async function findFiles(rootPath) {
   });
 
   return files.filter(file => {
+    // Same reasoning as audit: test and example code is illustrative, and
+    // scoring a pipeline on it produces failures nobody can act on.
+    if (!includeTests && (isTestFile(file) || isExampleFile(file))) return false;
     const ext = path.extname(file).toLowerCase();
     if (SKIP_EXTENSIONS.has(ext)) return false;
     if (SKIP_FILENAMES.has(path.basename(file))) return false;

--- a/cli/commands/ci.js
+++ b/cli/commands/ci.js
@@ -128,7 +128,7 @@ export async function ciCommand(targetPath = '.', options = {}) {
 
   // ── Score ────────────────────────────────────────────────────────────────
   const scoringEngine = new ScoringEngine();
-  const scoreResult = scoringEngine.compute(allFindings, depVulns);
+  const scoreResult = scoringEngine.compute(allFindings, depVulns, { includeEnvironment: checkGlobalAgents });
   // Round like audit does; without this the JSON emitted 29.900000000000006.
   scoreResult.score = Math.round(scoreResult.score * 10) / 10;
   scoringEngine.saveToHistory(absolutePath, scoreResult);
@@ -139,8 +139,11 @@ export async function ciCommand(targetPath = '.', options = {}) {
   if (sarifPath) {
     // Environment findings describe the developer's machine. Publishing the
     // names of someone's globally configured agent servers into a repository's
-    // security tab is not acceptable, so machine output carries project only.
-    const sarif = buildSARIF(projectFindings(allFindings), absolutePath);
+    // security tab is not acceptable, so machine output carries project only —
+    // unless --check-global-agents was passed, which is the caller declaring
+    // the environment in scope. A flag that ran a check and then discarded its
+    // result would be worse than no flag.
+    const sarif = buildSARIF(checkGlobalAgents ? allFindings : projectFindings(allFindings), absolutePath);
     fs.writeFileSync(sarifPath, JSON.stringify(sarif, null, 2));
   }
 

--- a/cli/utils/patterns.js
+++ b/cli/utils/patterns.js
@@ -1185,3 +1185,35 @@ export const TEST_FILE_PATTERNS = [
   /\.stories\.[jt]sx?$/,   // Storybook story files
   /\.mock\.[jt]sx?$/,
 ];
+
+/**
+ * Is this path test, fixture, or mock code?
+ *
+ * `scan` has excluded these by default for a long time, on the reasoning that
+ * test files deliberately contain credential-shaped strings and vulnerable
+ * constructs. `audit` and `ci` did not, so the same repository could be clean
+ * under one command and fail under another.
+ *
+ * Measured on four mature projects (express, requests, flask, chalk): 89% of
+ * all findings came from test, example, and fixture paths. Express alone
+ * produced 601 API_NO_SECURITY_HEADERS findings, of which 528 were in `test/`
+ * and 2 in `lib/`. A test app that skips security headers is not a defect.
+ */
+export function isTestFile(filePath) {
+  return TEST_FILE_PATTERNS.some((pattern) => pattern.test(filePath));
+}
+
+/**
+ * Example, sample, and demo code. Illustrative rather than production, so it
+ * carries the same reasoning as test code, kept separate because callers may
+ * want to treat them differently.
+ */
+export const EXAMPLE_FILE_PATTERNS = [
+  /[/\\]examples?[/\\]/i,
+  /[/\\]samples?[/\\]/i,
+  /[/\\]demos?[/\\]/i,
+];
+
+export function isExampleFile(filePath) {
+  return EXAMPLE_FILE_PATTERNS.some((pattern) => pattern.test(filePath));
+}


### PR DESCRIPTION
Prompted by an outside review that rated the project's credibility 3/5 and asked for measured detection quality rather than feature counts. I built the false-positive benchmark to answer it, and the answer was bad.

## What the benchmark found

Four mature, heavily reviewed projects:

| repo | findings | score |
|---|---|---|
| express | 811 | **31 / F** |
| requests | 110 | **30 / F** |
| flask | 104 | **25 / F** |
| chalk | 6 | 83.6 / B |

Fourteen criticals in `requests` are not real. A user running Ship Safe on Express today gets an F and 811 findings.

**89% of all findings came from test, example, and fixture paths.** Express alone produced 601 `API_NO_SECURITY_HEADERS` hits: **528 in `test/`, 71 in `examples/`, 2 in `lib/`**. A test app that skips security headers is not a defect.

## The fix already existed, in one command

`scan` has excluded these paths by default for a long time, documented as *"excluded by default to reduce false positives"*, with `--include-tests` to opt back in. `audit` and `ci` never got it, so the same repository could be clean under one command and fail under another.

This is the third instance of the same pattern, after `.ship-safeignore` (#94) and the secrets-only confidence downgrade: correct logic in one place, not propagated.

Applied where agents share their file list, so it covers every agent rather than just the secret scan. My first attempt only patched `findFiles` and moved express by zero, because its findings come from agents.

## Result

```
express   811 -> 28    31/F   -> 59.5/D
requests  110 -> 35    30/F   -> 55.9/D
flask     104 -> 55    25/F   -> 31/F
chalk       6 ->  6    unchanged
```

Total across the corpus: **1031 -> 124**.

## Detection is unchanged

The regression corpus still reports 100% scenario recall and 100% clean-control pass. What moved is where the scanner looks, not what it catches. `--include-tests` restores the previous behaviour on both commands.

327 tests, up from 324. New cases cover the classification, including paths like `contest/`, `latest.js`, and `protester.py` that contain "test" but are production code, since misclassifying those would hide the findings that matter.

## Honest limits

- This **changes reported findings for existing users**. It belongs in the changelog as a behaviour change and argues for a minor bump.
- **Flask remains F on 55 findings.** The remainder is a mix rather than one systemic cause, so this reduces the noise rather than solving it.
- These are *findings on repos with no known active vulnerabilities*, which is a proxy for a false-positive rate, not a verified one. Verifying each finding by hand is the next step if you want a number to publish.

Also rounds the `ci` score, which emitted `29.900000000000006` in JSON where `audit` already rounded.
