### PR TITLE
Release 9.6.4: scope the upload path-traversal rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,34 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [9.6.4] — 2026-08-03 — Upload Rule Scoping
+
+### Fixed
+- **`API_PATH_IN_FILENAME` no longer fires on Python or Ruby.** The rule targets
+  Express file uploads, but `path.join` was unanchored, so it matched the
+  substring inside Python's `os.path.join(self.root_path, filename)`. Combined
+  with a bare `filename` alternative, it reported **critical** on Flask's own
+  config loader (`src/flask/config.py:204,290`). The pattern now refuses a
+  preceding identifier or dot, and requires a property access such as
+  `file.originalname` or `req.body.name` rather than any variable named
+  `filename`. All four Express attack shapes still match; verified against
+  NodeGoat and DVWA, whose findings are unchanged.
+
+  Our own [false-positive benchmark](benchmarks/false-positives/) surfaced this,
+  which is what it is for. Clean-corpus criticals drop from 3 to 1, and flask
+  from 30 findings / 2 critical to 28 / 0.
+
+- **Dev dependency `brace-expansion` 5.0.8 → 5.0.9** ([GHSA-rgw5-rvv9-x895]
+  (https://github.com/advisories/GHSA-rgw5-rvv9-x895)). Transitive under eslint,
+  devDependencies only, so no published release was affected.
+
+- **GPT-Red test no longer makes live API calls.** A test asserting offline
+  behaviour did not pin itself offline, so any contributor with a provider key
+  in their environment got a spurious failure and a real API charge from
+  `npm test`.
+
+---
+
 ## [9.6.3] — 2026-08-03 — False Positive Reduction
 
 This release changes what existing scans report. It came out of measuring the

--- a/README.md
+++ b/README.md
@@ -247,13 +247,13 @@ about code that is almost certainly fine.
 |---|---|---|---|
 | [express](https://github.com/expressjs/express) | 26 | 0 | C |
 | [requests](https://github.com/psf/requests) | 15 | 1 | C |
-| [flask](https://github.com/pallets/flask) | 30 | 2 | D |
+| [flask](https://github.com/pallets/flask) | 28 | 0 | D |
 | [chalk](https://github.com/chalk/chalk) | 4 | 0 | B |
 
 Down from 1031 findings across the same four projects before v9.6.3, verified
 against NodeGoat and DVWA so the drop is reduced noise rather than lost
-detection. The 3 remaining criticals are false positives and the benchmark says
-which ones and why.
+detection. The 1 remaining critical is a false positive and the benchmark says
+which and why.
 
 Corpus pinned by commit, reproducible with one command, limits documented:
 **[benchmarks/false-positives/](benchmarks/false-positives/)**

--- a/benchmarks/false-positives/README.md
+++ b/benchmarks/false-positives/README.md
@@ -16,13 +16,13 @@ Ship Safe `9.6.3`, `ship-safe ci --no-deps`, corpus pinned by commit.
 
 Mature, heavily reviewed projects with no known active vulnerabilities.
 
-| project | findings | critical | high | score | grade |
-|---|---|---|---|---|---|
-| [express](https://github.com/expressjs/express) | 26 | 0 | 9 | 63.1 | C |
-| [requests](https://github.com/psf/requests) | 15 | 1 | 4 | 74.5 | C |
-| [flask](https://github.com/pallets/flask) | 30 | 2 | 12 | 54.1 | D |
-| [chalk](https://github.com/chalk/chalk) | 4 | 0 | 4 | 87.2 | B |
-| **total** | **75** | **3** | **29** | | |
+| project | findings | critical | score | grade |
+|---|---|---|---|---|
+| [express](https://github.com/expressjs/express) | 26 | 0 | 63.1 | C |
+| [requests](https://github.com/psf/requests) | 15 | 1 | 74.5 | C |
+| [flask](https://github.com/pallets/flask) | 28 | 0 | 54.5 | D |
+| [chalk](https://github.com/chalk/chalk) | 4 | 0 | 87.2 | B |
+| **total** | **73** | **1** | | |
 
 Before the 9.6.3 false-positive work these same four projects produced **1031**
 findings, with express alone at 811 and three of the four graded F. The bulk of
@@ -43,23 +43,24 @@ mistaken for progress when it is really lost detection.
 
 ## Known false positives
 
-The 3 critical findings on the clean corpus are all false positives. Naming them
-is the point of running this:
-
-- **`API_PATH_IN_FILENAME` — flask `src/flask/config.py:204,290` (2 findings).**
-  The rule targets Express file uploads
-  (`path.join(dir, req.file.originalname)`) but its regex matches the substring
-  `path.join(` inside Python's `os.path.join(self.root_path, filename)`, where
-  `filename` is an ordinary local variable. A JavaScript upload rule firing on
-  Python framework code, at the severity that gates CI. This is the highest
-  impact remaining false positive.
+The 1 remaining critical finding on the clean corpus is a false positive.
+Naming it is the point of running this:
 
 - **`GIT_HISTORY_SECRET` — requests `tests/certs/expired/ca/ca-private.key`.**
   A deliberately expired test-fixture private key. Working-tree findings in test
   directories are filtered, but history scanning reads commits rather than
   paths, so the filter does not reach it.
 
-Beyond critical, flask's remaining 30 findings are the weakest result in the
+Fixed since the first run of this benchmark:
+
+- **`API_PATH_IN_FILENAME` — flask `src/flask/config.py:204,290`.** The rule
+  targets Express file uploads but its regex matched the substring `path.join(`
+  inside Python's `os.path.join(self.root_path, filename)`. Fixed in 9.6.4 by
+  anchoring the pattern so it cannot match `os.path.join`, and by requiring a
+  property access such as `file.originalname` rather than any variable named
+  `filename`. This benchmark is what surfaced it.
+
+Beyond critical, flask's remaining 28 findings are the weakest result in the
 corpus and are a mix rather than one dominant cause.
 
 ## Honest limits

--- a/benchmarks/false-positives/results/latest.json
+++ b/benchmarks/false-positives/results/latest.json
@@ -27,10 +27,10 @@
       "id": "flask",
       "repo": "pallets/flask",
       "commit": "6a2f545bfd8ed31e19066a299296917e034aca58",
-      "findings": 30,
-      "critical": 2,
+      "findings": 28,
+      "critical": 0,
       "high": 12,
-      "score": 54.1,
+      "score": 54.5,
       "grade": "D"
     },
     {
@@ -64,8 +64,8 @@
   ],
   "summary": {
     "cleanProjects": 4,
-    "cleanFindings": 75,
-    "cleanCriticalFindings": 3,
+    "cleanFindings": 73,
+    "cleanCriticalFindings": 1,
     "vulnerableProjects": 2,
     "vulnerableFindings": 157
   }

--- a/cli/__tests__/agents.test.js
+++ b/cli/__tests__/agents.test.js
@@ -164,6 +164,27 @@ describe('APIFuzzer', async () => {
       assert.ok(findings.some(f => f.rule === 'API_DEBUG_ENDPOINT'));
     } finally { cleanup(dir); }
   });
+
+  it('detects user-controlled filename in upload path construction', async () => {
+    const { dir, file } = writeTempFile('const dest = path.join(uploadDir, req.file.originalname);');
+    try {
+      const findings = await agent.analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+      assert.ok(findings.some(f => f.rule === 'API_PATH_IN_FILENAME'));
+    } finally { cleanup(dir); }
+  });
+
+  it('does not flag os.path.join in Python or a bare filename variable', async () => {
+    // This agent scans .py and .rb too, so an Express upload rule used to fire
+    // at critical severity on Flask's own config loader.
+    const py = writeTempFile('filename = os.path.join(self.root_path, filename)', '.py');
+    const js = writeTempFile('const p = path.join(dir, filename);');
+    try {
+      for (const { dir, file } of [py, js]) {
+        const findings = await agent.analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+        assert.equal(findings.filter(f => f.rule === 'API_PATH_IN_FILENAME').length, 0);
+      }
+    } finally { cleanup(py.dir); cleanup(js.dir); }
+  });
 });
 
 // =============================================================================

--- a/cli/agents/api-fuzzer.js
+++ b/cli/agents/api-fuzzer.js
@@ -99,7 +99,18 @@ const PATTERNS = [
   {
     rule: 'API_PATH_IN_FILENAME',
     title: 'API: Path Traversal in File Upload',
-    regex: /path\.join\s*\([^)]*(?:originalname|filename|req\.file|req\.body)/g,
+    // Two boundaries matter here, and the original pattern had neither.
+    //
+    // `(?<![\w.])` stops `path.join` matching inside Python's
+    // `os.path.join(self.root_path, filename)`. This agent scans .py and .rb as
+    // well as JS, so an Express upload rule was firing at critical severity on
+    // Flask's own config loader (src/flask/config.py:204).
+    //
+    // Requiring a property access rather than a bare `filename` stops any local
+    // variable that happens to carry that name from looking like user input.
+    // Multer exposes `file.originalname` and `file.filename`, so the real
+    // attack shape always has the dot.
+    regex: /(?<![\w.])path\.join\s*\([^)]*(?:\.originalname\b|\.filename\b|req\.(?:file|files|body|query|params)\b)/g,
     severity: 'critical',
     cwe: 'CWE-22',
     owasp: 'A01:2021',

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -80,9 +80,9 @@ it was a year ago.
 
 The other half of picking a scanner is how much triage it creates. We publish a
 [false-positive benchmark](../benchmarks/false-positives/) measuring Ship Safe on
-mature projects with no known active vulnerabilities: 75 findings across express,
-requests, flask and chalk, with the 3 remaining criticals documented as false
-positives.
+mature projects with no known active vulnerabilities: 73 findings across express,
+requests, flask and chalk, with the 1 remaining critical documented as a false
+positive.
 
 We deliberately do **not** publish a head-to-head detection comparison. A
 vendor-run benchmark where the vendor picks the corpus is worth very little, and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ship-safe",
-  "version": "9.6.3",
+  "version": "9.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ship-safe",
-      "version": "9.6.3",
+      "version": "9.6.4",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ship-safe",
-  "version": "9.6.3",
-  "description": "AI-powered multi-agent security platform. 29 agents scan 80+ attack classes including AI integration supply chain (Vercel-class attacks), Hermes Agent deployments (ASI-01\u2013ASI-10), tool registry poisoning, function-call injection, skill permission drift, and agent attestation. Ship Safe \u00d7 Hermes Agent.",
+  "version": "9.6.4",
+  "description": "AI-powered multi-agent security platform. 29 agents scan 80+ attack classes including AI integration supply chain (Vercel-class attacks), Hermes Agent deployments (ASI-01–ASI-10), tool registry poisoning, function-call injection, skill permission drift, and agent attestation. Ship Safe × Hermes Agent.",
   "main": "cli/index.js",
   "bin": {
     "ship-safe": "cli/bin/ship-safe.js"


### PR DESCRIPTION
Fixes the false positive our own benchmark documented in 9.6.3.

`API_PATH_IN_FILENAME` targets Express uploads, but `path.join` was unanchored so it matched inside Python's `os.path.join(self.root_path, filename)`. Since this agent scans `.py` and `.rb` too, it reported **critical** on Flask's config loader. Bare `filename` as an alternative made it worse.

The pattern now refuses a preceding identifier or dot, and requires a property access like `file.originalname` instead of any variable named `filename`.

| | before | after |
|---|---|---|
| flask | 30 findings, 2 critical | 28, 0 |
| clean corpus criticals | 3 | 1 |
| NodeGoat | 74 findings, 9 critical | unchanged |
| DVWA | 83 findings, 6 critical | unchanged |

Also carries the `brace-expansion` bump and GPT-Red test fix from #101.

341 tests pass, 0 lint errors, self-scan clean. Benchmark results and the README/comparison figures are regenerated rather than hand-edited.