### PR TITLE
Proposal (#107): asymptotic deduction cap to restore score resolution

### DIFF
--- a/cli/__tests__/agents.test.js
+++ b/cli/__tests__/agents.test.js
@@ -285,15 +285,16 @@ describe('ScoringEngine', async () => {
     assert.equal(result.grade.letter, 'A');
   });
 
-  it('deducts for critical findings (capped at category weight)', () => {
+  it('deducts for critical findings, bounded by category weight', () => {
     const engine = new ScoringEngine();
     const findings = [
       { severity: 'critical', category: 'secrets', confidence: 'high' },
     ];
     const result = engine.compute(findings, []);
     assert.ok(result.score < 100, 'Score should decrease with critical finding');
-    // 25 pts deduction capped at category weight of 15
-    assert.equal(result.categories.secrets.deduction, 15);
+    const { deduction, weight } = result.categories.secrets;
+    assert.ok(deduction > 0, 'a critical secret must cost something');
+    assert.ok(deduction < weight, 'no single category may exceed its weight');
   });
 
   it('applies confidence multiplier', () => {
@@ -306,12 +307,18 @@ describe('ScoringEngine', async () => {
     assert.ok(lowResult.score > highResult.score, 'Low confidence should deduct less');
   });
 
-  it('caps deduction at category weight', () => {
+  it('bounds a category by its weight while still ranking severity of noise', () => {
     const engine = new ScoringEngine();
-    // 10 critical findings in secrets (25 pts each = 250, but capped at 15)
-    const findings = Array(10).fill({ severity: 'critical', category: 'secrets', confidence: 'high' });
-    const result = engine.compute(findings, []);
-    assert.equal(result.categories.secrets.deduction, 15);
+    const one = engine.compute(
+      [{ severity: 'critical', category: 'secrets', confidence: 'high' }], []);
+    const ten = engine.compute(
+      Array(10).fill({ severity: 'critical', category: 'secrets', confidence: 'high' }), []);
+
+    const weight = ten.categories.secrets.weight;
+    assert.ok(ten.categories.secrets.deduction < weight,
+      'a category may approach its weight but never exceed it');
+    assert.ok(ten.categories.secrets.deduction > one.categories.secrets.deduction,
+      'ten criticals must cost more than one — the old hard cap made them equal');
   });
 
   it('handles dependency vulnerabilities', () => {

--- a/cli/__tests__/scoring-resolution.test.js
+++ b/cli/__tests__/scoring-resolution.test.js
@@ -1,0 +1,69 @@
+/**
+ * Scoring resolution
+ * ==================
+ *
+ * The score has to stay responsive across the whole range of finding counts a
+ * real repository can produce. It previously did not: category deductions were
+ * clamped with Math.min, every category's weight is worth only 3 to 5
+ * medium-severity findings, and the eight weights sum to 100 — so about thirty
+ * findings spread across categories bottomed the score out. hermes-agent
+ * scored 13/F at 6,948 findings and 13/F at 799, an 89% reduction the number
+ * could not see.
+ *
+ * These are invariants, not fixed values: they assert how two scans must relate
+ * to each other, so they survive re-cut grade bands and re-weighted categories.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { ScoringEngine, CATEGORIES } from '../agents/scoring-engine.js';
+
+const cats = Object.keys(CATEGORIES);
+
+function findings(n) {
+  return Array.from({ length: n }, (_, i) => ({
+    category: cats[i % cats.length],
+    severity: ['critical', 'high', 'medium'][i % 3],
+    confidence: 'medium',
+    rule: 'TEST_RULE',
+    title: 'test',
+    file: `f${i}.js`,
+    line: 1,
+  }));
+}
+
+const scoreOf = (n) => new ScoringEngine().compute(findings(n), []).score;
+
+describe('scoring stays responsive as findings grow', () => {
+  it('is strictly decreasing across four orders of magnitude', () => {
+    const counts = [5, 15, 30, 60, 120, 300, 800, 2000, 7000];
+    const scores = counts.map(scoreOf);
+
+    for (let i = 1; i < scores.length; i++) {
+      assert.ok(
+        scores[i] < scores[i - 1],
+        `${counts[i]} findings scored ${scores[i]}, not below ${counts[i - 1]} findings at ${scores[i - 1]}`
+      );
+    }
+  });
+
+  it('separates a noisy repository from a catastrophic one', () => {
+    // The case that motivated this: an 89% reduction in findings has to move
+    // the number. Under the old hard cap both of these scored 0.
+    assert.ok(scoreOf(800) < scoreOf(90), '800 findings must score below 90');
+    assert.ok(scoreOf(7000) < scoreOf(800), '7000 findings must score below 800');
+  });
+
+  it('still charges the first finding in a category the most', () => {
+    const first = 100 - scoreOf(8);        // one per category
+    const second = 100 - scoreOf(16) - first;
+    assert.ok(first > second, 'marginal cost must fall as findings accumulate');
+  });
+
+  it('never goes negative or above 100', () => {
+    for (const n of [0, 1, 50, 5000]) {
+      const s = scoreOf(n);
+      assert.ok(s >= 0 && s <= 100, `score ${s} out of range for ${n} findings`);
+    }
+  });
+});

--- a/cli/agents/scoring-engine.js
+++ b/cli/agents/scoring-engine.js
@@ -62,6 +62,34 @@ const GRADES = [
   { min: 0,  letter: 'F', label: 'Not safe to ship',             color: 'red' },
 ];
 
+/**
+ * Bound a category's deduction by its weight without ever reaching it.
+ *
+ *   d = weight * raw / (raw + weight)
+ *
+ * A hard `Math.min(raw, weight)` saturates, and it saturates almost at once:
+ * every category's weight is worth only 3 to 5 medium-severity findings, so
+ * roughly thirty findings spread across categories bottom out the score of a
+ * project of any size. hermes-agent scored 13/F at 6,948 findings and 13/F at
+ * 799 — an 89% reduction the number could not see.
+ *
+ * This curve keeps the same bound and the same ceiling on any one category's
+ * influence, but stays strictly monotonic, so more findings always cost more
+ * and two runs are always comparable:
+ *
+ *   raw = 0          → 0
+ *   raw = weight     → weight / 2
+ *   raw = 5 × weight → weight × 5/6
+ *   raw → ∞          → weight
+ *
+ * The first finding in a category still costs the most, which is the property
+ * the hard cap was reaching for.
+ */
+function softCap(raw, weight) {
+  if (raw <= 0 || weight <= 0) return 0;
+  return (weight * raw) / (raw + weight);
+}
+
 // =============================================================================
 // SCORING ENGINE
 // =============================================================================
@@ -141,7 +169,8 @@ export class ScoringEngine {
         }
       }
 
-      result.deduction = Math.min(deduction, result.maxDeduction);
+      result.rawDeduction = deduction;
+      result.deduction = softCap(deduction, result.maxDeduction);
     }
 
     // ── Compute total score ───────────────────────────────────────────────────


### PR DESCRIPTION
**Draft — do not merge as-is.** A concrete option for #107, so the decision has numbers attached instead of four bullet points. It is deliberately incomplete in one respect, described at the bottom.

## The problem, measured

Category deductions were clamped with `Math.min(raw, weight)`. Each category's weight is worth only 3–5 medium findings and the eight weights sum to 100, so about thirty findings spread across categories bottom out the score of a project of any size.

| findings | hard cap (today) | soft cap (this PR) |
|---|---|---|
| 5 | 59.2 | 76.1 |
| 15 | 17.8 | 53.2 |
| 30 | **0.0** | 35.1 |
| 60 | **0.0** | 21.3 |
| 120 | **0.0** | 12.0 |
| 300 | **0.0** | 5.2 |
| 800 | **0.0** | 2.0 |
| 7000 | **0.0** | 0.2 |

Today the score cannot tell 30 findings from 7,000. That is not hypothetical: across #108 and #109 hermes-agent went from 6,948 findings to 799, an 89% reduction that removed rules which were structurally incapable of staying quiet, and the score read 13/F before and 13/F after.

## The change

```js
d = weight * raw / (raw + weight)
```

Same bound and the same ceiling on any one category's influence, but strictly monotonic. `raw = weight` costs half the weight, `5 × weight` costs 5/6 of it, and it approaches but never reaches the cap. The first finding in a category still costs the most, which is the property the clamp was reaching for.

Corpus effect:

| project | findings | now | proposed |
|---|---|---|---|
| chalk | 4 | 87.2 B | 91.8 A |
| requests | 11 | 81.1 B | 87.0 B |
| flask | 20 | 67.7 C | 79.2 B |
| express | 22 | 71.3 C | 81.2 B |
| hermes-agent | 799 | 13 F | 20.9 F |

## What is deliberately missing

**Every score shifts upward, and grade bands and the default `--threshold 75` were cut against the old curve.** As committed here, express, flask and requests all pass a 75 gate they currently fail. That is a real regression in CI strictness and it is why this is a draft.

Bands need re-cutting in the same change. My suggestion, which puts the corpus roughly where it was:

| grade | now | proposed |
|---|---|---|
| A | ≥ 90 | ≥ 88 |
| B | ≥ 75 | ≥ 78 |
| C | ≥ 60 | ≥ 60 |
| D | ≥ 40 | ≥ 30 |

with the default `ci --threshold` moving 75 → 78 so the pass bar stays at the bottom of B rather than mid-B. That keeps hermes-agent at F and chalk at A, and moves express and flask from C to B — which I think is right, since 20-odd findings on a mature framework is a B, but it is a product judgement and it is yours.

`benchmarks/false-positives/results/latest.json` and the README tables also need regenerating on merge, since every score in them moves.

## Tests

`cli/__tests__/scoring-resolution.test.js` asserts invariants rather than values: strictly decreasing across four orders of magnitude, 800 scoring below 90, marginal cost falling as findings accumulate, output staying in range. These survive re-cut bands and re-weighted categories.

Two existing tests asserted the clamp by its literal value (`deduction === 15`). Rewritten as contracts — bounded by weight, and ten criticals costing more than one, which the old cap made equal.

377 tests pass, lint clean.
