### PR TITLE
Fix npm audit high severity and env-sensitive GPT-Red test

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,20 @@ which ones and why.
 Corpus pinned by commit, reproducible with one command, limits documented:
 **[benchmarks/false-positives/](benchmarks/false-positives/)**
 
+### How does it compare to Semgrep, Gitleaks, Trivy, CodeQL?
+
+Run Ship Safe alongside them, not instead of them. CodeQL does interprocedural
+taint analysis Ship Safe does not attempt, Gitleaks is the specialist for
+secrets, and Trivy has a real CVE database behind it.
+
+Ship Safe covers a narrower question: what an AI coding agent just did to your
+repository, your CI, and your local tool configuration. MCP client config,
+agent memory poisoning, hallucinated-package imports and AIBOM are the areas
+where we found no equivalent public rules in the other four.
+
+Full coverage matrix, verified against their public registries, including where
+they beat us: **[docs/comparison.md](docs/comparison.md)**
+
 ---
 
 ## Add a Badge

--- a/cli/__tests__/agents.test.js
+++ b/cli/__tests__/agents.test.js
@@ -2059,7 +2059,12 @@ describe('GPTRedAgent', async () => {
     ].join('\n'));
 
     try {
-      const findings = await agent.analyze({ rootPath: dir, files: [file], recon: {}, options: { gptRed: true } });
+      // `noAi` pins this to the offline path, which is what the test is about.
+      // Without it the agent auto-detects any provider key in the environment,
+      // so a contributor with KIMI_API_KEY or OPENAI_API_KEY set would get a
+      // second, AI-generated finding, a 50s test, and a real API charge for
+      // running `npm test`. CI has no keys, so this only ever broke locally.
+      const findings = await agent.analyze({ rootPath: dir, files: [file], recon: {}, options: { gptRed: true, noAi: true } });
       assert.equal(findings.length, 1);
       assert.equal(findings[0].rule, 'GPT_RED_AGENT_CONTEXT_INJECTION');
       assert.equal(findings[0].severity, 'critical');

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,105 @@
+# Ship Safe compared to other scanners
+
+**Short version: run Ship Safe alongside Semgrep, Gitleaks and Trivy, not instead
+of them.** They are better than Ship Safe at the things they are built for, and
+this page says where. If you are choosing exactly one security scanner and your
+main risk is injection bugs in application code, pick Semgrep or CodeQL.
+
+Ship Safe is aimed at a narrower question: *what did an AI coding agent just do
+to my repository, my CI, and my local tool configuration?*
+
+## Coverage
+
+Verified against each project's public rule registry and changelog in August
+2026. This space moves fast — if a cell is out of date, please open an issue.
+
+| | Ship Safe | Semgrep | Gitleaks | Trivy | CodeQL |
+|---|---|---|---|---|---|
+| Interprocedural taint analysis | ✗ | ✅ | ✗ | ✗ | ✅✅ |
+| Secrets in git history | ✅ | ✗ | ✅✅ | ✗ | ✗ |
+| Dependency CVEs | basic | ✗ | ✗ | ✅✅ | ✗ |
+| Container / IaC misconfig | basic | ✅ | ✗ | ✅✅ | ✗ |
+| Prompt injection in app code | ✅ | ✅ | ✗ | ✗ | ✅ (JS/TS) |
+| Malicious agent skill definitions | ✅ | ✅ (Pro) | ✗ | ✗ | ✗ |
+| CI/CD workflow misconfig | ✅ | ✅ | ✗ | ✗ | ✗ |
+| **MCP client config files** | ✅ | ✗ | ✗ | ✗ | ✗ |
+| **Agent memory poisoning** | ✅ | ✗ | ✗ | ✗ | ✗ |
+| **Hallucinated-package imports** | ✅ | ✗ | ✗ | ✗ | ✗ |
+| **AIBOM / agent attestation** | ✅ | ✗ | ✗ | ✗ | ✗ |
+| Zero-config, no rule selection | ✅ | partial | ✅ | ✅ | ✗ |
+| Runs without a build | ✅ | ✅ | ✅ | ✅ | ✗ |
+
+`✅✅` means this is the tool's core competency and it is the best available
+option. `basic` means Ship Safe checks it but a dedicated tool is better.
+
+## Where the others are clearly better
+
+- **CodeQL** does real interprocedural dataflow. If a tainted value crosses four
+  function boundaries before reaching a sink, CodeQL follows it and Ship Safe
+  does not. Ship Safe is pattern-based and does not attempt this.
+- **Gitleaks** has years of tuned entropy heuristics and detector coverage for
+  secrets. Ship Safe scans history too, but Gitleaks is the specialist.
+- **Trivy** has a real vulnerability database behind it, plus container image and
+  full IaC scanning. Ship Safe's dependency checking is not a substitute.
+- **Semgrep** has ~5,000 rules, a large community registry, and custom rule
+  authoring. It has also moved into AI security: 27 AI security rules covering
+  prompt injection and unrestricted tool use, 186 Shadow AI rules, and 122 Pro
+  rules for malicious patterns in agent skill definitions.
+
+## Where Ship Safe is currently alone
+
+These are the bolded rows above. We found no equivalent public rules in the
+other four projects as of August 2026:
+
+- **MCP client configuration.** Semgrep can analyze the *source code* of an MCP
+  server. Ship Safe reads the config files that decide which servers your editor
+  actually launches (`.cursor/mcp.json`, `.vscode/mcp.json`,
+  `claude_desktop_config.json`) and flags risky declarations: unpinned remote
+  servers, broad filesystem scope, secrets inline in the server definition.
+  Auditing a server's source is a different question from auditing what your
+  machine is configured to run.
+- **Agent memory poisoning.** Persistent instruction stores that an agent will
+  re-read on a later run, where an attacker who writes once influences every
+  subsequent session.
+- **Hallucinated-package imports.** Ship Safe flags imports that are not Node
+  builtins, not declared in `package.json`, and not present in `node_modules`,
+  which is the shape a slopsquatted suggestion takes before you install it. Note
+  this is a heuristic on unresolvable imports, not live registry verification —
+  commercial supply-chain tools such as Socket and Snyk do verify against the
+  registry and go deeper here.
+- **AIBOM and agent attestation.** Inventory of which models, agents and tools a
+  repository depends on.
+
+The honest read: this gap is narrowing. Semgrep shipped Guardian specifically to
+scan AI-generated code as it is written, and CodeQL added prompt injection
+queries in 2026. Ship Safe's advantage is in the agent's *environment and
+configuration* rather than the code it emits, and that is a smaller island than
+it was a year ago.
+
+## Noise
+
+The other half of picking a scanner is how much triage it creates. We publish a
+[false-positive benchmark](../benchmarks/false-positives/) measuring Ship Safe on
+mature projects with no known active vulnerabilities: 75 findings across express,
+requests, flask and chalk, with the 3 remaining criticals documented as false
+positives.
+
+We deliberately do **not** publish a head-to-head detection comparison. A
+vendor-run benchmark where the vendor picks the corpus is worth very little, and
+we would rather give you a reproducible measurement of our own noise than a
+scoreboard we designed to win.
+
+## Suggested combination
+
+```bash
+trivy fs .          # dependency CVEs and container/IaC misconfiguration
+gitleaks detect     # secrets across git history
+semgrep --config auto   # application-code vulnerabilities and taint
+ship-safe ci .      # agent, MCP, CI/CD and AI supply-chain surface
+```
+
+Sources: [Semgrep Guardian](https://semgrep.dev/products/product-updates/detect-risks-in-ai-generated-code-with-semgrep-guardian/),
+[Semgrep github-actions ruleset](https://registry.semgrep.dev/ruleset/github-actions),
+[CodeQL 2.26.0 changelog](https://github.blog/changelog/2026-07-10-codeql-2-26-0-adds-kotlin-2-4-0-support-and-ai-prompt-injection-detection/),
+[Trivy scanners](https://trivy.dev/latest/docs/scanner/misconfiguration/),
+[Gitleaks](https://gitleaks.org/how-gitleaks-works-deep-dive-into-secret-detection-scanning-engine-and-security-automation/).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ship-safe",
-  "version": "9.6.2",
+  "version": "9.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ship-safe",
-      "version": "9.6.2",
+      "version": "9.6.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
@@ -340,9 +340,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## 1. The audit failure

`brace-expansion` 5.0.8 → 5.0.9 ([GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895), DoS via unbounded intermediate arrays).

**No release is affected and 9.6.3 does not need reissuing.** It is transitive under `eslint → minimatch`, devDependencies only:

- `npm audit --omit=dev` → **0 vulnerabilities**
- not present in the published tarball (125 files, no `node_modules`)

Lockfile-only change, one package touched, eslint still clean.

## 2. What verifying it uncovered

The suite failed while I was checking the fix. It turned out to be unrelated and pre-existing — it reproduces identically on a stashed tree — but it is a genuine contributor-facing bug.

The test `flags prompt injection reachable from agent-readable content without an API key` never pinned itself to the offline path. `GPTRedAgent.analyze()` auto-detects any provider key in the environment, so with `KIMI_API_KEY` set it resolved a real Kimi provider and called `api.moonshot.ai`:

- 52 seconds instead of milliseconds
- a second, AI-generated `GPT_RED_AI_*` finding, so `findings.length` was 2 instead of 1
- **a real API charge for running `npm test`**

CI has no provider keys, which is why it has always been green there and only breaks on developer machines — the worst shape for this kind of bug, since it looks like the contributor broke something.

Fix is `noAi: true`, matching the convention already used by the orchestrator test at line 2215 in the same file.

## Verification

| | result |
|---|---|
| `npm audit --audit-level=high` | 0 vulnerabilities |
| `npm test` with `KIMI_API_KEY` set | 339 pass, 0 fail |
| `npm test` with the key unset | 339 pass, 0 fail |
| `npx eslint .` | 0 errors |

The middle row is the one that previously failed.