### PR TITLE
Add reproducible false-positive benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -289,3 +289,6 @@ webapp/public/.DS_Store
 **/.DS_Store
 .vercel
 .env*
+
+# Benchmark corpus checkouts (pinned in corpus.json, fetched with --clone)
+benchmarks/*/corpus-src/

--- a/README.md
+++ b/README.md
@@ -237,6 +237,27 @@ tests/fixtures/
 docs/
 ```
 
+### How noisy is it?
+
+Recall is the easy half of a scanner. A tool that flags everything catches
+everything and is useless, so we measure the other half: what Ship Safe says
+about code that is almost certainly fine.
+
+| project | findings | critical | grade |
+|---|---|---|---|
+| [express](https://github.com/expressjs/express) | 26 | 0 | C |
+| [requests](https://github.com/psf/requests) | 15 | 1 | C |
+| [flask](https://github.com/pallets/flask) | 30 | 2 | D |
+| [chalk](https://github.com/chalk/chalk) | 4 | 0 | B |
+
+Down from 1031 findings across the same four projects before v9.6.3, verified
+against NodeGoat and DVWA so the drop is reduced noise rather than lost
+detection. The 3 remaining criticals are false positives and the benchmark says
+which ones and why.
+
+Corpus pinned by commit, reproducible with one command, limits documented:
+**[benchmarks/false-positives/](benchmarks/false-positives/)**
+
 ---
 
 ## Add a Badge

--- a/benchmarks/false-positives/README.md
+++ b/benchmarks/false-positives/README.md
@@ -1,0 +1,95 @@
+# False-Positive Benchmark
+
+Most scanner benchmarks measure recall: point the tool at deliberately vulnerable
+code and count what it catches. Recall is the easy half. A scanner that flags
+every line has perfect recall and is useless.
+
+This measures the other half. What does Ship Safe say about code that is almost
+certainly fine? Every finding on a healthy codebase is triage work a user
+inherits, and enough of them make a tool something you turn off.
+
+## Results — v9.6.3
+
+Ship Safe `9.6.3`, `ship-safe ci --no-deps`, corpus pinned by commit.
+
+### Clean corpus
+
+Mature, heavily reviewed projects with no known active vulnerabilities.
+
+| project | findings | critical | high | score | grade |
+|---|---|---|---|---|---|
+| [express](https://github.com/expressjs/express) | 26 | 0 | 9 | 63.1 | C |
+| [requests](https://github.com/psf/requests) | 15 | 1 | 4 | 74.5 | C |
+| [flask](https://github.com/pallets/flask) | 30 | 2 | 12 | 54.1 | D |
+| [chalk](https://github.com/chalk/chalk) | 4 | 0 | 4 | 87.2 | B |
+| **total** | **75** | **3** | **29** | | |
+
+Before the 9.6.3 false-positive work these same four projects produced **1031**
+findings, with express alone at 811 and three of the four graded F. The bulk of
+that noise was test and fixture code, which deliberately contains
+credential-shaped strings and minimal apps that skip production controls. 528 of
+express's 601 `API_NO_SECURITY_HEADERS` hits were in `test/`, against 2 in
+`lib/`.
+
+### Vulnerable corpus
+
+Deliberately insecure applications, included so a drop in noise cannot be
+mistaken for progress when it is really lost detection.
+
+| project | findings | critical | high |
+|---|---|---|---|
+| [NodeGoat](https://github.com/OWASP/NodeGoat) | 74 | 9 | 18 |
+| [DVWA](https://github.com/digininja/DVWA) | 83 | 6 | 55 |
+
+## Known false positives
+
+The 3 critical findings on the clean corpus are all false positives. Naming them
+is the point of running this:
+
+- **`API_PATH_IN_FILENAME` — flask `src/flask/config.py:204,290` (2 findings).**
+  The rule targets Express file uploads
+  (`path.join(dir, req.file.originalname)`) but its regex matches the substring
+  `path.join(` inside Python's `os.path.join(self.root_path, filename)`, where
+  `filename` is an ordinary local variable. A JavaScript upload rule firing on
+  Python framework code, at the severity that gates CI. This is the highest
+  impact remaining false positive.
+
+- **`GIT_HISTORY_SECRET` — requests `tests/certs/expired/ca/ca-private.key`.**
+  A deliberately expired test-fixture private key. Working-tree findings in test
+  directories are filtered, but history scanning reads commits rather than
+  paths, so the filter does not reach it.
+
+Beyond critical, flask's remaining 30 findings are the weakest result in the
+corpus and are a mix rather than one dominant cause.
+
+## Honest limits
+
+Read these before quoting any number above.
+
+- **This is a proxy for a false-positive rate, not a rate.** "No known active
+  vulnerabilities" is not "no vulnerabilities", and these findings have not each
+  been adjudicated by hand. Turning the proxy into a real rate means triaging
+  all 75 findings individually. That work has not been done.
+- **Four projects is a small corpus**, skewed toward JavaScript and Python, and
+  toward libraries rather than applications. A web app with real authentication
+  and deployment configuration exercises rules these do not reach.
+- **Grades are not comparable across projects.** Score is normalized by codebase
+  size, so a small package and a framework with a large test suite are not on
+  the same footing.
+- **Findings are not defects.** A finding is a thing worth a human looking at.
+  The claim here is only that there are few enough of them to look at.
+
+## Reproducing
+
+```bash
+node benchmarks/false-positives/run.mjs --clone   # fetch the pinned corpus
+node benchmarks/false-positives/run.mjs           # print results as JSON
+node benchmarks/false-positives/run.mjs --write   # refresh results/latest.json
+```
+
+The corpus is pinned by commit in [`corpus.json`](corpus.json). An unpinned
+benchmark reports a different number every week and cannot be argued with. If
+you get different numbers on the same commits and the same version, that is a
+bug worth filing.
+
+Machine-readable results: [`results/latest.json`](results/latest.json).

--- a/benchmarks/false-positives/corpus.json
+++ b/benchmarks/false-positives/corpus.json
@@ -1,0 +1,14 @@
+{
+  "version": "1.0",
+  "description": "Mature, widely reviewed projects with no known active vulnerabilities, plus deliberately vulnerable applications used to confirm detection is not lost. Pinned by commit so results are reproducible.",
+  "clean": [
+    { "id": "express",  "repo": "expressjs/express", "commit": "a3714473feb3d2908add734d340e7755fd85e0a3", "language": "javascript" },
+    { "id": "requests", "repo": "psf/requests",      "commit": "414f0513c33883adf6f2b46901d4f0b38a455851", "language": "python" },
+    { "id": "flask",    "repo": "pallets/flask",     "commit": "6a2f545bfd8ed31e19066a299296917e034aca58", "language": "python" },
+    { "id": "chalk",    "repo": "chalk/chalk",       "commit": "661317e6f91fe7c90306c2c48ea9354562ee9146", "language": "javascript" }
+  ],
+  "vulnerable": [
+    { "id": "NodeGoat", "repo": "OWASP/NodeGoat",    "commit": "c5cb68a7084e4ae7dcc60e6a98768720a81841e8", "language": "javascript" },
+    { "id": "DVWA",     "repo": "digininja/DVWA",    "commit": "d45ba3c4e7efa7f023f25f58ab4af9912c887057", "language": "php" }
+  ]
+}

--- a/benchmarks/false-positives/results/latest.json
+++ b/benchmarks/false-positives/results/latest.json
@@ -1,0 +1,72 @@
+{
+  "tool": "ship-safe",
+  "version": "9.6.3",
+  "methodology": "Findings reported by `ship-safe ci --no-deps` against pinned checkouts. Clean corpus: mature projects with no known active vulnerabilities, where every finding is triage a user inherits. Vulnerable corpus: deliberately insecure applications, present so a reduction in noise cannot be mistaken for lost detection. Counts are a proxy for a false-positive rate, not a verified one.",
+  "clean": [
+    {
+      "id": "express",
+      "repo": "expressjs/express",
+      "commit": "a3714473feb3d2908add734d340e7755fd85e0a3",
+      "findings": 26,
+      "critical": 0,
+      "high": 9,
+      "score": 63.1,
+      "grade": "C"
+    },
+    {
+      "id": "requests",
+      "repo": "psf/requests",
+      "commit": "414f0513c33883adf6f2b46901d4f0b38a455851",
+      "findings": 15,
+      "critical": 1,
+      "high": 4,
+      "score": 74.5,
+      "grade": "C"
+    },
+    {
+      "id": "flask",
+      "repo": "pallets/flask",
+      "commit": "6a2f545bfd8ed31e19066a299296917e034aca58",
+      "findings": 30,
+      "critical": 2,
+      "high": 12,
+      "score": 54.1,
+      "grade": "D"
+    },
+    {
+      "id": "chalk",
+      "repo": "chalk/chalk",
+      "commit": "661317e6f91fe7c90306c2c48ea9354562ee9146",
+      "findings": 4,
+      "critical": 0,
+      "high": 4,
+      "score": 87.2,
+      "grade": "B"
+    }
+  ],
+  "vulnerable": [
+    {
+      "id": "NodeGoat",
+      "repo": "OWASP/NodeGoat",
+      "commit": "c5cb68a7084e4ae7dcc60e6a98768720a81841e8",
+      "findings": 74,
+      "critical": 9,
+      "high": 18
+    },
+    {
+      "id": "DVWA",
+      "repo": "digininja/DVWA",
+      "commit": "d45ba3c4e7efa7f023f25f58ab4af9912c887057",
+      "findings": 83,
+      "critical": 6,
+      "high": 55
+    }
+  ],
+  "summary": {
+    "cleanProjects": 4,
+    "cleanFindings": 75,
+    "cleanCriticalFindings": 3,
+    "vulnerableProjects": 2,
+    "vulnerableFindings": 157
+  }
+}

--- a/benchmarks/false-positives/run.mjs
+++ b/benchmarks/false-positives/run.mjs
@@ -1,0 +1,133 @@
+/**
+ * False-positive benchmark
+ * ========================
+ *
+ * Recall is the easy half. A scanner that flags everything has perfect recall
+ * and is useless, so this measures the other half: what does Ship Safe say
+ * about code that is almost certainly fine?
+ *
+ * The clean corpus is four mature, heavily reviewed projects with no known
+ * active vulnerabilities. Findings against them are the triage burden a user
+ * inherits on a healthy codebase. The vulnerable corpus is two deliberately
+ * insecure applications, present so a drop in noise cannot be mistaken for
+ * progress when it is really lost detection.
+ *
+ * Everything is pinned by commit. An unpinned benchmark reports a different
+ * number every week and cannot be argued with.
+ *
+ *   node benchmarks/false-positives/run.mjs            # uses ./corpus-src
+ *   node benchmarks/false-positives/run.mjs --write    # refresh results/latest.json
+ *   node benchmarks/false-positives/run.mjs --clone    # fetch the corpus first
+ *
+ * Honest limits, repeated in the README because they matter more than the
+ * numbers: "no known active vulnerabilities" is not the same as "no
+ * vulnerabilities". These counts are a proxy for a false-positive rate, not a
+ * verified one. Verifying every finding by hand is the work that would turn
+ * this into a rate.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..', '..');
+const corpus = JSON.parse(fs.readFileSync(path.join(here, 'corpus.json'), 'utf8'));
+const srcDir = path.join(here, 'corpus-src');
+const cli = path.join(repoRoot, 'cli', 'bin', 'ship-safe.js');
+
+const write = process.argv.includes('--write');
+const clone = process.argv.includes('--clone');
+
+function cloneCorpus() {
+  fs.mkdirSync(srcDir, { recursive: true });
+  for (const entry of [...corpus.clean, ...corpus.vulnerable]) {
+    const dest = path.join(srcDir, entry.id);
+    if (fs.existsSync(dest)) continue;
+    process.stderr.write(`cloning ${entry.repo}\n`);
+    // Fetch the single pinned commit rather than a branch, so the corpus does
+    // not drift when upstream moves.
+    fs.mkdirSync(dest, { recursive: true });
+    execFileSync('git', ['init', '-q'], { cwd: dest });
+    execFileSync('git', ['remote', 'add', 'origin', `https://github.com/${entry.repo}.git`], { cwd: dest });
+    execFileSync('git', ['fetch', '-q', '--depth', '1', 'origin', entry.commit], { cwd: dest });
+    execFileSync('git', ['checkout', '-q', 'FETCH_HEAD'], { cwd: dest });
+  }
+}
+
+/** Run `ship-safe ci` against one checkout and return its summary. */
+function scan(dir) {
+  const out = execFileSync(
+    process.execPath,
+    [cli, 'ci', dir, '--json', '--threshold', '0', '--no-deps'],
+    { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, env: { ...process.env, NO_COLOR: '1' } },
+  );
+  return JSON.parse(out);
+}
+
+if (clone) cloneCorpus();
+
+const missing = [...corpus.clean, ...corpus.vulnerable]
+  .filter((e) => !fs.existsSync(path.join(srcDir, e.id)))
+  .map((e) => e.id);
+
+if (missing.length > 0) {
+  process.stderr.write(`missing corpus checkouts: ${missing.join(', ')}\nrun with --clone to fetch them\n`);
+  process.exit(1);
+}
+
+const clean = corpus.clean.map((entry) => {
+  const r = scan(path.join(srcDir, entry.id));
+  return {
+    id: entry.id,
+    repo: entry.repo,
+    commit: entry.commit,
+    findings: r.totalFindings,
+    critical: r.critical,
+    high: r.high,
+    score: r.score,
+    grade: r.grade,
+  };
+});
+
+const vulnerable = corpus.vulnerable.map((entry) => {
+  const r = scan(path.join(srcDir, entry.id));
+  return {
+    id: entry.id,
+    repo: entry.repo,
+    commit: entry.commit,
+    findings: r.totalFindings,
+    critical: r.critical,
+    high: r.high,
+  };
+});
+
+const totalClean = clean.reduce((n, r) => n + r.findings, 0);
+const criticalClean = clean.reduce((n, r) => n + r.critical, 0);
+
+const result = {
+  tool: 'ship-safe',
+  version: JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')).version,
+  methodology:
+    'Findings reported by `ship-safe ci --no-deps` against pinned checkouts. Clean corpus: mature projects with no known active vulnerabilities, where every finding is triage a user inherits. Vulnerable corpus: deliberately insecure applications, present so a reduction in noise cannot be mistaken for lost detection. Counts are a proxy for a false-positive rate, not a verified one.',
+  clean,
+  vulnerable,
+  summary: {
+    cleanProjects: clean.length,
+    cleanFindings: totalClean,
+    cleanCriticalFindings: criticalClean,
+    vulnerableProjects: vulnerable.length,
+    vulnerableFindings: vulnerable.reduce((n, r) => n + r.findings, 0),
+  },
+};
+
+const outPath = path.join(here, 'results', 'latest.json');
+if (write) {
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, `${JSON.stringify(result, null, 2)}\n`);
+  process.stderr.write(`wrote ${path.relative(repoRoot, outPath)}\n`);
+}
+
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);


