### PR TITLE
docs: point MCP allowlist page at audit, not scan

### DIFF
--- a/docs/mcp-allowlist-bypass.md
+++ b/docs/mcp-allowlist-bypass.md
@@ -77,6 +77,6 @@ List each permitted tool by its real name, avoid alias mappings for tools you
 allowlist, and keep permission blocks flat so a denial can't be re-opened by a
 nested override further down the config.
 
-Run `ship-safe scan .` to check project-local MCP configuration for these
+Run `ship-safe audit .` to check project-local MCP configuration for these
 patterns. Findings are reported under `MCP_ALLOWLIST_WILDCARD`,
 `MCP_TOOL_ALIAS_BYPASS`, and `MCP_NESTED_PERMISSION_OVERRIDE`.


### PR DESCRIPTION
One word. The page merged in #113 closes with `ship-safe scan .`, but `scan` does not run the MCP agents, so a reader following it would never see the findings the page describes. `audit` does.

Not a problem with #113. The command confusion is ours and is tracked in #115 (`scan-mcp` errors on a directory path, which is the invocation its name implies) and #116 (`MCP_NESTED_PERMISSION_OVERRIDE` matches two hardcoded key names while its name and every published description say "nested permission blocks" generally).

This just makes the published page correct while those are open.