### PR TITLE
feat: flag mutable model downloads

### DIFF
--- a/cli/__tests__/fixtures/model-downloads/mutable.py
+++ b/cli/__tests__/fixtures/model-downloads/mutable.py
@@ -1,0 +1,10 @@
+import torch
+import requests
+from huggingface_hub import hf_hub_download, snapshot_download
+from transformers import AutoModel
+
+AutoModel.from_pretrained("acme/mutable-model", trust_remote_code=True)
+snapshot_download(repo_id="acme/mutable-weights")
+model_path = hf_hub_download("acme/pickled-model", filename="model.pkl")
+requests.get("https://huggingface.co/acme/model/resolve/main/model.safetensors")
+model = torch.load(model_path)

--- a/cli/__tests__/fixtures/model-downloads/safe.py
+++ b/cli/__tests__/fixtures/model-downloads/safe.py
@@ -1,0 +1,22 @@
+from huggingface_hub import snapshot_download
+from transformers import AutoModel
+import hashlib
+import requests
+
+AutoModel.from_pretrained("./models/local")
+AutoModel.from_pretrained("models/cache/local-model")
+AutoModel.from_pretrained(
+    "acme/reviewed-model",
+    revision="0123456789abcdef0123456789abcdef01234567",
+)
+snapshot_download(
+    repo_id="acme/reviewed-weights",
+    revision="0123456789abcdef0123456789abcdef01234567",
+)
+requests.get(
+    "https://huggingface.co/acme/model/resolve/0123456789abcdef0123456789abcdef01234567/model.safetensors"
+)
+response = requests.get("https://models.example.invalid/release/model.safetensors")
+assert hashlib.sha256(response.content).hexdigest() == (
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+)

--- a/cli/__tests__/model-scan-agent.test.js
+++ b/cli/__tests__/model-scan-agent.test.js
@@ -13,8 +13,11 @@ import assert from 'node:assert/strict';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { fileURLToPath } from 'url';
 
 import { ModelScanAgent } from '../agents/model-scan-agent.js';
+
+const FIXTURES = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures', 'model-downloads');
 
 function tmp() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-model-'));
