### PR TITLE
Drop the "Ship Safe × Hermes Agent" claim from the package description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ship-safe",
   "version": "9.6.3",
-  "description": "AI-powered multi-agent security platform. 29 agents scan 80+ attack classes including AI integration supply chain (Vercel-class attacks), Hermes Agent deployments (ASI-01\u2013ASI-10), tool registry poisoning, function-call injection, skill permission drift, and agent attestation. Ship Safe \u00d7 Hermes Agent.",
+  "description": "AI-powered multi-agent security platform. 29 agents scan 80+ attack classes including AI integration supply chain (Vercel-class attacks), Hermes Agent deployment scanning (ASI-01\u2013ASI-10), tool registry poisoning, function-call injection, skill permission drift, and agent attestation.",
   "main": "cli/index.js",
   "bin": {
     "ship-safe": "cli/bin/ship-safe.js"


### PR DESCRIPTION
There is no partnership with Nous Research. The `×` reads as one, and this is the description npm renders on the package page.

The capability claim is unchanged and still there: Ship Safe scans Hermes Agent deployments against ASI-01–ASI-10. That is true, verifiable, and about our own scanner. Implying a relationship that does not exist is a different thing.

The practical reason to do this now rather than later: the Hermes collaboration plan has us sending patches upstream to `NousResearch/hermes-agent`. Having them discover this on our npm page after we have introduced ourselves is a much worse conversation than never having claimed it.

Branches from `main`, independent of the calibration stack. One line.

Checked for other affiliation claims across the README, docs, `action.yml`, the Claude Code plugin and skills — this was the only one.