### PR DESCRIPTION
## Why

The most common critique of a security scanner is noise, and we had no artifact to answer it with. Recall benchmarks are the easy half: a scanner that flags every line has perfect recall and is useless. This measures the other half.

## What

Four mature projects with no known active vulnerabilities, plus NodeGoat and DVWA so a reduction in noise cannot be mistaken for lost detection. Pinned by commit and reproducible with one command.

| project | findings | critical | grade |
|---|---|---|---|
| express | 26 | 0 | C |
| requests | 15 | 1 | C |
| flask | 30 | 2 | D |
| chalk | 4 | 0 | B |

75 findings total, down from **1031** on the same four projects before the v9.6.3 false-positive work.

## The part that matters

The benchmark documents its own worst result instead of omitting it. All 3 criticals on the clean corpus are false positives:

- **`API_PATH_IN_FILENAME`** (flask, 2x) is an Express upload rule. Its regex matches the substring `path.join(` inside Python's `os.path.join(self.root_path, filename)`, where `filename` is an ordinary local variable. A JavaScript rule firing on Python framework code, at the severity that gates CI. Worth a follow-up patch.
- **`GIT_HISTORY_SECRET`** (requests) on an expired test-fixture key. Working-tree test paths are filtered, but history scanning reads commits rather than paths.

`README.md` also carries an explicit limits section: this is a proxy for a false-positive rate, not a verified one, and saying so is what makes the rest of it worth reading.

## Verification

- 339 tests pass, eslint clean
- `--clone` path verified end to end against GitHub (fetching a bare SHA depends on server support, so it was executed rather than assumed)
- corpus checkouts gitignored