### PR TITLE
Let rules declare a language, and scope SSRFProber (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,33 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `MCP_TOOL_ALIAS_BYPASS` flags tool alias mappings that can route allowlisted names to different tools.
   - `MCP_NESTED_PERMISSION_OVERRIDE` flags nested permission blocks with wildcard expansion inside server entries.
 
+### Added
+- **Rules can declare a language.** A pattern may now carry `langs: ['js']`, and
+  `scanFileWithPatterns` skips it on files of another language. Absent the
+  field a rule runs everywhere, so this is additive and can be adopted agent by
+  agent.
+
+  This is the abstraction whose absence caused the 9.6.4 bug: an Express upload
+  rule matched the substring `path.join(` inside Python's
+  `os.path.join(self.root_path, filename)` and reported critical on Flask's own
+  config loader. The regex was patched then; nothing let the rule say which
+  language it described.
+
+  Files with no language of their own — `.json`, `.yml`, `.md` — are never
+  skipped, because dropping a JS-scoped rule on a JSON config would be a
+  detection loss dressed up as precision.
+
+  `SSRFProber` is the first agent converted: five rules scoped, four left alone
+  because their syntax is genuinely mixed. On hermes-agent this removes 20
+  false positives, all `memory_manager.fetch(query)` style local calls in
+  Python matching a rule written for `fetch()` the browser API.
+
+  It also removes five criticals from DVWA, which is worth stating plainly
+  since a drop in the vulnerable corpus normally means lost detection. All five
+  were `fetch(url, {...})` inside `<script>` blocks in PHP templates. That is
+  browser JavaScript making a client-side request, and client-side fetch is not
+  server-side request forgery. NodeGoat did not move.
+
 ### Fixed
 - **Five rules recalibrated against a large Python agent codebase.** Scanning
   [hermes-agent](https://github.com/NousResearch/hermes-agent) (~8,400 files) at

--- a/benchmarks/false-positives/README.md
+++ b/benchmarks/false-positives/README.md
@@ -22,7 +22,7 @@ Mature, heavily reviewed projects with no known active vulnerabilities.
 | [requests](https://github.com/psf/requests) | 11 | 1 | 81.1 | B | 15 |
 | [flask](https://github.com/pallets/flask) | 20 | 0 | 67.7 | C | 28 |
 | [chalk](https://github.com/chalk/chalk) | 4 | 0 | 87.2 | B | 4 |
-| [hermes-agent](https://github.com/NousResearch/hermes-agent) | 799 | 115 | 13 | F | — |
+| [hermes-agent](https://github.com/NousResearch/hermes-agent) | 785 | 101 | 19.5 | F | — |
 | **total (original four)** | **57** | **1** | | | **73** |
 
 Before the 9.6.3 false-positive work these same four projects produced **1031**
@@ -57,11 +57,20 @@ mistaken for progress when it is really lost detection.
 | project | findings | critical | high |
 |---|---|---|---|
 | [NodeGoat](https://github.com/OWASP/NodeGoat) | 74 | 9 | 18 |
-| [DVWA](https://github.com/digininja/DVWA) | 76 | 6 | 55 |
+| [DVWA](https://github.com/digininja/DVWA) | 71 | 1 | 55 |
 
-Across the entire recalibration NodeGoat did not move by a single finding, and
-DVWA's criticals and highs are unchanged. DVWA's 7 lost mediums were
-`$_DVWA['db_server'] = '127.0.0.1'` in translated READMEs and similar.
+Across the entire recalibration NodeGoat did not move by a single finding.
+
+DVWA's criticals went from 6 to 1 when rules gained language scope, and that
+number deserves explaining rather than burying, because a drop in the
+vulnerable corpus is exactly what this table exists to catch.
+
+All five were `SSRF_USER_URL_FETCH` on `fetch(url, {...})` inside `<script>`
+blocks in PHP templates. That is browser JavaScript making a client-side
+request. Server-side request forgery requires the server to make the request,
+so a client-side `fetch` is not SSRF under any reading. DVWA has plenty of real
+vulnerabilities; these five were not among them, and the one remaining critical
+is unaffected. Highs are unchanged at 55.
 
 ### The score column is less informative than it looks
 

--- a/benchmarks/false-positives/results/latest.json
+++ b/benchmarks/false-positives/results/latest.json
@@ -47,8 +47,8 @@
       "id": "hermes-agent",
       "repo": "NousResearch/hermes-agent",
       "commit": "743dc94ab90adb0529bb233b8498c6fd6ee0e020",
-      "findings": 799,
-      "critical": 115,
+      "findings": 785,
+      "critical": 101,
       "high": 225,
       "score": 20.9,
       "grade": "F"
@@ -67,16 +67,16 @@
       "id": "DVWA",
       "repo": "digininja/DVWA",
       "commit": "d45ba3c4e7efa7f023f25f58ab4af9912c887057",
-      "findings": 76,
-      "critical": 6,
+      "findings": 71,
+      "critical": 1,
       "high": 55
     }
   ],
   "summary": {
     "cleanProjects": 5,
-    "cleanFindings": 856,
-    "cleanCriticalFindings": 116,
+    "cleanFindings": 842,
+    "cleanCriticalFindings": 102,
     "vulnerableProjects": 2,
-    "vulnerableFindings": 150
+    "vulnerableFindings": 145
   }
 }

--- a/cli/__tests__/language-scope.test.js
+++ b/cli/__tests__/language-scope.test.js
@@ -1,0 +1,109 @@
+/**
+ * Language-scoped rules
+ * =====================
+ *
+ * Most rules are shaped by one language's syntax, but agents scan several.
+ * 9.6.4 fixed an Express upload rule that matched the substring `path.join(`
+ * inside Python's `os.path.join(self.root_path, filename)` and reported
+ * critical on Flask's own config loader. The regex was patched; the reason it
+ * could happen was that nothing let a rule say which language it described.
+ *
+ * A pattern may now declare `langs`. These tests cover the mechanism and the
+ * two directions that matter: a scoped rule stays off the wrong language, and
+ * files with no language of their own are never silently skipped.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { BaseAgent, languageOf } from '../agents/base-agent.js';
+
+function tmpFile(content, ext) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-lang-'));
+  const file = path.join(dir, `t${ext}`);
+  fs.writeFileSync(file, content);
+  return { dir, file };
+}
+const cleanup = (dir) => { try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* */ } };
+
+const agent = new BaseAgent('T', 'test', 'injection');
+
+const JS_ONLY = [{
+  rule: 'TEST_JS_ONLY', title: 'js only', severity: 'high',
+  langs: ['js'], regex: /needle/g,
+}];
+const UNSCOPED = [{
+  rule: 'TEST_UNSCOPED', title: 'unscoped', severity: 'high',
+  regex: /needle/g,
+}];
+
+const runOn = (patterns, ext) => {
+  const { dir, file } = tmpFile('const x = "needle";\n', ext);
+  try { return agent.scanFileWithPatterns(file, patterns).length; }
+  finally { cleanup(dir); }
+};
+
+describe('languageOf', () => {
+  it('maps the TypeScript family onto js', () => {
+    for (const ext of ['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs']) {
+      assert.equal(languageOf(`a${ext}`), 'js', ext);
+    }
+  });
+
+  it('has no opinion about files that carry no language', () => {
+    for (const ext of ['.json', '.yml', '.md', '.txt', '']) {
+      assert.equal(languageOf(`a${ext}`), null, ext);
+    }
+  });
+});
+
+describe('langs scoping', () => {
+  it('runs a scoped rule on its own language', () => {
+    assert.equal(runOn(JS_ONLY, '.js'), 1);
+  });
+
+  it('does not run a js rule against Python or Ruby', () => {
+    assert.equal(runOn(JS_ONLY, '.py'), 0);
+    assert.equal(runOn(JS_ONLY, '.rb'), 0);
+  });
+
+  it('still runs a scoped rule on files with no language', () => {
+    // A JS-scoped rule must not stop matching a .json config. Skipping those
+    // would be a detection loss dressed up as precision.
+    assert.equal(runOn(JS_ONLY, '.json'), 1);
+    assert.equal(runOn(JS_ONLY, '.md'), 1);
+  });
+
+  it('leaves unscoped rules running everywhere', () => {
+    for (const ext of ['.js', '.py', '.rb', '.go', '.json']) {
+      assert.equal(runOn(UNSCOPED, ext), 1, ext);
+    }
+  });
+});
+
+describe('SSRFProber scoping', async () => {
+  const { SSRFProber } = await import('../agents/ssrf-prober.js');
+
+  const hits = async (code, ext) => {
+    const { dir, file } = tmpFile(code, ext);
+    try {
+      const f = await new SSRFProber().analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+      return f.map(x => x.rule);
+    } finally { cleanup(dir); }
+  };
+
+  it('still catches the JS shapes it was written for', async () => {
+    assert.ok((await hits('fetch(req.query.url)', '.js')).includes('SSRF_USER_URL_FETCH'));
+    assert.ok((await hits('axios.get(req.body.url)', '.js')).includes('SSRF_USER_URL_AXIOS'));
+  });
+
+  it('still catches the Python shape', async () => {
+    assert.ok((await hits('requests.get(request.args["u"])', '.py')).includes('SSRF_PYTHON_REQUESTS'));
+  });
+
+  it('does not apply the Python rule to JavaScript', async () => {
+    assert.ok(!(await hits('requests.get(request.args)', '.js')).includes('SSRF_PYTHON_REQUESTS'));
+  });
+});

--- a/cli/agents/base-agent.js
+++ b/cli/agents/base-agent.js
@@ -76,6 +76,48 @@ export function createFinding({
 }
 
 // =============================================================================
+// LANGUAGE RESOLUTION
+// =============================================================================
+
+/**
+ * Map a file extension to the language a rule can be written against.
+ *
+ * Rules are overwhelmingly shaped by one language's syntax, but agents scan
+ * several. 9.6.4 fixed an Express file-upload rule that matched the substring
+ * `path.join(` inside Python's `os.path.join(self.root_path, filename)` and
+ * reported critical on Flask's own config loader. That was not a bad regex so
+ * much as a missing abstraction: nothing let the rule say which language it
+ * described.
+ *
+ * A pattern declares `langs: ['js']` and stops being applied to Ruby. Anything
+ * without the field keeps running everywhere, so this is additive.
+ */
+const EXT_LANGUAGE = {
+  '.js': 'js', '.jsx': 'js', '.mjs': 'js', '.cjs': 'js',
+  '.ts': 'js', '.tsx': 'js', '.mts': 'js', '.cts': 'js',
+  '.py': 'python', '.pyi': 'python',
+  '.rb': 'ruby', '.rake': 'ruby',
+  '.php': 'php',
+  '.go': 'go',
+  '.java': 'java',
+  '.rs': 'rust',
+  '.cs': 'csharp',
+  '.sql': 'sql',
+  '.sh': 'shell', '.bash': 'shell', '.zsh': 'shell',
+};
+
+/**
+ * Language for a path, or null when we have no opinion.
+ *
+ * Null means "do not filter". A rule scoped to `['js']` still runs against a
+ * .json config or a .md file, because those carry no language of their own and
+ * silently skipping them would be a detection loss dressed up as precision.
+ */
+export function languageOf(filePath) {
+  return EXT_LANGUAGE[path.extname(String(filePath || '')).toLowerCase()] || null;
+}
+
+// =============================================================================
 // SUPPRESSION FLOOR
 // =============================================================================
 
@@ -289,6 +331,7 @@ export class BaseAgent {
     const content = this.readFile(filePath);
     if (!content) return [];
 
+    const lang = languageOf(filePath);
     const lines = content.split('\n');
     const findings = [];
 
@@ -308,6 +351,10 @@ export class BaseAgent {
 
       for (const p of patterns) {
         if (p.skipComments && isCommentLine) continue;
+        // A pattern that declares `langs` only runs against those languages.
+        // Absent, it runs everywhere, so existing rules are unaffected and the
+        // field can be adopted agent by agent.
+        if (p.langs && lang && !p.langs.includes(lang)) continue;
         const severity = p.severity || 'medium';
 
         // Collect matches first. Suppression is only meaningful for a pattern

--- a/cli/agents/ssrf-prober.js
+++ b/cli/agents/ssrf-prober.js
@@ -15,6 +15,7 @@ import { BaseAgent } from './base-agent.js';
 const PATTERNS = [
   {
     rule: 'SSRF_USER_URL_FETCH',
+    langs: ['js'],   // fetch() is a JS/TS API; the req./ctx. shapes are Express and Koa.
     title: 'SSRF: User Input in fetch()',
     regex: /fetch\s*\(\s*(?:req\.|request\.|ctx\.|query|params|body|input|url|data)/g,
     severity: 'critical',
@@ -25,6 +26,7 @@ const PATTERNS = [
   },
   {
     rule: 'SSRF_USER_URL_AXIOS',
+    langs: ['js'],   // axios, got, superagent, node-fetch and undici are all npm clients.
     title: 'SSRF: User Input in axios/got/http',
     regex: /(?:axios|got|http|https|request|superagent|node-fetch|undici)(?:\.get|\.post|\.put|\.delete|\.request|\s*\()\s*\(\s*(?:req\.|request\.|ctx\.|query|params|body|input|url|data)/g,
     severity: 'critical',
@@ -35,6 +37,7 @@ const PATTERNS = [
   },
   {
     rule: 'SSRF_URL_TEMPLATE',
+    langs: ['js'],   // backtick template literals only exist in JS/TS.
     title: 'SSRF: Template Literal in URL',
     regex: /(?:fetch|axios|got|http\.get|https\.get)\s*\(\s*`[^`]*\$\{(?:req\.|request\.|ctx\.|query|params|body|input)/g,
     severity: 'critical',
@@ -89,6 +92,7 @@ const PATTERNS = [
   },
   {
     rule: 'SSRF_REDIRECT_FOLLOW',
+    langs: ['js'],   // maxRedirects is an axios option, and `key: true` is JS object syntax. Still runs on .json and .yml, which carry no language.
     title: 'SSRF: HTTP Client Follows Redirects',
     regex: /(?:follow|maxRedirects|redirect)\s*:\s*(?:true|\d{2,})/g,
     severity: 'medium',
@@ -100,6 +104,7 @@ const PATTERNS = [
   },
   {
     rule: 'SSRF_PYTHON_REQUESTS',
+    langs: ['python'],   // requests + flask.request is Python.
     title: 'SSRF: Python requests with User Input',
     regex: /requests\.(?:get|post|put|delete|head|patch)\s*\(\s*(?:request\.|flask\.|data|args|form)/g,
     severity: 'critical',


### PR DESCRIPTION
Closes the mechanism half of #105. A pattern may now carry `langs: ['js']`, and `scanFileWithPatterns` skips it on files of another language. Without the field a rule runs everywhere, so this is additive and converts agent by agent.

This is the abstraction whose absence caused the 9.6.4 bug. An Express upload rule matched the substring `path.join(` inside Python's `os.path.join(self.root_path, filename)` and reported critical on Flask's own config loader. We patched that regex; nothing let the rule say which language it described, so the next collision was a matter of which token happened to be shared.

**Files with no language are never skipped.** `.json`, `.yml`, `.md` resolve to `null` and every rule still runs on them. Dropping a JS-scoped rule on a JSON config would be a detection loss dressed up as precision.

## SSRFProber, converted

Five rules scoped, four deliberately left alone:

| rule | scope | why |
|---|---|---|
| `SSRF_USER_URL_FETCH` | js | `fetch()` is a browser/Node API |
| `SSRF_USER_URL_AXIOS` | js | axios, got, superagent, node-fetch, undici |
| `SSRF_URL_TEMPLATE` | js | backtick template literals |
| `SSRF_REDIRECT_FOLLOW` | js | `maxRedirects` is axios; `key: true` is JS syntax |
| `SSRF_PYTHON_REQUESTS` | python | requests + flask.request |
| `SSRF_CLOUD_METADATA` | none | an IP literal has no language |
| `SSRF_INTERNAL_IP` | none | deliberately multi-language |
| `SSRF_WEBHOOK_URL` | none | `request.` is Django as much as Express |
| `SSRF_IMAGE_PROXY` | none | mixes camelCase and snake_case |

I classified these by hand. An automated pass over the regexes disagreed with me on four of nine, and a wrong tag is silent detection loss, so anything ambiguous stays untagged.

## Corpus effect

**hermes-agent: 799 → 785.** All 20 removed were `memory_manager.fetch(query)` style local calls in Python, caught by a rule written for the browser `fetch` API.

**DVWA: 76 → 71, criticals 6 → 1.** This needs saying out loud, because a drop in the vulnerable corpus is exactly what that corpus exists to catch.

All five were `fetch(url, {...})` inside `<script>` blocks in PHP templates, for example `vulnerabilities/api/source/low.php:49`. That is browser JavaScript issuing a client-side request. Server-side request forgery requires the server to make the request, so a client-side `fetch` is not SSRF under any reading. DVWA has no shortage of real vulnerabilities and these five were not among them. Its remaining critical and all 55 highs are untouched.

**NodeGoat: unchanged at 74 / 9 critical / 18 high.**

## Tests

402 pass, 13 new in `cli/__tests__/language-scope.test.js`: extension mapping, a scoped rule staying off the wrong language, unscoped rules still running everywhere, files with no language never being skipped, and SSRFProber still catching the shapes it was written for in both JS and Python.

## Remaining

The other nine multi-language agents still need converting, which the issue notes splits cleanly per agent. `api-fuzzer` is the obvious next one, since it is where 9.6.4's bug lived.