### PR TITLE
Recalibrate 14 rules against hermes-agent: 6,948 findings to 818

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,34 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [9.6.4] — 2026-08-03 — Upload Rule Scoping
+
+### Fixed
+- **`API_PATH_IN_FILENAME` no longer fires on Python or Ruby.** The rule targets
+  Express file uploads, but `path.join` was unanchored, so it matched the
+  substring inside Python's `os.path.join(self.root_path, filename)`. Combined
+  with a bare `filename` alternative, it reported **critical** on Flask's own
+  config loader (`src/flask/config.py:204,290`). The pattern now refuses a
+  preceding identifier or dot, and requires a property access such as
+  `file.originalname` or `req.body.name` rather than any variable named
+  `filename`. All four Express attack shapes still match; verified against
+  NodeGoat and DVWA, whose findings are unchanged.
+
+  Our own [false-positive benchmark](benchmarks/false-positives/) surfaced this,
+  which is what it is for. Clean-corpus criticals drop from 3 to 1, and flask
+  from 30 findings / 2 critical to 28 / 0.
+
+- **Dev dependency `brace-expansion` 5.0.8 → 5.0.9** ([GHSA-rgw5-rvv9-x895]
+  (https://github.com/advisories/GHSA-rgw5-rvv9-x895)). Transitive under eslint,
+  devDependencies only, so no published release was affected.
+
+- **GPT-Red test no longer makes live API calls.** A test asserting offline
+  behaviour did not pin itself offline, so any contributor with a provider key
+  in their environment got a spurious failure and a real API charge from
+  `npm test`.
+
+---
+
 ## [9.6.3] — 2026-08-03 — False Positive Reduction
 
 This release changes what existing scans report. It came out of measuring the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,48 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   '127.0.0.1'` in translated READMEs. The clean corpus improves from 73
   findings to 67.
 
-  16 other rules share the backtracking-lookahead defect and are tracked for
-  follow-up.
+  Continued through the long tail, another nine rules:
+
+  - `AGENT_NO_COST_LIMIT`, `AGENT_NO_OUTPUT_SCHEMA`, `LLM_NO_COST_LIMIT` and
+    `OAUTH_NO_STATE` carried the same never-failing absence assertion.
+    `OAUTH_NO_STATE` was worse: its alternation put the lookahead on only the
+    last branch, so the first two matched any mention of an authorize URL
+    unconditionally. Spend control is now asked once per project, where a
+    budget is actually configured.
+  - `SQL_INJECTION_TEMPLATE_LITERAL` listed `CREATE` as a bare alternative, so
+    ``showToast(`Create failed: ${e}`)`` was 24 criticals on a file browser.
+    `PYTHON_SQL_FSTRING` flagged `f"Select a model ({n} available)"`. Both now
+    require clause structure — SELECT with FROM, UPDATE with SET — instead of a
+    keyword.
+  - Patterns can now set `skipComments`. A comment explaining why code *avoids*
+    the cloud metadata endpoint is not access to it, and that was every
+    `SSRF_CLOUD_METADATA` hit. `SSRF_INTERNAL_IP` also stops flagging loopback
+    OAuth redirect URIs, which RFC 8252 recommends for native apps.
+  - `CODE_INJECTION_EVAL_GENERIC` counted any method named `eval` — `cdp.eval`,
+    the Chrome DevTools Protocol helper, 126 times. `API_UPLOAD_NO_TYPE_CHECK`
+    matched `filename)` in any language, the same mistake 9.6.4 fixed next door.
+    `TIMING_ATTACK_COMPARISON` flagged two locally held values compared to each
+    other. `AGENT_TOOL_SHELL_ACCESS` fired on any file containing the word
+    "tools" and a subprocess call.
+  - `SlopSquatAgent` resolved every import against the root `package.json`, so
+    in a workspace every sub-package dependency looked hallucinated. It now
+    walks up from the importing file the way Node does. 137 → 33.
+
+  **hermes-agent: 6,948 → 818, an 88% reduction.** Clean corpus 73 → 57;
+  express and flask reach C, requests B. NodeGoat did not move by a single
+  finding. hermes-agent is now a pinned clean-corpus entry.
+
+- **`MCPSecurityAgent` referenced `createFinding` without importing it.** The
+  new per-file tool-validation check threw a `ReferenceError` that the
+  orchestrator swallowed, taking the rest of that agent's output for MCP server
+  files with it.
+
+### Known issues
+
+- 16 rules still carry the backtracking-lookahead defect, and the score
+  saturates after 3–5 medium findings per category, which is why hermes-agent
+  reports the same 13/F at 818 findings as it did at 6,948. Both are tracked as
+  issues.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,46 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `MCP_TOOL_ALIAS_BYPASS` flags tool alias mappings that can route allowlisted names to different tools.
   - `MCP_NESTED_PERMISSION_OVERRIDE` flags nested permission blocks with wildcard expansion inside server entries.
 
+### Fixed
+- **Five rules recalibrated against a large Python agent codebase.** Scanning
+  [hermes-agent](https://github.com/NousResearch/hermes-agent) (~8,400 files) at
+  `743dc94` produced **6,948 findings**, and five rules accounted for 4,684 of
+  them. Each turned out to be a defect rather than a threshold problem.
+
+  - `PII_EMAIL_HARDCODED` (2,037 → 0 on that repo). Two bugs. The `noreply`
+    exclusion was anchored to the first domain label, so GitHub's
+    `<id>+<user>@users.noreply.github.com` privacy addresses — the ones GitHub
+    issues *specifically* to keep a contributor's real address private — never
+    matched it. And a contributor credit map was reported once per entry: 1,963
+    findings from `scripts/release.py` alone, 28% of the entire report. Files
+    holding more than 10 addresses now produce one `PII_EMAIL_DIRECTORY`
+    finding describing the file, and `.mailmap` / `AUTHORS` / `CONTRIBUTORS`
+    are skipped outright. A single stray address still reports as before.
+  - `AGENT_NO_AUDIT_LOG` (1,904 → per-file). The rule asserted the *absence* of
+    logging using a negative lookahead placed after `[\s\S]{0,300}`. A
+    variable-length gap backtracks until the lookahead succeeds, so the
+    assertion could never fail and every line mentioning `tool_call` fired. Now
+    a structural check: at most one finding per file, and any logger in the
+    file refutes it.
+  - `AGENT_MEMORY_NO_EXPIRY` (234 → per-file). Same defect, same fix.
+  - `AGENT_OUTPUT_TO_ACTION` (329 → 0 on that repo). Matched any `.run` within
+    100 characters of a variable named `result`, which is `subprocess.run` in
+    every Python CLI ever written. Now requires the action to be invoked on the
+    model output itself.
+  - `SSRF_INTERNAL_IP` (312 → 102). Fired on bare private-IP literals, so
+    local-first software binding loopback on purpose was reported 312 times for
+    following its own documentation. Now requires an outbound-request context.
+
+  Total on hermes-agent: **6,948 → 2,264**, a 67% reduction, with triage of the
+  remaining long tail still to come. Detection is unchanged: NodeGoat holds at
+  74 findings / 9 critical / 18 high, and DVWA's criticals and highs are
+  identical, its only two lost findings being `$_DVWA['db_server'] =
+  '127.0.0.1'` in translated READMEs. The clean corpus improves from 73
+  findings to 67.
+
+  16 other rules share the backtracking-lookahead defect and are tracked for
+  follow-up.
+
 ---
 
 ## [9.6.4] — 2026-08-03 — Upload Rule Scoping

--- a/README.md
+++ b/README.md
@@ -247,13 +247,13 @@ about code that is almost certainly fine.
 |---|---|---|---|
 | [express](https://github.com/expressjs/express) | 26 | 0 | C |
 | [requests](https://github.com/psf/requests) | 15 | 1 | C |
-| [flask](https://github.com/pallets/flask) | 30 | 2 | D |
+| [flask](https://github.com/pallets/flask) | 28 | 0 | D |
 | [chalk](https://github.com/chalk/chalk) | 4 | 0 | B |
 
 Down from 1031 findings across the same four projects before v9.6.3, verified
 against NodeGoat and DVWA so the drop is reduced noise rather than lost
-detection. The 3 remaining criticals are false positives and the benchmark says
-which ones and why.
+detection. The 1 remaining critical is a false positive and the benchmark says
+which and why.
 
 Corpus pinned by commit, reproducible with one command, limits documented:
 **[benchmarks/false-positives/](benchmarks/false-positives/)**

--- a/benchmarks/false-positives/README.md
+++ b/benchmarks/false-positives/README.md
@@ -16,13 +16,13 @@ Ship Safe `9.6.3`, `ship-safe ci --no-deps`, corpus pinned by commit.
 
 Mature, heavily reviewed projects with no known active vulnerabilities.
 
-| project | findings | critical | high | score | grade |
-|---|---|---|---|---|---|
-| [express](https://github.com/expressjs/express) | 26 | 0 | 9 | 63.1 | C |
-| [requests](https://github.com/psf/requests) | 15 | 1 | 4 | 74.5 | C |
-| [flask](https://github.com/pallets/flask) | 30 | 2 | 12 | 54.1 | D |
-| [chalk](https://github.com/chalk/chalk) | 4 | 0 | 4 | 87.2 | B |
-| **total** | **75** | **3** | **29** | | |
+| project | findings | critical | score | grade |
+|---|---|---|---|---|
+| [express](https://github.com/expressjs/express) | 26 | 0 | 63.1 | C |
+| [requests](https://github.com/psf/requests) | 15 | 1 | 74.5 | C |
+| [flask](https://github.com/pallets/flask) | 28 | 0 | 54.5 | D |
+| [chalk](https://github.com/chalk/chalk) | 4 | 0 | 87.2 | B |
+| **total** | **73** | **1** | | |
 
 Before the 9.6.3 false-positive work these same four projects produced **1031**
 findings, with express alone at 811 and three of the four graded F. The bulk of
@@ -43,23 +43,24 @@ mistaken for progress when it is really lost detection.
 
 ## Known false positives
 
-The 3 critical findings on the clean corpus are all false positives. Naming them
-is the point of running this:
-
-- **`API_PATH_IN_FILENAME` — flask `src/flask/config.py:204,290` (2 findings).**
-  The rule targets Express file uploads
-  (`path.join(dir, req.file.originalname)`) but its regex matches the substring
-  `path.join(` inside Python's `os.path.join(self.root_path, filename)`, where
-  `filename` is an ordinary local variable. A JavaScript upload rule firing on
-  Python framework code, at the severity that gates CI. This is the highest
-  impact remaining false positive.
+The 1 remaining critical finding on the clean corpus is a false positive.
+Naming it is the point of running this:
 
 - **`GIT_HISTORY_SECRET` — requests `tests/certs/expired/ca/ca-private.key`.**
   A deliberately expired test-fixture private key. Working-tree findings in test
   directories are filtered, but history scanning reads commits rather than
   paths, so the filter does not reach it.
 
-Beyond critical, flask's remaining 30 findings are the weakest result in the
+Fixed since the first run of this benchmark:
+
+- **`API_PATH_IN_FILENAME` — flask `src/flask/config.py:204,290`.** The rule
+  targets Express file uploads but its regex matched the substring `path.join(`
+  inside Python's `os.path.join(self.root_path, filename)`. Fixed in 9.6.4 by
+  anchoring the pattern so it cannot match `os.path.join`, and by requiring a
+  property access such as `file.originalname` rather than any variable named
+  `filename`. This benchmark is what surfaced it.
+
+Beyond critical, flask's remaining 28 findings are the weakest result in the
 corpus and are a mix rather than one dominant cause.
 
 ## Honest limits

--- a/benchmarks/false-positives/README.md
+++ b/benchmarks/false-positives/README.md
@@ -8,21 +8,22 @@ This measures the other half. What does Ship Safe say about code that is almost
 certainly fine? Every finding on a healthy codebase is triage work a user
 inherits, and enough of them make a tool something you turn off.
 
-## Results — v9.6.3
+## Results — unreleased
 
-Ship Safe `9.6.3`, `ship-safe ci --no-deps`, corpus pinned by commit.
+Ship Safe at `HEAD`, `ship-safe ci --no-deps`, corpus pinned by commit.
 
 ### Clean corpus
 
 Mature, heavily reviewed projects with no known active vulnerabilities.
 
-| project | findings | critical | score | grade |
-|---|---|---|---|---|
-| [express](https://github.com/expressjs/express) | 26 | 0 | 63.1 | C |
-| [requests](https://github.com/psf/requests) | 15 | 1 | 74.5 | C |
-| [flask](https://github.com/pallets/flask) | 28 | 0 | 54.5 | D |
-| [chalk](https://github.com/chalk/chalk) | 4 | 0 | 87.2 | B |
-| **total** | **73** | **1** | | |
+| project | findings | critical | score | grade | was (9.6.3) |
+|---|---|---|---|---|---|
+| [express](https://github.com/expressjs/express) | 22 | 0 | 71.3 | C | 26 |
+| [requests](https://github.com/psf/requests) | 11 | 1 | 81.1 | B | 15 |
+| [flask](https://github.com/pallets/flask) | 20 | 0 | 67.7 | C | 28 |
+| [chalk](https://github.com/chalk/chalk) | 4 | 0 | 87.2 | B | 4 |
+| [hermes-agent](https://github.com/NousResearch/hermes-agent) | 818 | 115 | 13 | F | — |
+| **total (original four)** | **57** | **1** | | | **73** |
 
 Before the 9.6.3 false-positive work these same four projects produced **1031**
 findings, with express alone at 811 and three of the four graded F. The bulk of
@@ -30,6 +31,23 @@ that noise was test and fixture code, which deliberately contains
 credential-shaped strings and minimal apps that skip production controls. 528 of
 express's 601 `API_NO_SECURITY_HEADERS` hits were in `test/`, against 2 in
 `lib/`.
+
+### hermes-agent, and why it is here
+
+[hermes-agent](https://github.com/NousResearch/hermes-agent) joined the clean
+corpus because the original four are small, and three of them are libraries. It
+is ~8,400 files of actively maintained Python, and it is in our own domain: an
+AI agent with tools, MCP servers, memory, and a gateway. Rules written for
+agent security should be measured against a real agent.
+
+It found more than any other corpus entry ever has. The first run reported
+**6,948 findings**, of which five rules were 4,684 — including 1,963 on a single
+contributor credit map, and two rules whose absence-assertions were structurally
+incapable of failing. It is now at **818**, an 88% reduction, with the full
+accounting in the changelog for this release.
+
+818 is not a passing number and this table does not pretend otherwise. The
+remaining tail is documented under "Known false positives" below.
 
 ### Vulnerable corpus
 
@@ -39,7 +57,22 @@ mistaken for progress when it is really lost detection.
 | project | findings | critical | high |
 |---|---|---|---|
 | [NodeGoat](https://github.com/OWASP/NodeGoat) | 74 | 9 | 18 |
-| [DVWA](https://github.com/digininja/DVWA) | 83 | 6 | 55 |
+| [DVWA](https://github.com/digininja/DVWA) | 76 | 6 | 55 |
+
+Across the entire recalibration NodeGoat did not move by a single finding, and
+DVWA's criticals and highs are unchanged. DVWA's 7 lost mediums were
+`$_DVWA['db_server'] = '127.0.0.1'` in translated READMEs and similar.
+
+### The score column is less informative than it looks
+
+Category deductions are capped at the category's weight, and the eight weights
+sum to 100. Each category therefore saturates after **3 to 5 medium-severity
+findings**. Past that point the score stops responding: hermes-agent scored 13/F
+at 6,948 findings and still scores 13/F at 818.
+
+This is why the table leads with finding counts. Treat the score as a signal
+only for small, already-clean projects, and see the tracking issue on scoring
+saturation.
 
 ## Known false positives
 
@@ -60,8 +93,28 @@ Fixed since the first run of this benchmark:
   property access such as `file.originalname` rather than any variable named
   `filename`. This benchmark is what surfaced it.
 
-Beyond critical, flask's remaining 28 findings are the weakest result in the
-corpus and are a mix rather than one dominant cause.
+Beyond critical, flask's remaining 20 findings are a mix rather than one
+dominant cause.
+
+### hermes-agent's remaining 818
+
+Not yet triaged, listed so the next pass has a starting point. Counts are from
+the run that produced this table.
+
+| rule | count | first read |
+|---|---|---|
+| `SSRF_INTERNAL_IP` | 98 | local-first software talking to its own loopback services |
+| `RUST_UNWRAP_IN_PROD` | 58 | `.unwrap()` in a small native extension; a lint, not a vulnerability, and arguably out of scope at medium |
+| `AGENT_TOOL_CALL_REPLAY_MISSING_ASSISTANT` | 33 | needs checking against their actual message-history handling |
+| `AGENT_NO_COST_LIMIT` | 33 | now per-file; a project-level question asked per file will always over-report |
+| `SLOPSQUAT_PHANTOM_IMPORT` | 33 | down from 137 after workspace resolution; the rest need checking |
+| `AGENT_REMOTE_EXEC_INSTRUCTION` | 32 | `curl \| bash` in the project's own install docs, across translations |
+| `AGENT_NO_OUTPUT_SCHEMA` | 22 | same shape as the cost-limit rule |
+| `Password Assignment` | 21 | secret scanner; needs sampling |
+
+The two structural issues behind much of this tail — rules that assert an
+absence per line, and the scoring saturation above — are tracked as issues
+rather than patched case by case.
 
 ## Honest limits
 

--- a/benchmarks/false-positives/corpus.json
+++ b/benchmarks/false-positives/corpus.json
@@ -5,7 +5,8 @@
     { "id": "express",  "repo": "expressjs/express", "commit": "a3714473feb3d2908add734d340e7755fd85e0a3", "language": "javascript" },
     { "id": "requests", "repo": "psf/requests",      "commit": "414f0513c33883adf6f2b46901d4f0b38a455851", "language": "python" },
     { "id": "flask",    "repo": "pallets/flask",     "commit": "6a2f545bfd8ed31e19066a299296917e034aca58", "language": "python" },
-    { "id": "chalk",    "repo": "chalk/chalk",       "commit": "661317e6f91fe7c90306c2c48ea9354562ee9146", "language": "javascript" }
+    { "id": "chalk",    "repo": "chalk/chalk",       "commit": "661317e6f91fe7c90306c2c48ea9354562ee9146", "language": "javascript" },
+    { "id": "hermes-agent", "repo": "NousResearch/hermes-agent", "commit": "743dc94ab90adb0529bb233b8498c6fd6ee0e020", "language": "python" }
   ],
   "vulnerable": [
     { "id": "NodeGoat", "repo": "OWASP/NodeGoat",    "commit": "c5cb68a7084e4ae7dcc60e6a98768720a81841e8", "language": "javascript" },

--- a/benchmarks/false-positives/results/latest.json
+++ b/benchmarks/false-positives/results/latest.json
@@ -27,10 +27,10 @@
       "id": "flask",
       "repo": "pallets/flask",
       "commit": "6a2f545bfd8ed31e19066a299296917e034aca58",
-      "findings": 30,
-      "critical": 2,
+      "findings": 28,
+      "critical": 0,
       "high": 12,
-      "score": 54.1,
+      "score": 54.5,
       "grade": "D"
     },
     {
@@ -64,8 +64,8 @@
   ],
   "summary": {
     "cleanProjects": 4,
-    "cleanFindings": 75,
-    "cleanCriticalFindings": 3,
+    "cleanFindings": 73,
+    "cleanCriticalFindings": 1,
     "vulnerableProjects": 2,
     "vulnerableFindings": 157
   }

--- a/benchmarks/false-positives/results/latest.json
+++ b/benchmarks/false-positives/results/latest.json
@@ -1,37 +1,37 @@
 {
   "tool": "ship-safe",
-  "version": "9.6.3",
+  "version": "9.6.4",
   "methodology": "Findings reported by `ship-safe ci --no-deps` against pinned checkouts. Clean corpus: mature projects with no known active vulnerabilities, where every finding is triage a user inherits. Vulnerable corpus: deliberately insecure applications, present so a reduction in noise cannot be mistaken for lost detection. Counts are a proxy for a false-positive rate, not a verified one.",
   "clean": [
     {
       "id": "express",
       "repo": "expressjs/express",
       "commit": "a3714473feb3d2908add734d340e7755fd85e0a3",
-      "findings": 26,
+      "findings": 22,
       "critical": 0,
-      "high": 9,
-      "score": 63.1,
+      "high": 5,
+      "score": 71.3,
       "grade": "C"
     },
     {
       "id": "requests",
       "repo": "psf/requests",
       "commit": "414f0513c33883adf6f2b46901d4f0b38a455851",
-      "findings": 15,
+      "findings": 11,
       "critical": 1,
-      "high": 4,
-      "score": 74.5,
-      "grade": "C"
+      "high": 2,
+      "score": 81.1,
+      "grade": "B"
     },
     {
       "id": "flask",
       "repo": "pallets/flask",
       "commit": "6a2f545bfd8ed31e19066a299296917e034aca58",
-      "findings": 28,
+      "findings": 20,
       "critical": 0,
-      "high": 12,
-      "score": 54.5,
-      "grade": "D"
+      "high": 7,
+      "score": 67.7,
+      "grade": "C"
     },
     {
       "id": "chalk",
@@ -42,6 +42,16 @@
       "high": 4,
       "score": 87.2,
       "grade": "B"
+    },
+    {
+      "id": "hermes-agent",
+      "repo": "NousResearch/hermes-agent",
+      "commit": "743dc94ab90adb0529bb233b8498c6fd6ee0e020",
+      "findings": 818,
+      "critical": 115,
+      "high": 226,
+      "score": 13,
+      "grade": "F"
     }
   ],
   "vulnerable": [
@@ -57,16 +67,16 @@
       "id": "DVWA",
       "repo": "digininja/DVWA",
       "commit": "d45ba3c4e7efa7f023f25f58ab4af9912c887057",
-      "findings": 83,
+      "findings": 76,
       "critical": 6,
       "high": 55
     }
   ],
   "summary": {
-    "cleanProjects": 4,
-    "cleanFindings": 73,
-    "cleanCriticalFindings": 1,
+    "cleanProjects": 5,
+    "cleanFindings": 875,
+    "cleanCriticalFindings": 116,
     "vulnerableProjects": 2,
-    "vulnerableFindings": 157
+    "vulnerableFindings": 150
   }
 }

--- a/cli/__tests__/agents.test.js
+++ b/cli/__tests__/agents.test.js
@@ -164,6 +164,27 @@ describe('APIFuzzer', async () => {
       assert.ok(findings.some(f => f.rule === 'API_DEBUG_ENDPOINT'));
     } finally { cleanup(dir); }
   });
+
+  it('detects user-controlled filename in upload path construction', async () => {
+    const { dir, file } = writeTempFile('const dest = path.join(uploadDir, req.file.originalname);');
+    try {
+      const findings = await agent.analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+      assert.ok(findings.some(f => f.rule === 'API_PATH_IN_FILENAME'));
+    } finally { cleanup(dir); }
+  });
+
+  it('does not flag os.path.join in Python or a bare filename variable', async () => {
+    // This agent scans .py and .rb too, so an Express upload rule used to fire
+    // at critical severity on Flask's own config loader.
+    const py = writeTempFile('filename = os.path.join(self.root_path, filename)', '.py');
+    const js = writeTempFile('const p = path.join(dir, filename);');
+    try {
+      for (const { dir, file } of [py, js]) {
+        const findings = await agent.analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+        assert.equal(findings.filter(f => f.rule === 'API_PATH_IN_FILENAME').length, 0);
+      }
+    } finally { cleanup(py.dir); cleanup(js.dir); }
+  });
 });
 
 // =============================================================================

--- a/cli/__tests__/agents.test.js
+++ b/cli/__tests__/agents.test.js
@@ -2706,3 +2706,150 @@ describe('SSRF internal IP calibration', async () => {
     } finally { cleanup(dir); }
   });
 });
+
+describe('Long-tail calibration — hermes-agent corpus', async () => {
+  const { InjectionTester } = await import('../agents/injection-tester.js');
+  const { SSRFProber } = await import('../agents/ssrf-prober.js');
+  const { AuthBypassAgent } = await import('../agents/auth-bypass-agent.js');
+  const { SlopSquatAgent } = await import('../agents/slopsquat-agent.js');
+  const { LLMRedTeam } = await import('../agents/llm-redteam.js');
+
+  const run = async (agent, files, dir) =>
+    agent.analyze({ rootPath: dir, files, recon: {}, options: {} });
+
+  it('does not read an English sentence starting with "Create" as SQL', async () => {
+    const { dir, file } = writeTempFile('showToast(`Create failed: ${e}`, "error");');
+    try {
+      const findings = await run(new InjectionTester(), [file], dir);
+      assert.equal(findings.filter(f => f.rule === 'SQL_INJECTION_TEMPLATE_LITERAL').length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('still flags a real interpolated SQL template literal', async () => {
+    const { dir, file } = writeTempFile('db.query(`SELECT * FROM users WHERE id = ${id}`);');
+    try {
+      const findings = await run(new InjectionTester(), [file], dir);
+      assert.ok(findings.some(f => f.rule === 'SQL_INJECTION_TEMPLATE_LITERAL'));
+    } finally { cleanup(dir); }
+  });
+
+  it('does not read an f-string prompt as SQL', async () => {
+    const { dir, file } = writeTempFile('hint = f"Select a model ({len(models)} available)"\n', '.py');
+    try {
+      const findings = await run(new InjectionTester(), [file], dir);
+      assert.equal(findings.filter(f => f.rule === 'PYTHON_SQL_FSTRING').length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('accepts the parameterised IN-clause idiom', async () => {
+    const { dir, file } = writeTempFile(
+      'ph = ",".join("?" * len(ids))\nconn.execute(f"DELETE FROM messages WHERE id IN ({ph})", ids)\n', '.py');
+    try {
+      const findings = await run(new InjectionTester(), [file], dir);
+      assert.equal(findings.filter(f => f.rule === 'PYTHON_SQL_FSTRING').length, 0,
+        'values are bound; only the placeholder string is interpolated');
+    } finally { cleanup(dir); }
+  });
+
+  it('does not treat a method named eval as the global sink', async () => {
+    const { dir, file } = writeTempFile('await cdp.eval(expression);');
+    try {
+      const findings = await run(new InjectionTester(), [file], dir);
+      assert.equal(findings.filter(f => f.rule === 'CODE_INJECTION_EVAL_GENERIC').length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('still flags a bare eval call', async () => {
+    const { dir, file } = writeTempFile('const v = eval(payload);');
+    try {
+      const findings = await run(new InjectionTester(), [file], dir);
+      assert.ok(findings.some(f => f.rule === 'CODE_INJECTION_EVAL_GENERIC'));
+    } finally { cleanup(dir); }
+  });
+
+  it('ignores a metadata endpoint named only in a comment', async () => {
+    const { dir, file } = writeTempFile(
+      '# avoid probing 169.254.169.254 when not on EC2\nclient = build()\n', '.py');
+    try {
+      const findings = await run(new SSRFProber(), [file], dir);
+      assert.equal(findings.filter(f => f.rule === 'SSRF_CLOUD_METADATA').length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('still flags a metadata endpoint actually requested', async () => {
+    const { dir, file } = writeTempFile('requests.get("http://169.254.169.254/latest/meta-data/")\n', '.py');
+    try {
+      const findings = await run(new SSRFProber(), [file], dir);
+      assert.ok(findings.some(f => f.rule === 'SSRF_CLOUD_METADATA'));
+    } finally { cleanup(dir); }
+  });
+
+  it('ignores a loopback OAuth redirect URI', async () => {
+    const { dir, file } = writeTempFile(
+      'DEFAULT_REDIRECT_URI = "http://127.0.0.1:43827/spotify/callback"\n', '.py');
+    try {
+      const findings = await run(new SSRFProber(), [file], dir);
+      assert.equal(findings.filter(f => f.rule === 'SSRF_INTERNAL_IP').length, 0,
+        'RFC 8252 recommends a loopback redirect for native apps');
+    } finally { cleanup(dir); }
+  });
+
+  it('ignores equality between two locally held secrets', async () => {
+    const { dir, file } = writeTempFile('if new_token == self._anthropic_api_key:\n    pass\n', '.py');
+    try {
+      const findings = await run(new AuthBypassAgent(), [file], dir);
+      assert.equal(findings.filter(f => f.rule === 'TIMING_ATTACK_COMPARISON').length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('still flags a request-supplied token compared to a stored secret', async () => {
+    const { dir, file } = writeTempFile('if (req.headers["x-api-key"] === API_TOKEN) { allow(); }');
+    try {
+      const findings = await run(new AuthBypassAgent(), [file], dir);
+      assert.ok(findings.some(f => f.rule === 'TIMING_ATTACK_COMPARISON'));
+    } finally { cleanup(dir); }
+  });
+
+  it('resolves imports against the nearest package.json in a workspace', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-ws-'));
+    try {
+      fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'root' }));
+      const app = path.join(dir, 'apps', 'desktop');
+      fs.mkdirSync(app, { recursive: true });
+      fs.writeFileSync(path.join(app, 'package.json'),
+        JSON.stringify({ name: 'desktop', dependencies: { 'some-real-dep': '^1.0.0' } }));
+      const file = path.join(app, 'index.js');
+      fs.writeFileSync(file, "import x from 'some-real-dep';\n");
+
+      const findings = await run(new SlopSquatAgent(), [file], dir);
+      assert.equal(findings.filter(f => f.rule === 'SLOPSQUAT_PHANTOM_IMPORT').length, 0,
+        'a workspace dependency is declared, not hallucinated');
+    } finally { cleanup(dir); }
+  });
+
+  it('reports absent LLM spend controls once for the project', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-llm-'));
+    try {
+      const files = [];
+      for (let i = 0; i < 5; i++) {
+        const f = path.join(dir, `call${i}.js`);
+        fs.writeFileSync(f, 'await client.chat.completions.create({ model: "gpt-4" });\n');
+        files.push(f);
+      }
+      const findings = await run(new LLMRedTeam(), files, dir);
+      assert.equal(findings.filter(f => f.rule === 'LLM_NO_COST_LIMIT').length, 1);
+    } finally { cleanup(dir); }
+  });
+
+  it('stays quiet about spend controls when a budget exists somewhere', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-llm2-'));
+    try {
+      const a = path.join(dir, 'call.js');
+      const b = path.join(dir, 'config.js');
+      fs.writeFileSync(a, 'await client.chat.completions.create({ model: "gpt-4" });\n');
+      fs.writeFileSync(b, 'export const TOKEN_BUDGET = 100000;\n');
+      const findings = await run(new LLMRedTeam(), [a, b], dir);
+      assert.equal(findings.filter(f => f.rule === 'LLM_NO_COST_LIMIT').length, 0);
+    } finally { cleanup(dir); }
+  });
+});

--- a/cli/__tests__/agents.test.js
+++ b/cli/__tests__/agents.test.js
@@ -2578,3 +2578,131 @@ Run security audits on your codebase before deploying.
     assert.equal(critical.length, 0, 'Well-formed skill should have no critical/high findings');
   });
 });
+
+// =============================================================================
+// FALSE-POSITIVE CALIBRATION — hermes-agent corpus
+// =============================================================================
+//
+// Each case below is a shape taken from NousResearch/hermes-agent at 743dc94,
+// where these five rules produced 4684 of 6948 findings. The assertions are
+// about cardinality and context, not about detection: every rule here still
+// fires on the attack shape it was written for.
+
+describe('PII email calibration', async () => {
+  const { PIIComplianceAgent } = await import('../agents/pii-compliance-agent.js');
+  const agent = new PIIComplianceAgent();
+
+  it('ignores GitHub noreply addresses anywhere in the domain', async () => {
+    const { dir, file } = writeTempFile(
+      'AUTHOR = "122438640+ragingbulld@users.noreply.github.com"\n', '.py');
+    try {
+      const findings = await agent.analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+      assert.equal(findings.filter(f => f.rule === 'PII_EMAIL_HARDCODED').length, 0,
+        'users.noreply.github.com is the address GitHub issues to keep the real one private');
+    } finally { cleanup(dir); }
+  });
+
+  it('collapses a contributor map into one directory finding', async () => {
+    const rows = Array.from({ length: 40 },
+      (_, i) => `    "person${i}@gmail.com": "person${i}",`).join('\n');
+    const { dir, file } = writeTempFile(`AUTHOR_MAP = {\n${rows}\n}\n`, '.py');
+    try {
+      const findings = await agent.analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+      assert.equal(findings.filter(f => f.rule === 'PII_EMAIL_HARDCODED').length, 0);
+      const dirFindings = findings.filter(f => f.rule === 'PII_EMAIL_DIRECTORY');
+      assert.equal(dirFindings.length, 1, 'one finding for the file, not one per address');
+      assert.match(dirFindings[0].description, /40 hardcoded email/);
+    } finally { cleanup(dir); }
+  });
+
+  it('still reports a single stray address', async () => {
+    const { dir, file } = writeTempFile('const SUPPORT = "carol@realcompany.com";');
+    try {
+      const findings = await agent.analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+      assert.ok(findings.some(f => f.rule === 'PII_EMAIL_HARDCODED'),
+        'below the directory threshold this is still a hardcoded address');
+    } finally { cleanup(dir); }
+  });
+});
+
+describe('Agentic rule calibration', async () => {
+  const { AgenticSecurityAgent } = await import('../agents/agentic-security-agent.js');
+  const agent = new AgenticSecurityAgent();
+
+  it('reports missing tool audit logging once per file, not once per mention', async () => {
+    const body = Array.from({ length: 30 },
+      (_, i) => `def step${i}(): return executeTool(name${i}, args${i})`).join('\n');
+    const { dir, file } = writeTempFile(body, '.py');
+    try {
+      const findings = await agent.analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+      assert.equal(findings.filter(f => f.rule === 'AGENT_NO_AUDIT_LOG').length, 1);
+    } finally { cleanup(dir); }
+  });
+
+  it('does not claim missing audit logging when the file logs', async () => {
+    const { dir, file } = writeTempFile(
+      'def run(c):\n    logger.info("tool %s", c.name)\n    return executeTool(c.name, c.args)\n', '.py');
+    try {
+      const findings = await agent.analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+      assert.equal(findings.filter(f => f.rule === 'AGENT_NO_AUDIT_LOG').length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('does not treat subprocess.run near a result binding as an agent action', async () => {
+    const { dir, file } = writeTempFile(
+      'result = None\nproc = subprocess.run(cmd, capture_output=True)\nresult = proc.stdout\n', '.py');
+    try {
+      const findings = await agent.analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+      assert.equal(findings.filter(f => f.rule === 'AGENT_OUTPUT_TO_ACTION').length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('still flags an action invoked on the model output', async () => {
+    const { dir, file } = writeTempFile('const completion = await llm(); completion.execute();');
+    try {
+      const findings = await agent.analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+      assert.ok(findings.some(f => f.rule === 'AGENT_OUTPUT_TO_ACTION'));
+    } finally { cleanup(dir); }
+  });
+
+  it('does not claim missing memory expiry when a TTL is set', async () => {
+    const { dir, file } = writeTempFile(
+      'def save(e):\n    memory.store(e, ttl=3600)\n', '.py');
+    try {
+      const findings = await agent.analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+      assert.equal(findings.filter(f => f.rule === 'AGENT_MEMORY_NO_EXPIRY').length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('flags memory persistence with no retention policy, once', async () => {
+    const body = Array.from({ length: 20 },
+      (_, i) => `def w${i}(e): memory.store(e)`).join('\n');
+    const { dir, file } = writeTempFile(body, '.py');
+    try {
+      const findings = await agent.analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+      assert.equal(findings.filter(f => f.rule === 'AGENT_MEMORY_NO_EXPIRY').length, 1);
+    } finally { cleanup(dir); }
+  });
+});
+
+describe('SSRF internal IP calibration', async () => {
+  const { SSRFProber } = await import('../agents/ssrf-prober.js');
+  const agent = new SSRFProber();
+
+  it('ignores a loopback bind address', async () => {
+    const { dir, file } = writeTempFile('app.listen(8080, "127.0.0.1")\nHOST = "127.0.0.1"\n', '.py');
+    try {
+      const findings = await agent.analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+      assert.equal(findings.filter(f => f.rule === 'SSRF_INTERNAL_IP').length, 0,
+        'binding loopback is not an SSRF sink');
+    } finally { cleanup(dir); }
+  });
+
+  it('still flags an internal address as a request destination', async () => {
+    const { dir, file } = writeTempFile('requests.get("http://169.254.0.1")\nfetch("http://192.168.1.5/admin")');
+    try {
+      const findings = await agent.analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+      assert.ok(findings.some(f => f.rule === 'SSRF_INTERNAL_IP'));
+    } finally { cleanup(dir); }
+  });
+});

--- a/cli/agents/agentic-security-agent.js
+++ b/cli/agents/agentic-security-agent.js
@@ -122,17 +122,11 @@ const PATTERNS = [
     description: 'User-controlled content written directly to agent persistent memory. Enables memory poisoning — attacker instructions persist across sessions.',
     fix: 'Sanitize and validate content before writing to agent memory. Separate user messages from system state.',
   },
-  {
-    rule: 'AGENT_MEMORY_NO_EXPIRY',
-    title: 'Agent: Persistent Memory Without Expiration',
-    regex: /(?:memory|longTermMemory|persistentState)[\s\S]{0,200}(?:save|store|persist|write)(?![\s\S]{0,200}(?:ttl|expir|maxAge|retention|cleanup|prune))/g,
-    severity: 'medium',
-    cwe: 'CWE-404',
-    owasp: 'A04:2021',
-    confidence: 'low',
-    description: 'Agent memory persists without expiration policy. Poisoned memories remain indefinitely.',
-    fix: 'Set TTL or retention policies on agent memory. Implement periodic cleanup of stale entries.',
-  },
+  // AGENT_MEMORY_NO_EXPIRY moved to AGENT_STRUCTURAL_RULES below. Like
+  // AGENT_NO_AUDIT_LOG it asserted the absence of something (a TTL) using a
+  // negative lookahead after a variable-length gap, which backtracks until the
+  // lookahead succeeds. 234 findings on hermes-agent, one per mention of the
+  // word "memory" near a write.
 
   // ── Unbounded Execution ──────────────────────────────────────────────────
   {
@@ -196,7 +190,11 @@ const PATTERNS = [
   {
     rule: 'AGENT_OUTPUT_TO_ACTION',
     title: 'Agent: LLM Output Directly Triggers Actions',
-    regex: /(?:completion|response|output|result|generated)[\s\S]{0,100}(?:\.execute\b|\.run\b|\.send\b|\.post\b|\.delete\b|\.pay\b|\.transfer\b|\.deploy\b)/g,
+    // The action has to be invoked *on* the model output, not merely appear
+    // within 100 characters of a variable called `result`. The loose version
+    // matched `subprocess.run` anywhere near a `result =` binding and fired
+    // 329 times on hermes-agent, almost all of it ordinary CLI code.
+    regex: /\b(?:completion|response|output|result|generated)\w*\s*(?:\.\w+)?\s*\.\s*(?:execute|run|send|post|delete|pay|transfer|deploy)\s*\(/g,
     severity: 'high',
     cwe: 'CWE-862',
     owasp: 'A01:2021',
@@ -251,24 +249,20 @@ const PATTERNS = [
   },
 
   // ── Audit & Observability ────────────────────────────────────────────────
-  {
-    rule: 'AGENT_NO_AUDIT_LOG',
-    title: 'Agent: Tool Invocations Not Logged',
-    regex: /(?:tool_call|function_call|executeTool|callTool|tool\.run)[\s\S]{0,300}(?![\s\S]{0,300}(?:log|audit|record|track|monitor|trace|emit|publish))/g,
-    severity: 'medium',
-    cwe: 'CWE-778',
-    owasp: 'A09:2021',
-    confidence: 'low',
-    description: 'Agent tool invocations are not being logged or audited. Makes incident response and forensics impossible.',
-    fix: 'Log all tool invocations including: tool name, arguments, caller identity, timestamp, and result status.',
-  },
+  // AGENT_NO_AUDIT_LOG used to live here as a line pattern. It is a property
+  // of a file, not of a line, and as a pattern it was structurally unable to
+  // say anything: `[\s\S]{0,300}` followed by a negative lookahead backtracks
+  // to whatever length makes the lookahead succeed, so any line mentioning
+  // `tool_call` fired. It produced 1904 findings on hermes-agent, second only
+  // to the contributor-map email flood. It now lives in
+  // AGENT_STRUCTURAL_RULES, which emits at most one finding per file.
 ];
 
 // =============================================================================
 // KIMI K3 / OPENAI-COMPATIBLE TOOL-CALL SECURITY CHECKS
 // =============================================================================
 
-const TOOL_CALL_STRUCTURAL_RULES = [
+const AGENT_STRUCTURAL_RULES = [
   {
     rule: 'AGENT_DYNAMIC_TOOL_LOADING_FROM_CONTEXT',
     title: 'Agent: Dynamic Tool Definitions Loaded From Prompt Context',
@@ -327,6 +321,51 @@ const TOOL_CALL_STRUCTURAL_RULES = [
       return appendsToolResult && !preservesAssistantToolCalls;
     },
   },
+  {
+    rule: 'AGENT_NO_AUDIT_LOG',
+    title: 'Agent: Tool Invocations Not Logged',
+    severity: 'medium',
+    cwe: 'CWE-778',
+    owasp: 'A09:2021',
+    description: 'This file dispatches agent tool invocations but has no visible logging, audit, or telemetry call anywhere in it. Without a record of which tool ran with which arguments, incident response and forensics have nothing to work from.',
+    fix: 'Log every tool invocation: tool name, arguments, caller identity, timestamp, and result status.',
+    test(content) {
+      // Dispatch, not mere mention. A file that names `tool_call` while
+      // building a request is not the file that runs the tool.
+      const dispatchesTool =
+        /(?:executeTool|callTool|invokeTool|runTool|dispatchTool|tool\.run|handler\s*\(\s*(?:args|params|input))/i.test(content)
+        || /(?:toolRegistry|tools|handlers)\s*\[[^\]]*\]\s*\(/i.test(content);
+      if (!dispatchesTool) return false;
+
+      // Any observability call in the file counts. This is deliberately
+      // generous: the claim is "nothing here records anything," and one
+      // logger is enough to refute it.
+      const hasObservability =
+        /(?:console\.(?:log|info|warn|error|debug)|logger?\.\w+|logging\.\w+|log\.\w+|audit\w*\s*\(|\btrace\w*\s*\(|telemetry|metrics?\.\w+|emit\s*\(|span\.|structlog|winston|pino|loguru)/i.test(content);
+
+      return !hasObservability;
+    },
+  },
+  {
+    rule: 'AGENT_MEMORY_NO_EXPIRY',
+    title: 'Agent: Persistent Memory Without Expiration',
+    severity: 'medium',
+    cwe: 'CWE-404',
+    owasp: 'A04:2026',
+    description: 'This file writes to agent persistent memory but nothing in it sets a TTL, retention window, or cleanup pass. A poisoned memory written once stays readable for every future session.',
+    fix: 'Set a TTL or retention policy on agent memory, and run a periodic prune of stale entries.',
+    test(content) {
+      const persistsMemory =
+        /(?:memory|longTermMemory|persistent_?[Ss]tate|memory_?store|memoryStore)\w*\s*\.\s*(?:save|store|persist|write|insert|upsert|add|append)\s*\(/i.test(content)
+        || /(?:save|store|persist|write)_?[Mm]emory\s*\(/i.test(content);
+      if (!persistsMemory) return false;
+
+      const hasRetention =
+        /\b(?:ttl|expir\w*|max_?age|retention|cleanup|prune|evict\w*|purge|vacuum|gc_\w+)\b/i.test(content);
+
+      return !hasRetention;
+    },
+  },
 ];
 
 // =============================================================================
@@ -363,7 +402,7 @@ export class AgenticSecurityAgent extends BaseAgent {
     if (!content) return [];
 
     const findings = [];
-    for (const rule of TOOL_CALL_STRUCTURAL_RULES) {
+    for (const rule of AGENT_STRUCTURAL_RULES) {
       if (!rule.test(content)) continue;
       const line = this.findLine(content, rule);
       const lines = content.split('\n');
@@ -405,6 +444,8 @@ export class AgenticSecurityAgent extends BaseAgent {
       AGENT_TOOL_CALL_NO_ALLOWLIST: /(?:executeTool|callTool|invokeTool|toolRegistry|tool_calls?|function_call)/i,
       AGENT_TOOL_CHOICE_REQUIRED_UNTRUSTED: /tool_choice/i,
       AGENT_TOOL_CALL_REPLAY_MISSING_ASSISTANT: /(?:role\s*:\s*['"]tool['"]|tool_call_id|toolCallId)/i,
+      AGENT_NO_AUDIT_LOG: /(?:executeTool|callTool|invokeTool|runTool|dispatchTool|tool\.run)/i,
+      AGENT_MEMORY_NO_EXPIRY: /(?:memory|longTermMemory|persistent_?[Ss]tate)/i,
     };
     const marker = markers[rule.rule] || /tool/i;
     const lines = content.split('\n');

--- a/cli/agents/agentic-security-agent.js
+++ b/cli/agents/agentic-security-agent.js
@@ -69,7 +69,12 @@ const PATTERNS = [
   {
     rule: 'AGENT_TOOL_SHELL_ACCESS',
     title: 'Agent: Tool With Shell/Command Execution',
-    regex: /(?:tools|functions)[\s\S]{0,500}(?:exec\s*\(|execSync|spawn|child_process|subprocess|os\.system|shell\s*[:=]\s*true)/g,
+    // A file that has the word "tools" somewhere and calls subprocess 500
+    // characters later is every agent codebase in existence, which is why
+    // this fired 56 times at critical severity on hermes-agent. The finding
+    // worth making is that a *tool definition* grants shell, so require the
+    // exec to sit inside the tool list or handler literal.
+    regex: /\b(?:tools|functions)\s*[:=]\s*[[{][^\]}]{0,300}?(?:exec\s*\(|execSync|spawn\s*\(|child_process|subprocess\.|os\.system|shell\s*[:=]\s*true)|\b(?:tool|function)\s*\(\s*['"][^'"]{0,60}['"][^)]{0,200}?(?:execSync|child_process|subprocess\.|os\.system|shell\s*[:=]\s*true)/g,
     severity: 'critical',
     cwe: 'CWE-78',
     owasp: 'A03:2021',
@@ -91,7 +96,11 @@ const PATTERNS = [
   {
     rule: 'AGENT_ESCALATED_PERMISSIONS',
     title: 'Agent: Runs With Elevated Permissions',
-    regex: /(?:agent|bot|assistant)[\s\S]{0,300}(?:admin|sudo|root|superuser|service.?role|elevated|full.?access|all.?permissions)/gi,
+    // Proximity of the words "agent" and "root" within 300 characters is not
+    // evidence of anything in a codebase whose subject is agents — it fired 79
+    // times on hermes-agent, largely on paths named `root_path`. Require the
+    // privilege to be assigned as configuration.
+    regex: /(?:agent|bot|assistant)\w*\s*(?:\.\w+)*\s*[:=]\s*[^\n=]{0,60}\b(?:admin|sudo|superuser|service[_-]?role|elevated|full[_-]?access|all[_-]?permissions)\b|\b(?:role|permission|privilege|run_?as|user)\s*[:=]\s*['"](?:admin|root|superuser|sudo)['"]/gi,
     severity: 'high',
     cwe: 'CWE-269',
     owasp: 'A04:2021',
@@ -150,23 +159,17 @@ const PATTERNS = [
     description: 'Agent execution without timeout configuration. Runaway agents can consume unlimited resources.',
     fix: 'Set explicit timeout on agent execution. Use AbortController or equivalent mechanism.',
   },
-  {
-    rule: 'AGENT_NO_COST_LIMIT',
-    title: 'Agent: No Spending/Token Limit',
-    regex: /(?:agent|completion|chat)[\s\S]{0,300}(?:model|engine)\s*[:=](?![\s\S]{0,300}(?:max_tokens|maxTokens|budget|cost|limit|cap))/g,
-    severity: 'medium',
-    cwe: 'CWE-770',
-    owasp: 'A04:2021',
-    confidence: 'low',
-    description: 'Agent makes LLM calls without token or cost limits. Enables denial of wallet attacks.',
-    fix: 'Set max_tokens on all LLM calls. Implement per-session cost budgets.',
-  },
+  // AGENT_NO_COST_LIMIT moved to AGENT_STRUCTURAL_RULES: same broken
+  // lookahead-after-a-gap as AGENT_NO_AUDIT_LOG, 41 findings on hermes-agent.
 
   // ── Multi-Agent Risks ────────────────────────────────────────────────────
   {
     rule: 'AGENT_RECURSIVE_INVOCATION',
     title: 'Agent: Recursive Self-Invocation',
-    regex: /(?:agent|assistant)[\s\S]{0,200}(?:call|invoke|run|execute)[\s\S]{0,100}(?:self|this|agent|itself)/g,
+    // `self` is a parameter on every Python method, so the loose proximity
+    // form matched 104 times on hermes-agent. Require an actual self-call:
+    // the agent invoking its own run/invoke entry point.
+    regex: /\b(?:self|this)\s*\.\s*(?:run|invoke|call|execute|step)\s*\(|\b(?:agent|assistant)\s*\.\s*(?:run|invoke|call|execute)\s*\([^)]*\b(?:self|this|agent)\b/g,
     severity: 'high',
     cwe: 'CWE-674',
     owasp: 'A04:2021',
@@ -205,7 +208,11 @@ const PATTERNS = [
   {
     rule: 'AGENT_NO_OUTPUT_SCHEMA',
     title: 'Agent: No Schema Validation on LLM Output',
-    regex: /(?:JSON\.parse|json\.loads)\s*\(\s*(?:completion|response|output|result|generated|llm|ai|gpt|claude)(?![\s\S]{0,200}(?:schema|validate|zod|yup|joi|ajv|parse|safeParse|type_adapter))/g,
+    // The trailing lookahead never failed, and one of its own escape hatches
+    // was the word `parse` — which `JSON.parse` supplies by definition. The
+    // per-file version of this question lives in AGENT_STRUCTURAL_RULES; here
+    // just record the parse of model output.
+    regex: /(?:JSON\.parse|json\.loads)\s*\(\s*(?:completion|response|output|result|generated|llm|ai|gpt|claude)\w*\s*[,)]/g,
     severity: 'medium',
     cwe: 'CWE-20',
     owasp: 'A03:2021',
@@ -272,7 +279,28 @@ const AGENT_STRUCTURAL_RULES = [
     description: 'Tool definitions appear to be injected into system/developer context from user, document, or retrieved content. Kimi K3-style dynamic tool loading makes this especially risky: poisoned context can add or reshape tools.',
     fix: 'Load tool definitions from trusted code/config only. Never let user, RAG, document, or tool-result content define available tools.',
     test(content) {
-      return /(?:system|developer|messages|prompt)[\s\S]{0,500}(?:tool|function)s?[\s\S]{0,500}(?:req\.|request\.|body\.|params\.|query\.|user|userMessage|input|retrieved|document|toolResult|tool_result)/i.test(content);
+      // The old form asked whether the words "prompt", "tool" and "user"
+      // appeared within 1000 characters of each other, which is true of 249
+      // files in hermes-agent and of essentially any agent codebase. What
+      // matters is a tool/function list being *assigned from* untrusted
+      // content, so require that shape directly.
+      // A tool or function list assigned from untrusted content.
+      const assignedFromUntrusted =
+        /\b(?:tools|functions|tool_?definitions|toolSchemas?)\s*[:=]\s*[^\n;]{0,120}\b(?:req\.|request\.|body\.|params\.|query\.|user_?(?:input|message|content)|retrieved|documents?|tool_?results?|completion|response)\b/i.test(content)
+        || /\b(?:tools|functions)\s*\.\s*(?:push|extend|append|concat)\s*\(\s*[^)\n]{0,80}\b(?:retrieved|documents?|tool_?results?|user_?(?:input|message)|body\.|req\.)\b/i.test(content);
+
+      // A tool schema read straight off the request, whatever it is then
+      // spliced into.
+      const toolShapedUntrustedRead =
+        /\b(?:req|request|body|params|query|ctx)\.[\w.]*tool[\w.]*/i.test(content);
+
+      // The Kimi K3 shape: the schema never lands in a `tools` array at all,
+      // it is concatenated into a system or developer message. The tool
+      // definitions still arrive from the request.
+      const injectedIntoInstructionMessage =
+        /content\s*[:=][^\n]{0,140}\b(?:tool|function)s?\b[^\n]{0,100}\b(?:req\.|request\.|body\.|params\.|query\.|user_?(?:input|message)|retrieved|documents?|tool_?results?)/i.test(content);
+
+      return assignedFromUntrusted || toolShapedUntrustedRead || injectedIntoInstructionMessage;
     },
   },
   {
@@ -366,6 +394,44 @@ const AGENT_STRUCTURAL_RULES = [
       return !hasRetention;
     },
   },
+  {
+    rule: 'AGENT_NO_COST_LIMIT',
+    title: 'Agent: No Spending/Token Limit',
+    severity: 'medium',
+    cwe: 'CWE-770',
+    owasp: 'A04:2021',
+    description: 'This file issues LLM completions but sets no token ceiling or cost budget anywhere in it. An agent loop that misbehaves bills the operator until the provider stops it.',
+    fix: 'Set max_tokens on every completion call and enforce a per-session cost budget.',
+    test(content) {
+      const callsModel =
+        /(?:chat\.completions\.create|messages\.create|responses\.create|createChatCompletion|\.generate(?:_content)?\s*\(|completion\s*\()/i.test(content);
+      if (!callsModel) return false;
+
+      const hasCeiling =
+        /\b(?:max_?tokens|max_?output_?tokens|max_?completion_?tokens|budget|cost_?limit|token_?limit|max_?spend|quota)\b/i.test(content);
+
+      return !hasCeiling;
+    },
+  },
+  {
+    rule: 'AGENT_NO_OUTPUT_SCHEMA',
+    title: 'Agent: Model Output Parsed Without Schema Validation',
+    severity: 'medium',
+    cwe: 'CWE-20',
+    owasp: 'A03:2021',
+    description: 'This file parses model output as JSON but validates it against no schema. A model that returns a differently shaped object, whether by drift or by injection, flows straight into the code that consumes it.',
+    fix: 'Validate parsed model output against an explicit schema (zod, pydantic, jsonschema) before use.',
+    test(content) {
+      const parsesModelOutput =
+        /(?:JSON\.parse|json\.loads)\s*\(\s*(?:completion|response|output|result|generated|llm|ai|gpt|claude)\w*\s*[,)]/i.test(content);
+      if (!parsesModelOutput) return false;
+
+      const validates =
+        /\b(?:zod|yup|joi|ajv|jsonschema|pydantic|BaseModel|TypeAdapter|type_adapter|safeParse|validate\w*\s*\(|schema)\b/i.test(content);
+
+      return !validates;
+    },
+  },
 ];
 
 // =============================================================================
@@ -446,6 +512,8 @@ export class AgenticSecurityAgent extends BaseAgent {
       AGENT_TOOL_CALL_REPLAY_MISSING_ASSISTANT: /(?:role\s*:\s*['"]tool['"]|tool_call_id|toolCallId)/i,
       AGENT_NO_AUDIT_LOG: /(?:executeTool|callTool|invokeTool|runTool|dispatchTool|tool\.run)/i,
       AGENT_MEMORY_NO_EXPIRY: /(?:memory|longTermMemory|persistent_?[Ss]tate)/i,
+      AGENT_NO_COST_LIMIT: /(?:completions\.create|messages\.create|responses\.create|createChatCompletion|\.generate)/i,
+      AGENT_NO_OUTPUT_SCHEMA: /(?:JSON\.parse|json\.loads)/i,
     };
     const marker = markers[rule.rule] || /tool/i;
     const lines = content.split('\n');

--- a/cli/agents/api-fuzzer.js
+++ b/cli/agents/api-fuzzer.js
@@ -99,7 +99,18 @@ const PATTERNS = [
   {
     rule: 'API_PATH_IN_FILENAME',
     title: 'API: Path Traversal in File Upload',
-    regex: /path\.join\s*\([^)]*(?:originalname|filename|req\.file|req\.body)/g,
+    // Two boundaries matter here, and the original pattern had neither.
+    //
+    // `(?<![\w.])` stops `path.join` matching inside Python's
+    // `os.path.join(self.root_path, filename)`. This agent scans .py and .rb as
+    // well as JS, so an Express upload rule was firing at critical severity on
+    // Flask's own config loader (src/flask/config.py:204).
+    //
+    // Requiring a property access rather than a bare `filename` stops any local
+    // variable that happens to carry that name from looking like user input.
+    // Multer exposes `file.originalname` and `file.filename`, so the real
+    // attack shape always has the dot.
+    regex: /(?<![\w.])path\.join\s*\([^)]*(?:\.originalname\b|\.filename\b|req\.(?:file|files|body|query|params)\b)/g,
     severity: 'critical',
     cwe: 'CWE-22',
     owasp: 'A01:2021',

--- a/cli/agents/api-fuzzer.js
+++ b/cli/agents/api-fuzzer.js
@@ -88,7 +88,12 @@ const PATTERNS = [
   {
     rule: 'API_UPLOAD_NO_TYPE_CHECK',
     title: 'API: File Upload Without Type Validation',
-    regex: /(?<!_)(?:originalname|filename)\s*(?:\)|;)/g,
+    // Same failure as API_PATH_IN_FILENAME in 9.6.4: an Express upload rule
+    // matching Python. `filename)` and `filename;` occur in every language that
+    // has a variable called filename — `os.path.basename(filename)` alone
+    // accounted for much of the 104 hits on hermes-agent. Require the multer
+    // property access that marks the value as upload-controlled.
+    regex: /\b(?:file|files\[\d*\]|req\.file|req\.files\[\d*\])\s*\.\s*(?:originalname|filename)\s*(?:\)|;|,|\})/g,
     severity: 'high',
     cwe: 'CWE-434',
     owasp: 'A04:2021',

--- a/cli/agents/auth-bypass-agent.js
+++ b/cli/agents/auth-bypass-agent.js
@@ -133,7 +133,12 @@ const PATTERNS = [
   {
     rule: 'OAUTH_NO_STATE',
     title: 'OAuth Missing State Parameter',
-    regex: /authorize_url|authorization_endpoint|auth_uri.*(?!state)/g,
+    // The alternation put the lookahead on the last branch only, so the first
+    // two matched any mention of an authorize URL unconditionally — and the
+    // lookahead itself, sitting after `.*`, could never fail anyway. Ask the
+    // real question: an authorization URL being built with no state parameter
+    // anywhere in its construction.
+    regex: /(?:authorize_?url|authorization_endpoint|auth_uri)\s*[:=]\s*(?:f?["'`][^"'`\n]*(?:\?|&)(?!(?:[^"'`\n]*[?&])?state=)[^"'`\n]*["'`]|[^\n]{0,80}\.(?:format|join)\((?![^\n]{0,120}state))/gi,
     severity: 'high',
     cwe: 'CWE-352',
     owasp: 'A07:2021',
@@ -200,7 +205,20 @@ const PATTERNS = [
   {
     rule: 'TIMING_ATTACK_COMPARISON',
     title: 'Timing Attack: String Comparison',
-    regex: /(?:apiKey|api_key|token|secret|signature|hmac)\s*(?:===?|!==?)\s*/gi,
+    // Comparing a secret against a sentinel is a presence check, not a
+    // timing-sensitive comparison. `if token == None` and `if not secret ==
+    // ""` are the two most common lines in any auth module and made up most of
+    // the 79 hits on hermes-agent.
+    // The whitespace has to live inside the lookahead. With `\s*` in front of
+    // it the quantifier just backtracks to zero width and the lookahead then
+    // inspects the space rather than the operand, which is why the first
+    // version of this exclusion changed nothing.
+    // A timing attack needs an attacker on one side of the comparison. Two
+    // locally-held values checked for equality — `if new_token ==
+    // self._anthropic_api_key`, cache and state bookkeeping — leak nothing to
+    // anyone, and they were all 78 remaining hits on hermes-agent. Require one
+    // side to be request-derived.
+    regex: /(?:\b(?:req|request|headers?|params|query|body|input|provided|supplied|incoming|client|candidate|given)\b[\w.[\]'"-]*\s*(?:===?|!==?)\s*[\w.]*(?:apiKey|api_key|token|secret|signature|hmac)|(?:apiKey|api_key|token|secret|signature|hmac)[\w.]*\s*(?:===?|!==?)\s*[\w.[\]'"-]*\b(?:req|request|headers?|params|query|body|input|provided|supplied|incoming|client|candidate|given)\b)/gi,
     severity: 'medium',
     cwe: 'CWE-208',
     owasp: 'A02:2021',

--- a/cli/agents/base-agent.js
+++ b/cli/agents/base-agent.js
@@ -299,7 +299,15 @@ export class BaseAgent {
       // which pattern matched.
       const lineMarked = /ship-safe-ignore/i.test(line);
 
+      // Some rules describe code and nothing else. A comment explaining why a
+      // codebase *avoids* the cloud metadata endpoint is not a finding about
+      // the cloud metadata endpoint, and prose that happens to contain a
+      // keyword is not code. Opt-in per pattern, because other rules
+      // deliberately target comments (hidden instructions, TODO markers).
+      const isCommentLine = /^\s*(?:#|\/\/|\*|<!--|--\s|;)/.test(line);
+
       for (const p of patterns) {
+        if (p.skipComments && isCommentLine) continue;
         const severity = p.severity || 'medium';
 
         // Collect matches first. Suppression is only meaningful for a pattern

--- a/cli/agents/injection-tester.js
+++ b/cli/agents/injection-tester.js
@@ -23,7 +23,11 @@ const PATTERNS = [
   {
     rule: 'SQL_INJECTION_TEMPLATE_LITERAL',
     title: 'SQL Injection via Template Literal',
-    regex: /`(?:SELECT|INSERT|UPDATE|DELETE|DROP\s+TABLE|ALTER\s+TABLE|TRUNCATE|CREATE|REPLACE|MERGE)[^`]*\$\{/gi,
+    // A bare `CREATE` alternative meant every template literal starting with
+    // the word "Create" was SQL injection — `showToast(\`Create failed:
+    // ${e}\`)` was 24 criticals on hermes-agent's file browser. Require the
+    // clause structure that makes a string a statement rather than a sentence.
+    regex: /`(?=[^`]*\$\{)[^`]*\b(?:SELECT\b[^`]*\bFROM\b|INSERT\s+INTO\b|UPDATE\b[^`]*\bSET\b|DELETE\s+FROM\b|DROP\s+TABLE\b|ALTER\s+TABLE\b|TRUNCATE\s+TABLE\b|CREATE\s+(?:TABLE|INDEX|VIEW|DATABASE)\b|REPLACE\s+INTO\b|MERGE\s+INTO\b)/gi,
     severity: 'critical',
     cwe: 'CWE-89',
     owasp: 'A03:2021',
@@ -129,7 +133,13 @@ const PATTERNS = [
   {
     rule: 'CODE_INJECTION_EVAL_GENERIC',
     title: 'Code Injection: eval() Usage',
-    regex: /\beval\s*\(/g,
+    // `\b` matches between `.` and `e`, so the bare form also claimed every
+    // method named eval. On hermes-agent that was `cdp.eval(...)`, the Chrome
+    // DevTools Protocol helper, 126 times across the desktop perf harness.
+    // A method call on an object is a different API from the global sink this
+    // rule describes; if a specific one is worth flagging it needs its own
+    // rule that can say why.
+    regex: /(?<![.\w$])eval\s*\(/g,
     severity: 'high',
     cwe: 'CWE-94',
     owasp: 'A03:2021',
@@ -348,7 +358,19 @@ const PATTERNS = [
   {
     rule: 'PYTHON_SQL_FSTRING',
     title: 'SQL Injection via Python f-string',
-    regex: /f["'](?:SELECT|INSERT|UPDATE|DELETE)\s+[^"']*\{/gi,
+    // Interpolation *with* bound parameters is the standard safe idiom for a
+    // variable-length IN clause:
+    //
+    //   conn.execute(f"DELETE FROM messages WHERE id IN ({ph})", ids)
+    //
+    // where `ph` is "?,?,?" and the values ride in `ids`. Requiring that no
+    // parameter argument follows the string keeps the real shape —
+    // `execute(f"... WHERE name = {name}")` — and drops the idiom, which was
+    // most of the 77 criticals on hermes-agent.
+    // Same problem as the template-literal rule: `f"Select a model ({n}
+    // available)"` is English, not SQL. Require clause structure as well as
+    // interpolation.
+    regex: /f["'][^"']*\b(?:SELECT\b[^"']*\bFROM\b|INSERT\s+INTO\b|UPDATE\b[^"']*\bSET\b|DELETE\s+FROM\b)[^"']*\{[^"']*["'](?!\s*,)/gi,
     severity: 'critical',
     cwe: 'CWE-89',
     owasp: 'A03:2021',

--- a/cli/agents/llm-redteam.js
+++ b/cli/agents/llm-redteam.js
@@ -8,7 +8,7 @@
  */
 
 import path from 'path';
-import { BaseAgent } from './base-agent.js';
+import { BaseAgent, createFinding } from './base-agent.js';
 
 const PATTERNS = [
   // ── LLM01: Prompt Injection ────────────────────────────────────────────────
@@ -172,17 +172,11 @@ const PATTERNS = [
     description: 'AI endpoint without rate limiting. Users could rack up API costs.',
     fix: 'Add rate limiting per user: express-rate-limit, @upstash/ratelimit, etc.',
   },
-  {
-    rule: 'LLM_NO_COST_LIMIT',
-    title: 'LLM Usage Without Cost Controls',
-    regex: /(?:OPENAI|ANTHROPIC|AI)_(?:API_KEY|KEY).*(?!(?:budget|limit|cap|max_cost|spending))/gi,
-    severity: 'medium',
-    cwe: 'CWE-770',
-    owasp: 'LLM10',
-    confidence: 'low',
-    description: 'AI API usage without cost controls. Set spending limits on your provider dashboard.',
-    fix: 'Configure spending limits in OpenAI/Anthropic dashboard. Add per-user token budgets.',
-  },
+  // LLM_NO_COST_LIMIT is emitted once per project by _checkCostControls. As a
+  // line pattern it was `KEY.*(?!budget|limit|...)`, where `.*` backtracks
+  // until the lookahead succeeds — so it reported every line mentioning a
+  // provider key, 307 times on hermes-agent. Spend control is a property of a
+  // project, not of a line.
 
   // ── LLM03: Supply Chain ────────────────────────────────────────────────────
   {
@@ -266,7 +260,57 @@ export class LLMRedTeam extends BaseAgent {
       if (applicable.length === 0) continue;
       findings = findings.concat(this.scanFileWithPatterns(file, applicable));
     }
+
+    findings = findings.concat(this._checkCostControls(codeFiles));
     return findings;
+  }
+
+  /**
+   * Report absent LLM spend controls once for the whole project.
+   *
+   * A budget is normally configured in one place — a config module, a wrapper
+   * client, a provider dashboard — so asking the question per file guarantees
+   * a wrong answer in every file that isn't that one.
+   */
+  _checkCostControls(codeFiles) {
+    let anchorFile = null;
+    let anchorLine = 1;
+
+    for (const file of codeFiles) {
+      const content = this.readFile(file);
+      if (!content) continue;
+
+      if (/\b(?:max_?cost|cost_?limit|budget|spend(?:ing)?_?limit|max_?spend|token_?budget|usage_?limit|quota)\b/i.test(content)) {
+        return [];
+      }
+
+      if (!anchorFile) {
+        const lines = content.split('\n');
+        const idx = lines.findIndex(l => /(?:OPENAI|ANTHROPIC)_API_KEY|openai\.|anthropic\.|chat\.completions|messages\.create/i.test(l));
+        if (idx !== -1) {
+          anchorFile = file;
+          anchorLine = idx + 1;
+        }
+      }
+    }
+
+    if (!anchorFile) return [];
+
+    return [createFinding({
+      file: anchorFile,
+      line: anchorLine,
+      column: 1,
+      severity: 'medium',
+      category: this.category,
+      rule: 'LLM_NO_COST_LIMIT',
+      title: 'LLM Usage Without Cost Controls',
+      description: 'This project calls an LLM provider but nothing in it sets a budget, token cap, or spend limit. A runaway agent loop or an abusive caller bills the operator until the provider cuts it off.',
+      matched: 'no budget, token cap, or spend limit found in project',
+      confidence: 'low',
+      cwe: 'CWE-770',
+      owasp: 'LLM10',
+      fix: 'Set per-user token budgets in code and a spending limit on the provider dashboard.',
+    })];
   }
 }
 

--- a/cli/agents/mcp-security-agent.js
+++ b/cli/agents/mcp-security-agent.js
@@ -19,7 +19,7 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { BaseAgent } from './base-agent.js';
+import { BaseAgent, createFinding } from './base-agent.js';
 
 // =============================================================================
 // MCP SECURITY PATTERNS

--- a/cli/agents/mcp-security-agent.js
+++ b/cli/agents/mcp-security-agent.js
@@ -27,17 +27,10 @@ import { BaseAgent } from './base-agent.js';
 
 const PATTERNS = [
   // ── Tool Poisoning & Validation ──────────────────────────────────────────
-  {
-    rule: 'MCP_NO_TOOL_VALIDATION',
-    title: 'MCP: Tool Call Without Validation',
-    regex: /(?:tools\/call|tool_call|callTool|executeTool)\s*\(/g,
-    severity: 'high',
-    cwe: 'CWE-20',
-    owasp: 'A03:2021',
-    confidence: 'medium',
-    description: 'MCP tool invocation without visible tool-name validation or allowlisting. Attackers can invoke arbitrary tools via tool poisoning.',
-    fix: 'Validate tool names against an explicit allowlist before execution',
-  },
+  // MCP_NO_TOOL_VALIDATION is emitted by _checkToolValidation, not from here.
+  // As a line pattern it matched every `callTool(` site and never looked for
+  // the validation whose absence it was reporting, so it fired 95 times on
+  // hermes-agent — once per call site, in files that do validate.
   {
     rule: 'MCP_DYNAMIC_TOOL_REGISTRATION',
     title: 'MCP: Dynamic Tool Registration from External Source',
@@ -303,6 +296,7 @@ export class MCPSecurityAgent extends BaseAgent {
 
     for (const file of mcpServerFiles) {
       findings = findings.concat(this._checkServerAuth(file));
+      findings = findings.concat(this._checkToolValidation(file));
     }
 
     // ── 4. Check MCP configs for typosquatting & over-permissioned servers ─
@@ -366,6 +360,44 @@ export class MCPSecurityAgent extends BaseAgent {
   /**
    * Check if MCP server files have authentication.
    */
+  _checkToolValidation(filePath) {
+    const content = this.readFile(filePath);
+    if (!content) return [];
+
+    const dispatches = /(?:tools\/call|tool_call|callTool|executeTool)\s*\(/.test(content);
+    if (!dispatches) return [];
+
+    // Any allowlist, schema check, or membership test in the file refutes the
+    // claim that names go unvalidated. Deliberately generous: the finding says
+    // "nothing here validates," and one check is enough to disprove it.
+    const validates =
+      /(?:allow_?list|allowedTools|ALLOWED_TOOLS|SAFE_TOOLS|permitted_?tools|tool_?schema|validate\w*\s*\(|zod|pydantic|jsonschema|BaseModel)/i.test(content)
+      || /\b(?:in|includes|has|hasOwnProperty|get)\s*\(?\s*(?:ALLOWED|allowed|registry|REGISTRY|_tools|TOOLS)\b/.test(content);
+    if (validates) return [];
+
+    const lines = content.split('\n');
+    const idx = lines.findIndex(l => /(?:tools\/call|tool_call|callTool|executeTool)\s*\(/.test(l));
+    const line = idx === -1 ? 1 : idx + 1;
+    const matched = (lines[line - 1] || '').trim().slice(0, 180);
+    if (this.isSuppressed(matched, 'high')) return [];
+
+    return [createFinding({
+      file: filePath,
+      line,
+      column: 1,
+      severity: 'high',
+      category: this.category,
+      rule: 'MCP_NO_TOOL_VALIDATION',
+      title: 'MCP: Tool Call Without Validation',
+      description: 'This file dispatches MCP tool invocations but contains no tool-name allowlist or argument schema check. Tool poisoning can then invoke whatever the server exposes.',
+      matched,
+      confidence: 'medium',
+      cwe: 'CWE-20',
+      owasp: 'A03:2021',
+      fix: 'Validate tool names against an explicit allowlist, and tool arguments against a schema, before execution.',
+    })];
+  }
+
   _checkServerAuth(filePath) {
     const content = this.readFile(filePath);
     if (!content) return [];

--- a/cli/agents/pii-compliance-agent.js
+++ b/cli/agents/pii-compliance-agent.js
@@ -151,7 +151,13 @@ const PATTERNS = [
   {
     rule: 'PII_EMAIL_HARDCODED',
     title: 'Privacy: Real Email Address Hardcoded',
-    regex: /['"][a-zA-Z0-9._%+-]+@(?!example\.com|example\.org|test\.com|test\.org|testing\.com|localhost|placeholder|fake|dummy|mailinator\.com|noreply|no-reply|sample\.com)[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}['"]/g,
+    // The noreply exclusion has to cover the whole domain, not just its first
+    // label. `noreply@` was already excluded, but GitHub's privacy addresses
+    // are `<id>+<user>@users.noreply.github.com`, so the old anchored
+    // alternative never fired on the exact addresses GitHub hands out
+    // specifically so a contributor's real one stays private. 622 of the 1965
+    // matches on hermes-agent's contributor map were these.
+    regex: /['"][a-zA-Z0-9._%+-]+@(?!example\.com|example\.org|test\.com|test\.org|testing\.com|localhost|placeholder|fake|dummy|mailinator\.com|sample\.com)(?![a-zA-Z0-9.-]*(?:noreply|no-reply))[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}['"]/g,
     severity: 'medium',
     cwe: 'CWE-312',
     owasp: 'A02:2021',
@@ -226,6 +232,25 @@ const PATTERNS = [
 // PII COMPLIANCE AGENT
 // =============================================================================
 
+/**
+ * Above this many hardcoded emails in one file, the file is an address
+ * directory rather than a leak, and the honest finding is "this file is a
+ * directory" reported once — not one finding per entry.
+ *
+ * Calibrated against hermes-agent, whose `scripts/release.py` carries a
+ * contributor credit map: 1965 matches from a single file, 28% of everything
+ * the scanner reported on that repo. Ten is comfortably above what an
+ * accidental leak looks like (a support address, a default recipient, a
+ * seeded test user) and far below any real directory.
+ */
+const EMAIL_DIRECTORY_THRESHOLD = 10;
+
+/**
+ * Files whose entire purpose is recording contributor identity. Emails here
+ * are the point of the file, and they are already public in git history.
+ */
+const CREDIT_FILE = /(?:^|\/)(?:\.mailmap|AUTHORS|CONTRIBUTORS|CREDITS)(?:\.[a-z]+)?$|(?:^|\/)contributors?\//i;
+
 export class PIIComplianceAgent extends BaseAgent {
   constructor() {
     super(
@@ -247,13 +272,71 @@ export class PIIComplianceAgent extends BaseAgent {
 
     // ── 1. Scan code files with PII patterns ─────────────────────────────
     for (const file of codeFiles) {
+      if (CREDIT_FILE.test(file)) continue;
       findings = findings.concat(this.scanFileWithPatterns(file, PATTERNS));
     }
 
-    // ── 2. Check for missing data deletion endpoint (GDPR right to erasure)
+    // ── 2. Collapse per-file email floods into one directory finding ─────
+    findings = this._collapseEmailDirectories(findings);
+
+    // ── 3. Check for missing data deletion endpoint (GDPR right to erasure)
     findings = findings.concat(this._checkDataDeletion(context));
 
     return findings;
+  }
+
+  /**
+   * Replace runs of PII_EMAIL_HARDCODED in a single file with one finding
+   * describing the file as an address directory.
+   *
+   * Reporting a contributor map once, accurately, is more useful than
+   * reporting it 1965 times: the reviewer's decision is about the file, not
+   * about each address in it, and a flood at this scale buries every other
+   * finding in the run.
+   */
+  _collapseEmailDirectories(findings) {
+    const counts = new Map();
+    for (const f of findings) {
+      if (f.rule !== 'PII_EMAIL_HARDCODED') continue;
+      counts.set(f.file, (counts.get(f.file) || 0) + 1);
+    }
+
+    const dirs = new Set(
+      [...counts.entries()]
+        .filter(([, n]) => n >= EMAIL_DIRECTORY_THRESHOLD)
+        .map(([file]) => file)
+    );
+    if (dirs.size === 0) return findings;
+
+    const kept = [];
+    const emitted = new Set();
+
+    for (const f of findings) {
+      if (f.rule !== 'PII_EMAIL_HARDCODED' || !dirs.has(f.file)) {
+        kept.push(f);
+        continue;
+      }
+      if (emitted.has(f.file)) continue;
+      emitted.add(f.file);
+
+      const count = counts.get(f.file);
+      kept.push(createFinding({
+        file: f.file,
+        line: f.line,
+        severity: 'low',
+        category: this.category,
+        rule: 'PII_EMAIL_DIRECTORY',
+        title: 'Privacy: File Contains an Email Address Directory',
+        description: `${count} hardcoded email addresses in one file. This is an address directory (contributor credits, a mailing list, a seed fixture) rather than an accidental leak. Reported once instead of ${count} times.`,
+        matched: `${count} email addresses`,
+        confidence: 'low',
+        cwe: 'CWE-312',
+        owasp: 'A02:2021',
+        fix: 'If this is a contributor or credits map, no action is needed — the addresses are already public in git history. If it is a real address list, move it out of source control.',
+      }));
+    }
+
+    return kept;
   }
 
   /**

--- a/cli/agents/slopsquat-agent.js
+++ b/cli/agents/slopsquat-agent.js
@@ -81,6 +81,7 @@ export class SlopSquatAgent extends BaseAgent {
           if (!pkg || reported.has(pkg)) continue;
           if (BUILTINS.has(pkg) || declared.has(pkg) || pkg === selfName) continue;
           if (this._installed(nodeModules, pkg)) continue;
+          if (this._resolvesNearby(file, rootPath, pkg)) continue;
 
           reported.add(pkg);
           const line = content.slice(0, m.index).split('\n').length;
@@ -136,6 +137,38 @@ export class SlopSquatAgent extends BaseAgent {
 
   _installed(nodeModules, pkg) {
     try { return fs.existsSync(path.join(nodeModules, ...pkg.split('/'))); } catch { return false; }
+  }
+
+  /**
+   * Resolve an import the way Node does: walk up from the importing file,
+   * checking each ancestor's package.json and node_modules until the project
+   * root.
+   *
+   * Resolving only against the root pair mis-reads any repository with more
+   * than one package in it. On hermes-agent — which has package.json files
+   * under apps/, web/, website/, ui-tui/ and tests-js/ — every dependency of
+   * every sub-package looked phantom, and the agent reported 137 of them as
+   * possible AI hallucinations. A workspace dependency is the opposite of a
+   * hallucination: it is declared, installed, and resolving fine.
+   */
+  _resolvesNearby(file, rootPath, pkg) {
+    let dir = path.dirname(path.resolve(file));
+    const stop = path.resolve(rootPath);
+
+    for (;;) {
+      if (this._installed(path.join(dir, 'node_modules'), pkg)) return true;
+
+      const pkgJson = path.join(dir, 'package.json');
+      if (fs.existsSync(pkgJson)) {
+        if (this._declaredDeps(pkgJson).has(pkg)) return true;
+        if (this._selfName(pkgJson) === pkg) return true;
+      }
+
+      if (dir === stop) return false;
+      const parent = path.dirname(dir);
+      if (parent === dir) return false;
+      dir = parent;
+    }
   }
 }
 

--- a/cli/agents/ssrf-prober.js
+++ b/cli/agents/ssrf-prober.js
@@ -57,6 +57,9 @@ const PATTERNS = [
     rule: 'SSRF_CLOUD_METADATA',
     title: 'SSRF: Cloud Metadata Endpoint Access',
     regex: /169\.254\.169\.254|metadata\.google\.internal|100\.100\.100\.200/g,
+    // Every hit on hermes-agent was a comment explaining why the code takes
+    // care *not* to probe IMDS. Prose about an endpoint is not access to it.
+    skipComments: true,
     severity: 'critical',
     cwe: 'CWE-918',
     owasp: 'A10:2021',
@@ -73,7 +76,10 @@ const PATTERNS = [
     // The SSRF question is whether an internal address is the destination of a
     // request, so require an outbound-request context on the same line. A bind
     // address, a default host, or a docs example no longer counts.
-    regex: /(?:fetch|axios|got|request|urlopen|requests\.\w+|httpx?\.\w+|curl|https?:\/\/|url\s*[:=]|endpoint\s*[:=]|baseURL\s*[:=]|proxy\s*[:=])[^\n]{0,80}(?:127\.0\.0\.|0\.0\.0\.0|10\.\d+\.\d+\.\d+|172\.(?:1[6-9]|2\d|3[01])\.\d+\.\d+|192\.168\.)\d+/gi,
+    // A loopback OAuth redirect URI is RFC 8252's recommended practice for a
+    // native app, not an SSRF sink, so exclude the callback shape outright.
+    regex: /(?<!(?:redirect_?uri|callback_?url|redirect_?url)\s*[:=]\s*f?["'`])(?:fetch|axios|got|request|urlopen|requests\.\w+|httpx?\.\w+|curl|https?:\/\/|url\s*[:=]|endpoint\s*[:=]|baseURL\s*[:=]|proxy\s*[:=])[^\n]{0,80}(?:127\.0\.0\.|0\.0\.0\.0|10\.\d+\.\d+\.\d+|172\.(?:1[6-9]|2\d|3[01])\.\d+\.\d+|192\.168\.)\d+/gi,
+    skipComments: true,
     severity: 'medium',
     cwe: 'CWE-918',
     owasp: 'A10:2021',

--- a/cli/agents/ssrf-prober.js
+++ b/cli/agents/ssrf-prober.js
@@ -66,12 +66,19 @@ const PATTERNS = [
   {
     rule: 'SSRF_INTERNAL_IP',
     title: 'SSRF: Internal IP Pattern',
-    regex: /(?:127\.0\.0\.|0\.0\.0\.0|10\.\d+\.\d+\.\d+|172\.(?:1[6-9]|2\d|3[01])\.\d+\.\d+|192\.168\.)\d+/g,
+    // A private IP literal on its own says nothing. Local-first software binds
+    // loopback on purpose, and the old bare-literal pattern reported 312 times
+    // on hermes-agent for doing exactly what its documentation says it does.
+    //
+    // The SSRF question is whether an internal address is the destination of a
+    // request, so require an outbound-request context on the same line. A bind
+    // address, a default host, or a docs example no longer counts.
+    regex: /(?:fetch|axios|got|request|urlopen|requests\.\w+|httpx?\.\w+|curl|https?:\/\/|url\s*[:=]|endpoint\s*[:=]|baseURL\s*[:=]|proxy\s*[:=])[^\n]{0,80}(?:127\.0\.0\.|0\.0\.0\.0|10\.\d+\.\d+\.\d+|172\.(?:1[6-9]|2\d|3[01])\.\d+\.\d+|192\.168\.)\d+/gi,
     severity: 'medium',
     cwe: 'CWE-918',
     owasp: 'A10:2021',
     confidence: 'low',
-    description: 'Internal IP address in code. Verify it is not reachable via user-controlled URLs.',
+    description: 'Internal IP address used as a request destination. Verify it cannot be reached via a user-controlled URL.',
     fix: 'Block private IP ranges in URL validation for user-supplied URLs',
   },
   {

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -80,9 +80,9 @@ it was a year ago.
 
 The other half of picking a scanner is how much triage it creates. We publish a
 [false-positive benchmark](../benchmarks/false-positives/) measuring Ship Safe on
-mature projects with no known active vulnerabilities: 75 findings across express,
-requests, flask and chalk, with the 3 remaining criticals documented as false
-positives.
+mature projects with no known active vulnerabilities: 73 findings across express,
+requests, flask and chalk, with the 1 remaining critical documented as a false
+positive.
 
 We deliberately do **not** publish a head-to-head detection comparison. A
 vendor-run benchmark where the vendor picks the corpus is worth very little, and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ship-safe",
-  "version": "9.6.3",
+  "version": "9.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ship-safe",
-      "version": "9.6.3",
+      "version": "9.6.4",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ship-safe",
-  "version": "9.6.3",
-  "description": "AI-powered multi-agent security platform. 29 agents scan 80+ attack classes including AI integration supply chain (Vercel-class attacks), Hermes Agent deployments (ASI-01\u2013ASI-10), tool registry poisoning, function-call injection, skill permission drift, and agent attestation. Ship Safe \u00d7 Hermes Agent.",
+  "version": "9.6.4",
+  "description": "AI-powered multi-agent security platform. 29 agents scan 80+ attack classes including AI integration supply chain (Vercel-class attacks), Hermes Agent deployments (ASI-01–ASI-10), tool registry poisoning, function-call injection, skill permission drift, and agent attestation. Ship Safe × Hermes Agent.",
   "main": "cli/index.js",
   "bin": {
     "ship-safe": "cli/bin/ship-safe.js"


### PR DESCRIPTION
Workstream 1 of the Hermes collaboration plan: get the scanner calibrated before anyone at Nous sees its output.

Scanning [hermes-agent](https://github.com/NousResearch/hermes-agent) at `743dc94` (~8,400 files) reported **6,948 findings** and graded it 13/F. A maintainer opening that report would have seen 1,963 findings on their contributor credits file and stopped reading. This takes it to **818**.

## What was actually wrong

Fourteen rules, and none of them needed a threshold nudged. Every one was a defect.

**Absence assertions that could never fail.** Six rules asked "is logging missing?" as a negative lookahead placed after `[\s\S]{0,300}`. The gap backtracks until the lookahead succeeds, so the assertion always holds. `AGENT_NO_AUDIT_LOG` was, in effect, "this line contains the string `tool_call`" — 1,904 findings. `OAUTH_NO_STATE` was worse: its alternation bound the lookahead to only the third branch, so the first two matched unconditionally. These are now structural checks that answer the question per file, or per project for spend controls. 16 more rules share the shape and are tracked in #106.

**English read as code.** `SQL_INJECTION_TEMPLATE_LITERAL` listed `CREATE` as a bare alternative, so ``showToast(`Create failed: ${e}`)`` was 24 criticals on a file browser. `PYTHON_SQL_FSTRING` flagged `f"Select a model ({n} available)"`. Both now require clause structure — SELECT with FROM, UPDATE with SET.

**Prose read as code.** Every `SSRF_CLOUD_METADATA` hit was a comment explaining why the code takes care *not* to probe IMDS. Patterns can now opt into `skipComments`.

**Context errors.** `CODE_INJECTION_EVAL_GENERIC` counted any method named `eval` (`cdp.eval`, 126 times). `API_UPLOAD_NO_TYPE_CHECK` matched `filename)` in any language — the same mistake 9.6.4 fixed in the rule next door. `TIMING_ATTACK_COMPARISON` flagged two locally held secrets compared to each other. `SSRF_INTERNAL_IP` flagged loopback OAuth redirect URIs, which RFC 8252 recommends.

**Two genuine bugs.** `PII_EMAIL_HARDCODED`'s `noreply` exclusion was anchored to the first domain label, so it never matched `<id>+<user>@users.noreply.github.com` — the address GitHub issues specifically to keep a contributor's real one private. And `SlopSquatAgent` resolved every import against the root `package.json`, so in a workspace every sub-package dependency looked like an AI hallucination (137 → 33).

## Detection is unchanged

- **NodeGoat: 74 findings, 9 critical, 18 high — identical, not one finding moved.**
- DVWA: criticals and highs identical. Lost 7 mediums, mostly `$_DVWA['db_server'] = '127.0.0.1'` in translated READMEs.
- Clean corpus improves 73 → 57. express 63.1 → 71.3 (C), flask 54.5 → 67.7 (C), requests 74.5 → 81.1 (B).
- 366 tests pass, 25 new, each recalibrated rule asserted in both directions.

## Also in here

hermes-agent is added to the false-positive corpus, pinned. The README lists its remaining 818 by rule rather than rounding it off.

And a bug found while committing: `MCPSecurityAgent` referenced `createFinding` without importing it, so the new check threw a `ReferenceError` the orchestrator swallowed, taking that agent's other MCP-server-file output with it.

## One thing to decide

The score never moved. 13/F at 6,948 findings, 13/F at 818. Category deductions cap at the category weight, the weights sum to 100, and each category saturates after 3–5 medium findings. The score cannot tell those two runs apart, and it is what the README leads with and what `ci --threshold` gates on. Written up with options in #107; it needs a decision before 10.0, not a patch.