@@ -98,6 +101,37 @@ describe('ModelScanAgent — source loaders', () => {
       fs.writeFileSync(file, 'import torch\nm = torch.load("model.pt", weights_only=True)\n');
       const f = await scan(dir, [file]);
       assert.equal(f.filter((x) => x.rule === 'MODEL_TORCH_LOAD_UNSAFE').length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('flags mutable Hugging Face references and remote code', async () => {
+    const file = path.join(FIXTURES, 'mutable.py');
+    const f = await scan(FIXTURES, [file]);
+    assert.ok(f.some((x) => x.rule === 'RAG_TRUST_REMOTE_CODE'));
+    assert.equal(f.filter((x) => x.rule === 'MODEL_MUTABLE_REMOTE_REFERENCE').length, 3);
+    assert.ok(f.some((x) => x.rule === 'MODEL_MUTABLE_RAW_URL'));
+    assert.ok(f.some((x) => x.rule === 'MODEL_MUTABLE_DOWNLOAD_PICKLE_LOAD' && x.severity === 'critical'));
+  });
+
+  it('keeps local and commit-pinned model references quiet', async () => {
+    const file = path.join(FIXTURES, 'safe.py');
+    const f = await scan(FIXTURES, [file]);
+    assert.equal(f.filter((x) => x.rule.startsWith('MODEL_MUTABLE_')).length, 0);
+  });
+
+  it('does not link an unrelated mutable download to a local pickle load', async () => {
+    const dir = tmp();
+    const file = path.join(dir, 'separate.py');
+    try {
+      fs.writeFileSync(file, `
+from huggingface_hub import snapshot_download
+import torch
+snapshot_download("acme/mutable-weights")
+model = torch.load("./local.pt", weights_only=True)
+`);
+      const f = await scan(dir, [file]);
+      assert.ok(f.some((x) => x.rule === 'MODEL_MUTABLE_REMOTE_REFERENCE'));
+      assert.ok(!f.some((x) => x.rule === 'MODEL_MUTABLE_DOWNLOAD_PICKLE_LOAD'));
     } finally { cleanup(dir); }
   });
 });

--- a/cli/agents/model-scan-agent.js
+++ b/cli/agents/model-scan-agent.js
@@ -54,6 +54,15 @@ const ZIP_MAGIC = Buffer.from([0x50, 0x4b, 0x03, 0x04]); // PyTorch .pt is a zip
 // Source-level unsafe loaders.
 const SOURCE_PATTERNS = [
   {
+    regex: /trust_remote_code\s*=\s*True/g,
+    rule: 'RAG_TRUST_REMOTE_CODE',
+    title: 'Model loaded with trust_remote_code=True',
+    severity: 'high',
+    description: 'The model loader allows executable Python code from the remote model repository.',
+    cwe: 'CWE-829',
+    fix: 'Set trust_remote_code=False and use a model whose code has been reviewed and pinned.',
+  },
+  {
     regex: /torch\s*\.\s*load\s*\((?![^)]*weights_only\s*=\s*True)/g,
     rule: 'MODEL_TORCH_LOAD_UNSAFE',
     title: 'torch.load() without weights_only=True',
@@ -110,10 +119,180 @@ export class ModelScanAgent extends BaseAgent {
       const ext = path.extname(file).toLowerCase();
       if (ext === '.py' || ext === '.ipynb') {
         findings.push(...this.scanFileWithPatterns(file, SOURCE_PATTERNS));
+        findings.push(...this._scanRemoteModelSources(file));
       }
     }
 
     return findings;
+  }
+
+  _scanRemoteModelSources(file) {
+    const content = this.readFile(file);
+    if (!content) return [];
+
+    const findings = [];
+    const mutableDownloads = [];
+    const hubCalls = this._findCalls(
+      content,
+      /\b(?:[A-Za-z_][\w]*\.)*(from_pretrained|snapshot_download|hf_hub_download)\s*\(/g
+    );
+
+    for (const call of hubCalls) {
+      const reference = this._modelReference(call.args);
+      if (!reference || this._isLocalReference(reference, file)) continue;
+      if (this._hasPinnedRevision(call.args)) continue;
+
+      mutableDownloads.push(call);
+      findings.push(createFinding({
+        file,
+        line: this._lineAt(content, call.index),
+        severity: 'high',
+        category: 'supply-chain',
+        rule: 'MODEL_MUTABLE_REMOTE_REFERENCE',
+        title: 'Model download uses a mutable remote reference',
+        description: `The ${call.name} call downloads model code or weights without pinning revision to a full commit hash. The reviewed artifact can change later.`,
+        matched: `${call.name} without commit revision`,
+        confidence: 'high',
+        cwe: 'CWE-829',
+        fix: 'Set revision to the full commit hash of the reviewed model repository.',
+      }));
+    }
+
+    const rawCalls = this._findCalls(
+      content,
+      /\b((?:requests\.(?:get|post)|urllib\.request\.(?:urlopen|urlretrieve)|wget\.download|torch\.hub\.download_url_to_file))\s*\(/g
+    );
+    for (const call of rawCalls) {
+      const url = call.args.match(/["'](https?:\/\/[^"']+)["']/i)?.[1];
+      if (!url || !/\.(?:pkl|pickle|pt|pth|ckpt|bin|safetensors|gguf|onnx)(?:[?#]|$)/i.test(url)) continue;
+      if (this._hasImmutableUrl(url) || this._hasChecksumVerification(content, call)) continue;
+
+      mutableDownloads.push(call);
+      findings.push(createFinding({
+        file,
+        line: this._lineAt(content, call.index),
+        severity: 'high',
+        category: 'supply-chain',
+        rule: 'MODEL_MUTABLE_RAW_URL',
+        title: 'Model artifact URL has no immutable revision or checksum',
+        description: 'A model artifact is downloaded from a mutable URL without a commit-pinned path or checksum verification.',
+        matched: 'model URL without revision or checksum',
+        confidence: 'high',
+        cwe: 'CWE-494',
+        fix: 'Use an immutable commit-pinned URL and verify the artifact SHA-256 before loading it.',
+      }));
+    }
+
+    const pickleDownload = mutableDownloads.find((call) => this._feedsPickleLoader(content, call));
+    if (pickleDownload) {
+      findings.push(createFinding({
+        file,
+        line: this._lineAt(content, pickleDownload.index),
+        severity: 'critical',
+        category: 'supply-chain',
+        rule: 'MODEL_MUTABLE_DOWNLOAD_PICKLE_LOAD',
+        title: 'Mutable model download is loaded through pickle',
+        description: 'This source downloads a mutable remote model artifact and later loads a pickle-capable format, allowing the remote artifact to become code execution.',
+        matched: 'mutable download followed by pickle load',
+        confidence: 'high',
+        cwe: 'CWE-502',
+        fix: 'Pin and verify the download, use safetensors, and avoid pickle-capable loaders for remote artifacts.',
+      }));
+    }
+
+    return findings;
+  }
+
+  _findCalls(content, pattern) {
+    const calls = [];
+    let match;
+    while ((match = pattern.exec(content)) !== null) {
+      const open = pattern.lastIndex - 1;
+      let depth = 1;
+      let quote = null;
+      let escaped = false;
+      let end = open + 1;
+
+      for (; end < content.length && depth > 0; end++) {
+        const char = content[end];
+        if (quote) {
+          if (escaped) escaped = false;
+          else if (char === '\\') escaped = true;
+          else if (char === quote) quote = null;
+          continue;
+        }
+        if (char === '"' || char === "'") quote = char;
+        else if (char === '(') depth++;
+        else if (char === ')') depth--;
+      }
+      if (depth === 0) {
+        const linePrefix = content.slice(content.lastIndexOf('\n', match.index) + 1, match.index);
+        calls.push({
+          name: match[1],
+          index: match.index,
+          end,
+          assignedTo: linePrefix.match(/\b([A-Za-z_]\w*)\s*=\s*$/)?.[1] || null,
+          args: content.slice(open + 1, end - 1),
+        });
+      }
+    }
+    return calls;
+  }
+
+  _feedsPickleLoader(content, call) {
+    const loaders = String.raw`(?:torch\.load|pickle\.load|joblib\.load|dill\.load)`;
+    if (call.assignedTo) {
+      const variable = call.assignedTo.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      if (new RegExp(String.raw`\b${loaders}\s*\(\s*${variable}\b`, 'i').test(content.slice(call.end))) {
+        return true;
+      }
+    }
+
+    const prefix = content.slice(Math.max(0, call.index - 120), call.index);
+    return new RegExp(String.raw`\b${loaders}\s*\(\s*$`, 'i').test(prefix);
+  }
+
+  _modelReference(args) {
+    return args.match(/\b(?:pretrained_model_name_or_path|repo_id)\s*=\s*["']([^"']+)["']/i)?.[1]
+      || args.match(/^\s*["']([^"']+)["']/)?.[1]
+      || null;
+  }
+
+  _isLocalReference(reference, sourceFile) {
+    if (/^(?:\.{0,2}[\\/]|~[\\/]|[A-Za-z]:[\\/]|file:\/\/)/i.test(reference)) return true;
+    if (path.isAbsolute(reference)) return true;
+    if (/^(?:models?|checkpoints?|weights?|artifacts?|outputs?)[\\/]/i.test(reference)) return true;
+    if (/\.(?:pkl|pickle|pt|pth|ckpt|bin|safetensors|gguf|onnx)$/i.test(reference)) return true;
+    return fs.existsSync(path.resolve(path.dirname(sourceFile), reference));
+  }
+
+  _hasPinnedRevision(args) {
+    const revision = args.match(/\brevision\s*=\s*["']([0-9a-f]+)["']/i)?.[1];
+    return Boolean(revision && (revision.length === 40 || revision.length === 64));
+  }
+
+  _hasImmutableUrl(url) {
+    return /\/(?:resolve|blob)\/(?:[0-9a-f]{40}|[0-9a-f]{64})\//i.test(url)
+      || /[?&](?:revision|rev)=(?:[0-9a-f]{40}|[0-9a-f]{64})(?:&|$)/i.test(url);
+  }
+
+  _hasChecksumVerification(content, call) {
+    if (call.name === 'torch.hub.download_url_to_file') {
+      return /\bhash_prefix\s*=\s*["'][0-9a-f]{8,64}["']/i.test(call.args);
+    }
+    if (!call.assignedTo) return false;
+
+    const variable = call.assignedTo.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const following = content.slice(call.end, call.end + 1200);
+    const hashesDownloadedBytes = new RegExp(
+      String.raw`hashlib\.sha256\s*\(\s*${variable}\.(?:content|raw\.read\s*\(\s*\))\s*\)`,
+      'i'
+    ).test(following);
+    return hashesDownloadedBytes && /["'][0-9a-f]{64}["']/i.test(following);
+  }
+
+  _lineAt(content, index) {
+    return content.slice(0, index).split('\n').length;
   }
 
   _scanModelFile(file) {


### PR DESCRIPTION
## Description

Detect mutable model download and loading patterns in source code while keeping false positives bounded:

- Flag `trust_remote_code=True`.
- Flag unpinned Hugging Face `from_pretrained`, `snapshot_download`, and `hf_hub_download` calls.
- Flag mutable raw model URLs without an immutable revision or checksum.
- Raise `MODEL_MUTABLE_DOWNLOAD_PICKLE_LOAD` only when the downloaded value actually flows into a pickle-capable loader.
- Add vulnerable and safe fixtures covering detection and false-positive boundaries.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] New security agent
- [x] New security rule
- [ ] New secret detection pattern
- [ ] New security config/checklist
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I've tested my changes locally
- [x] I've added or updated tests when behavior changed
- [x] I've explained security impact and remediation in finding copy/docs
- [x] I've updated documentation if needed
- [x] My code follows the project's style
- [x] I've checked for false positives for new detectors
- [x] I did not add real secrets, tokens, customer data, or private repo URLs

## Testing Done

```bash
node --test cli/__tests__/model-scan-agent.test.js
npm test
npm run lint
node cli/bin/ship-safe.js scan . --no-color
git diff --check origin/main...HEAD
```

- Targeted model scan tests: 10 passed.
- All tests except the Windows symlink fixture file: 336 passed.
- Full suite: 339 passed; 3 symlink fixture tests could not create links on this Windows host (`EPERM`).
- ESLint: 0 errors; existing warnings only.
- Self-scan: 0 findings across 84 files.

## Related Issues

Fixes #87

## Additional Notes

The branch is rebased onto current `main` after #92 merged.
