### PR TITLE
Add tool comparison page

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,20 @@ which ones and why.
 Corpus pinned by commit, reproducible with one command, limits documented:
 **[benchmarks/false-positives/](benchmarks/false-positives/)**
 
+### How does it compare to Semgrep, Gitleaks, Trivy, CodeQL?
+
+Run Ship Safe alongside them, not instead of them. CodeQL does interprocedural
+taint analysis Ship Safe does not attempt, Gitleaks is the specialist for
+secrets, and Trivy has a real CVE database behind it.
+
+Ship Safe covers a narrower question: what an AI coding agent just did to your
+repository, your CI, and your local tool configuration. MCP client config,
+agent memory poisoning, hallucinated-package imports and AIBOM are the areas
+where we found no equivalent public rules in the other four.
+
+Full coverage matrix, verified against their public registries, including where
+they beat us: **[docs/comparison.md](docs/comparison.md)**
+
 ---
 
 ## Add a Badge

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,105 @@
+# Ship Safe compared to other scanners
+
+**Short version: run Ship Safe alongside Semgrep, Gitleaks and Trivy, not instead
+of them.** They are better than Ship Safe at the things they are built for, and
+this page says where. If you are choosing exactly one security scanner and your
+main risk is injection bugs in application code, pick Semgrep or CodeQL.
+
+Ship Safe is aimed at a narrower question: *what did an AI coding agent just do
+to my repository, my CI, and my local tool configuration?*
+
+## Coverage
+
+Verified against each project's public rule registry and changelog in August
+2026. This space moves fast — if a cell is out of date, please open an issue.
+
+| | Ship Safe | Semgrep | Gitleaks | Trivy | CodeQL |
+|---|---|---|---|---|---|
+| Interprocedural taint analysis | ✗ | ✅ | ✗ | ✗ | ✅✅ |
+| Secrets in git history | ✅ | ✗ | ✅✅ | ✗ | ✗ |
+| Dependency CVEs | basic | ✗ | ✗ | ✅✅ | ✗ |
+| Container / IaC misconfig | basic | ✅ | ✗ | ✅✅ | ✗ |
+| Prompt injection in app code | ✅ | ✅ | ✗ | ✗ | ✅ (JS/TS) |
+| Malicious agent skill definitions | ✅ | ✅ (Pro) | ✗ | ✗ | ✗ |
+| CI/CD workflow misconfig | ✅ | ✅ | ✗ | ✗ | ✗ |
+| **MCP client config files** | ✅ | ✗ | ✗ | ✗ | ✗ |
+| **Agent memory poisoning** | ✅ | ✗ | ✗ | ✗ | ✗ |
+| **Hallucinated-package imports** | ✅ | ✗ | ✗ | ✗ | ✗ |
+| **AIBOM / agent attestation** | ✅ | ✗ | ✗ | ✗ | ✗ |
+| Zero-config, no rule selection | ✅ | partial | ✅ | ✅ | ✗ |
+| Runs without a build | ✅ | ✅ | ✅ | ✅ | ✗ |
+
+`✅✅` means this is the tool's core competency and it is the best available
+option. `basic` means Ship Safe checks it but a dedicated tool is better.
+
+## Where the others are clearly better
+
+- **CodeQL** does real interprocedural dataflow. If a tainted value crosses four
+  function boundaries before reaching a sink, CodeQL follows it and Ship Safe
+  does not. Ship Safe is pattern-based and does not attempt this.
+- **Gitleaks** has years of tuned entropy heuristics and detector coverage for
+  secrets. Ship Safe scans history too, but Gitleaks is the specialist.
+- **Trivy** has a real vulnerability database behind it, plus container image and
+  full IaC scanning. Ship Safe's dependency checking is not a substitute.
+- **Semgrep** has ~5,000 rules, a large community registry, and custom rule
+  authoring. It has also moved into AI security: 27 AI security rules covering
+  prompt injection and unrestricted tool use, 186 Shadow AI rules, and 122 Pro
+  rules for malicious patterns in agent skill definitions.
+
+## Where Ship Safe is currently alone
+
+These are the bolded rows above. We found no equivalent public rules in the
+other four projects as of August 2026:
+
+- **MCP client configuration.** Semgrep can analyze the *source code* of an MCP
+  server. Ship Safe reads the config files that decide which servers your editor
+  actually launches (`.cursor/mcp.json`, `.vscode/mcp.json`,
+  `claude_desktop_config.json`) and flags risky declarations: unpinned remote
+  servers, broad filesystem scope, secrets inline in the server definition.
+  Auditing a server's source is a different question from auditing what your
+  machine is configured to run.
+- **Agent memory poisoning.** Persistent instruction stores that an agent will
+  re-read on a later run, where an attacker who writes once influences every
+  subsequent session.
+- **Hallucinated-package imports.** Ship Safe flags imports that are not Node
+  builtins, not declared in `package.json`, and not present in `node_modules`,
+  which is the shape a slopsquatted suggestion takes before you install it. Note
+  this is a heuristic on unresolvable imports, not live registry verification —
+  commercial supply-chain tools such as Socket and Snyk do verify against the
+  registry and go deeper here.
+- **AIBOM and agent attestation.** Inventory of which models, agents and tools a
+  repository depends on.
+
+The honest read: this gap is narrowing. Semgrep shipped Guardian specifically to
+scan AI-generated code as it is written, and CodeQL added prompt injection
+queries in 2026. Ship Safe's advantage is in the agent's *environment and
+configuration* rather than the code it emits, and that is a smaller island than
+it was a year ago.
+
+## Noise
+
+The other half of picking a scanner is how much triage it creates. We publish a
+[false-positive benchmark](../benchmarks/false-positives/) measuring Ship Safe on
+mature projects with no known active vulnerabilities: 75 findings across express,
+requests, flask and chalk, with the 3 remaining criticals documented as false
+positives.
+
+We deliberately do **not** publish a head-to-head detection comparison. A
+vendor-run benchmark where the vendor picks the corpus is worth very little, and
+we would rather give you a reproducible measurement of our own noise than a
+scoreboard we designed to win.
+
+## Suggested combination
+
+```bash
+trivy fs .          # dependency CVEs and container/IaC misconfiguration
+gitleaks detect     # secrets across git history
+semgrep --config auto   # application-code vulnerabilities and taint
+ship-safe ci .      # agent, MCP, CI/CD and AI supply-chain surface
+```
+
+Sources: [Semgrep Guardian](https://semgrep.dev/products/product-updates/detect-risks-in-ai-generated-code-with-semgrep-guardian/),
+[Semgrep github-actions ruleset](https://registry.semgrep.dev/ruleset/github-actions),
+[CodeQL 2.26.0 changelog](https://github.blog/changelog/2026-07-10-codeql-2-26-0-adds-kotlin-2-4-0-support-and-ai-prompt-injection-detection/),
+[Trivy scanners](https://trivy.dev/latest/docs/scanner/misconfiguration/),
+[Gitleaks](https://gitleaks.org/how-gitleaks-works-deep-dive-into-secret-detection-scanning-engine-and-security-automation/).


### PR DESCRIPTION
Answers "why not just use Semgrep" directly, in [docs/comparison.md](docs/comparison.md).

## Verification changed the conclusion

I checked each cell against the projects' public registries and changelogs instead of asserting them, and the draft I started with was wrong:

- **Semgrep** ships 27 AI security rules (prompt injection, unrestricted tool use, data exfiltration), 186 Shadow AI rules, and 122 Pro rules for malicious patterns in agent skill definitions. It also has `p/github-actions` covering `pull_request_target`.
- **CodeQL 2.26.0** (July 2026) added a JS/TS system prompt injection query.

"The only scanner covering AI agents" would not have survived a fact check, so the page does not claim it.

## What actually holds up

No equivalent public rules found in the other four as of August 2026:

- **MCP client config files** — Semgrep analyzes MCP server *source*; Ship Safe reads the configs that decide what your editor launches
- **Agent memory poisoning**
- **Hallucinated-package imports** — described honestly as a heuristic on unresolvable imports, not registry verification, with Socket/Snyk credited as deeper
- **AIBOM / agent attestation**

The page states plainly that this gap is narrowing.

## Positioning

Leads with "run Ship Safe alongside these, not instead of them", and includes a section on where each competitor beats us: CodeQL's interprocedural taint, Gitleaks on secrets, Trivy's CVE database, Semgrep's 5000-rule registry. Ends with a suggested four-tool command block.

Explains why we publish our own false-positive numbers but not a head-to-head detection scoreboard: a vendor-run benchmark where the vendor picks the corpus is worth very little.

Every claim is sourced with links.