### PR TITLE
Fix COOKIE_NO_HTTPONLY and correct the lookahead claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,12 +87,30 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   orchestrator swallowed, taking the rest of that agent's output for MCP server
   files with it.
 
+- **`COOKIE_NO_HTTPONLY` reported correctly configured cookies as insecure.**
+  Its lookahead floated after whichever attribute matched rather than being
+  pinned to the options object, so `{ httpOnly: true, secure: true, path: '/' }`
+  matched on `path` and then asked whether `httpOnly` appeared *after* `path`.
+  It does not, so the rule fired. Now anchored at the call opener.
+
+  This was found by auditing the shape described below, and it was the only
+  unambiguous false positive in the group.
+
 ### Known issues
 
-- 16 rules still carry the backtracking-lookahead defect, and the score
-  saturates after 3–5 medium findings per category, which is why hermes-agent
-  reports the same 13/F at 818 findings as it did at 6,948. Both are tracked as
-  issues.
+- The score saturates after 3–5 medium findings per category, which is why
+  hermes-agent reports the same 13/F at 799 findings as it did at 6,948.
+  Tracked in #107.
+
+- Roughly a dozen rules still write an absence check as a negative lookahead
+  after a variable-length gap. An earlier draft of this entry called all of
+  them broken; that was wrong, and the correction is worth recording. The
+  defect only bites when the trigger token recurs after the mitigation, which
+  is common for `tool_call` (hence `AGENT_NO_AUDIT_LOG`'s 1,904 findings) and
+  rare for the rest. Probed individually with the mitigation present and a
+  single trigger, only `COOKIE_NO_HTTPONLY` misfired. The remainder are
+  fragile rather than broken, and `cli/__tests__/absence-rules.test.js` now
+  guards the quiet direction for the ones that matter. Tracked in #106.
 
 ---
 

--- a/benchmarks/false-positives/README.md
+++ b/benchmarks/false-positives/README.md
@@ -22,7 +22,7 @@ Mature, heavily reviewed projects with no known active vulnerabilities.
 | [requests](https://github.com/psf/requests) | 11 | 1 | 81.1 | B | 15 |
 | [flask](https://github.com/pallets/flask) | 20 | 0 | 67.7 | C | 28 |
 | [chalk](https://github.com/chalk/chalk) | 4 | 0 | 87.2 | B | 4 |
-| [hermes-agent](https://github.com/NousResearch/hermes-agent) | 818 | 115 | 13 | F | — |
+| [hermes-agent](https://github.com/NousResearch/hermes-agent) | 799 | 115 | 13 | F | — |
 | **total (original four)** | **57** | **1** | | | **73** |
 
 Before the 9.6.3 false-positive work these same four projects produced **1031**
@@ -42,11 +42,11 @@ agent security should be measured against a real agent.
 
 It found more than any other corpus entry ever has. The first run reported
 **6,948 findings**, of which five rules were 4,684 — including 1,963 on a single
-contributor credit map, and two rules whose absence-assertions were structurally
-incapable of failing. It is now at **818**, an 88% reduction, with the full
+contributor credit map, and two rules whose absence-assertions could not fail on
+input like theirs. It is now at **799**, an 89% reduction, with the full
 accounting in the changelog for this release.
 
-818 is not a passing number and this table does not pretend otherwise. The
+799 is not a passing number and this table does not pretend otherwise. The
 remaining tail is documented under "Known false positives" below.
 
 ### Vulnerable corpus
@@ -68,7 +68,7 @@ DVWA's criticals and highs are unchanged. DVWA's 7 lost mediums were
 Category deductions are capped at the category's weight, and the eight weights
 sum to 100. Each category therefore saturates after **3 to 5 medium-severity
 findings**. Past that point the score stops responding: hermes-agent scored 13/F
-at 6,948 findings and still scores 13/F at 818.
+at 6,948 findings and still scores 13/F at 799.
 
 This is why the table leads with finding counts. Treat the score as a signal
 only for small, already-clean projects, and see the tracking issue on scoring
@@ -96,7 +96,7 @@ Fixed since the first run of this benchmark:
 Beyond critical, flask's remaining 20 findings are a mix rather than one
 dominant cause.
 
-### hermes-agent's remaining 818
+### hermes-agent's remaining 799
 
 Not yet triaged, listed so the next pass has a starting point. Counts are from
 the run that produced this table.
@@ -112,9 +112,8 @@ the run that produced this table.
 | `AGENT_NO_OUTPUT_SCHEMA` | 22 | same shape as the cost-limit rule |
 | `Password Assignment` | 21 | secret scanner; needs sampling |
 
-The two structural issues behind much of this tail — rules that assert an
-absence per line, and the scoring saturation above — are tracked as issues
-rather than patched case by case.
+The scoring saturation described above is tracked as an issue rather than
+patched here.
 
 ## Honest limits
 
@@ -123,10 +122,11 @@ Read these before quoting any number above.
 - **This is a proxy for a false-positive rate, not a rate.** "No known active
   vulnerabilities" is not "no vulnerabilities", and these findings have not each
   been adjudicated by hand. Turning the proxy into a real rate means triaging
-  all 75 findings individually. That work has not been done.
-- **Four projects is a small corpus**, skewed toward JavaScript and Python, and
-  toward libraries rather than applications. A web app with real authentication
-  and deployment configuration exercises rules these do not reach.
+  each finding individually. That work has not been done.
+- **Five projects is a small corpus**, skewed toward JavaScript and Python. The
+  original four are libraries; hermes-agent is the first application in it. A
+  web app with real authentication and deployment configuration still exercises
+  rules none of these reach.
 - **Grades are not comparable across projects.** Score is normalized by codebase
   size, so a small package and a framework with a large test suite are not on
   the same footing.

--- a/benchmarks/false-positives/results/latest.json
+++ b/benchmarks/false-positives/results/latest.json
@@ -47,7 +47,7 @@
       "id": "hermes-agent",
       "repo": "NousResearch/hermes-agent",
       "commit": "743dc94ab90adb0529bb233b8498c6fd6ee0e020",
-      "findings": 818,
+      "findings": 799,
       "critical": 115,
       "high": 226,
       "score": 13,
@@ -74,7 +74,7 @@
   ],
   "summary": {
     "cleanProjects": 5,
-    "cleanFindings": 875,
+    "cleanFindings": 856,
     "cleanCriticalFindings": 116,
     "vulnerableProjects": 2,
     "vulnerableFindings": 150

--- a/cli/__tests__/absence-rules.test.js
+++ b/cli/__tests__/absence-rules.test.js
@@ -1,0 +1,77 @@
+/**
+ * Absence-rule regression
+ * =======================
+ *
+ * A rule that reports the *absence* of something has a failure mode a normal
+ * detection test never catches: it can be structurally incapable of staying
+ * quiet. Write the check as a negative lookahead after a variable-length gap
+ *
+ *   /trigger[\s\S]{0,300}(?![\s\S]{0,300}mitigation)/
+ *
+ * and the gap backtracks until the lookahead succeeds, so the rule degrades
+ * into "this line contains trigger". AGENT_NO_AUDIT_LOG shipped like this and
+ * produced 1904 findings on a single repository.
+ *
+ * The test below is the shape of check that finds it: feed each absence rule
+ * an input where the mitigation is present and there is exactly one trigger,
+ * and assert the rule stays quiet. Detection tests live with their agents;
+ * this file only guards the quiet direction.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+function writeTemp(content, ext = '.js') {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-absence-'));
+  const file = path.join(dir, `test${ext}`);
+  fs.writeFileSync(file, content);
+  return { dir, file };
+}
+const cleanup = (dir) => { try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* */ } };
+
+describe('absence rules stay quiet when the mitigation is present', async () => {
+  const { AuthBypassAgent } = await import('../agents/auth-bypass-agent.js');
+  const { AgenticSecurityAgent } = await import('../agents/agentic-security-agent.js');
+  const { RAGSecurityAgent } = await import('../agents/rag-security-agent.js');
+  const { PIIComplianceAgent } = await import('../agents/pii-compliance-agent.js');
+
+  const quiet = async (Agent, rule, code, ext = '.js') => {
+    const { dir, file } = writeTemp(code, ext);
+    try {
+      const findings = await new Agent().analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+      const hits = findings.filter(f => f.rule === rule);
+      assert.equal(hits.length, 0, `${rule} fired despite the mitigation being present`);
+    } finally { cleanup(dir); }
+  };
+
+  it('COOKIE_NO_HTTPONLY: httpOnly set before other attributes', () =>
+    quiet(AuthBypassAgent, 'COOKIE_NO_HTTPONLY',
+      "res.cookie('s', v, { httpOnly: true, secure: true, path: '/' });\nnext();"));
+
+  it('AGENT_NO_AUDIT_LOG: a logger anywhere in the file', () =>
+    quiet(AgenticSecurityAgent, 'AGENT_NO_AUDIT_LOG',
+      'def run(c):\n    logger.info("tool %s", c.name)\n    return executeTool(c.name, c.args)\n', '.py'));
+
+  it('AGENT_MEMORY_NO_EXPIRY: a TTL anywhere in the file', () =>
+    quiet(AgenticSecurityAgent, 'AGENT_MEMORY_NO_EXPIRY',
+      'def save(e):\n    memory.store(e, ttl=3600)\n', '.py'));
+
+  it('AGENT_NO_COST_LIMIT: a token ceiling on the call', () =>
+    quiet(AgenticSecurityAgent, 'AGENT_NO_COST_LIMIT',
+      'await client.chat.completions.create({ model: "gpt-4", max_tokens: 500 });'));
+
+  it('AGENT_NO_OUTPUT_SCHEMA: parsed output validated by a schema', () =>
+    quiet(AgenticSecurityAgent, 'AGENT_NO_OUTPUT_SCHEMA',
+      'const parsed = JSON.parse(completion);\nconst safe = ResultSchema.parse(parsed);'));
+
+  it('RAG_NO_TENANT_ISOLATION: namespace and filter supplied', () =>
+    quiet(RAGSecurityAgent, 'RAG_NO_TENANT_ISOLATION',
+      'await pinecone.upsert(vectors, { namespace: tenantId, filter: { user_id: uid } });'));
+
+  it('PII_TRACKING_NO_CONSENT: consent checked before init', () =>
+    quiet(PIIComplianceAgent, 'PII_TRACKING_NO_CONSENT',
+      'if (hasConsent) { gtag("config", id); } // gdpr cookie banner opt-in'));
+});

--- a/cli/agents/agentic-security-agent.js
+++ b/cli/agents/agentic-security-agent.js
@@ -205,20 +205,9 @@ const PATTERNS = [
     description: 'LLM output directly triggers side-effect actions without validation. Hallucinated or injected outputs can cause unintended actions.',
     fix: 'Validate LLM output against expected schemas before executing side effects. Add human confirmation for irreversible actions.',
   },
-  {
-    rule: 'AGENT_NO_OUTPUT_SCHEMA',
-    title: 'Agent: No Schema Validation on LLM Output',
-    // The trailing lookahead never failed, and one of its own escape hatches
-    // was the word `parse` — which `JSON.parse` supplies by definition. The
-    // per-file version of this question lives in AGENT_STRUCTURAL_RULES; here
-    // just record the parse of model output.
-    regex: /(?:JSON\.parse|json\.loads)\s*\(\s*(?:completion|response|output|result|generated|llm|ai|gpt|claude)\w*\s*[,)]/g,
-    severity: 'medium',
-    cwe: 'CWE-20',
-    owasp: 'A03:2021',
-    description: 'LLM JSON output parsed without schema validation. Malformed or malicious output can cause unexpected behavior.',
-    fix: 'Validate LLM structured output against a schema (Zod, Joi, Pydantic) before processing.',
-  },
+  // AGENT_NO_OUTPUT_SCHEMA moved to AGENT_STRUCTURAL_RULES. Its old lookahead
+  // never failed, and one of its own escape hatches was the word `parse`,
+  // which `JSON.parse` supplies by definition.
 
   // ── Credential Isolation ─────────────────────────────────────────────────
   {
@@ -426,8 +415,12 @@ const AGENT_STRUCTURAL_RULES = [
         /(?:JSON\.parse|json\.loads)\s*\(\s*(?:completion|response|output|result|generated|llm|ai|gpt|claude)\w*\s*[,)]/i.test(content);
       if (!parsesModelOutput) return false;
 
+      // Deliberately generous. The claim is "nothing here validates the
+      // shape"; one validator refutes it. `\w*schema` matters because the
+      // common idiom names the schema after the type — `ResultSchema.parse`,
+      // `UserSchema.safeParse` — and a bare `\bschema\b` misses all of them.
       const validates =
-        /\b(?:zod|yup|joi|ajv|jsonschema|pydantic|BaseModel|TypeAdapter|type_adapter|safeParse|validate\w*\s*\(|schema)\b/i.test(content);
+        /\b(?:zod|yup|joi|ajv|jsonschema|pydantic|BaseModel|TypeAdapter|type_adapter|safeParse|validate\w*\s*\(|\w*schema)\b/i.test(content);
 
       return !validates;
     },

--- a/cli/agents/auth-bypass-agent.js
+++ b/cli/agents/auth-bypass-agent.js
@@ -64,7 +64,13 @@ const PATTERNS = [
     // configuration: on Flask it flagged three keys of a config dict that sets
     // SESSION_COOKIE_HTTPONLY two lines below, and a docstring describing the
     // Domain parameter. 17 of Flask's 55 findings came from this one rule.
-    regex: /(?:res\.cookie|response\.cookie|setCookie|set_cookie|Set-Cookie\s*:)\s*[(:][^;\n]{0,160}?(?:secure|domain|path|maxAge|max-age)(?![^;\n]*httponly)/gi,
+    // The lookahead has to be pinned to the start of the options, not left
+    // floating after whichever attribute happened to match. Written the old
+    // way, `{ httpOnly: true, secure: true, path: '/' }` matched on `path`
+    // and then asked whether httpOnly appeared *after* `path` — it does not,
+    // so a correctly configured cookie was reported as insecure. Anchoring
+    // the check at the call opener asks about the whole options object.
+    regex: /(?:res\.cookie|response\.cookie|setCookie|set_cookie|Set-Cookie\s*:)\s*[(:](?![^;\n]{0,200}httponly)[^;\n]{0,160}(?:secure|domain|path|maxAge|max-age)/gi,
     severity: 'medium',
     cwe: 'CWE-1004',
     owasp: 'A05:2021',


### PR DESCRIPTION
Stacked on #108. Follow-up to #106, and a correction to a claim I made in that issue and in #108's description.

## The correction

#108 said 16 rules carried a never-failing absence assertion. That number came from a crude script — any negative lookahead in a `regex:` whose preceding text contained `{0,N}` — and it was wrong. Most of what it collected are exclusions pinned at a fixed position, `(?!localhost)` immediately after `http://` or `(?!__dirname)` immediately after `(`, which cannot drift and work as intended.

Probed individually, with the mitigation present and exactly one trigger, **one** rule actually misfired.

## What was really broken

**`COOKIE_NO_HTTPONLY`.** The lookahead floated after whichever attribute matched rather than being anchored to the options object:

```js
[^;\n]{0,160}?(?:secure|domain|path|maxAge)(?![^;\n]*httponly)
```

`{ httpOnly: true, secure: true, path: '/' }` matches on `path`, then asks whether `httpOnly` appears *after* `path`. It does not, so a correctly configured cookie was reported as insecure. Now anchored at the call opener so the check covers the whole options object.

The rest are fragile rather than broken. The defect only bites when the trigger recurs after the mitigation — constant for `tool_call`, hence `AGENT_NO_AUDIT_LOG`'s 1,904 findings, and rare elsewhere. #106 now lists all three groups: one confirmed, five fragile, eight fine as written, so nobody rewrites a rule that does not need it.

## The test that found it

`cli/__tests__/absence-rules.test.js` encodes the probe: give an absence rule an input where the mitigation is present and there is one trigger, assert it stays quiet. An ordinary detection test only exercises the loud direction, which is exactly why this shipped in the first place.

Writing it caught two more problems immediately:

- `AGENT_NO_OUTPUT_SCHEMA` was registered twice, as a leftover line pattern *and* the new structural rule, so it fired regardless of validation. My mistake in #108.
- Its mitigation check was too stingy to recognise `ResultSchema.parse` — `\bschema\b` does not match `ResultSchema`. That is the precise failure mode #106 warns about, found in code I had just written.

## Numbers

hermes-agent 823 → 799. Clean corpus unchanged at 57. NodeGoat 74/9C/18H and DVWA 76/6C/55H both unchanged. 373 tests pass, 7 new.
