### PR TITLE
Drop the duplicate trust_remote_code rule from ModelScanAgent

### DIFF
--- a/cli/__tests__/model-scan-agent.test.js
+++ b/cli/__tests__/model-scan-agent.test.js
@@ -107,7 +107,7 @@ describe('ModelScanAgent — source loaders', () => {
   it('flags mutable Hugging Face references and remote code', async () => {
     const file = path.join(FIXTURES, 'mutable.py');
     const f = await scan(FIXTURES, [file]);
-    assert.ok(f.some((x) => x.rule === 'RAG_TRUST_REMOTE_CODE'));
+    // trust_remote_code is RAGSecurityAgent's rule, asserted in its own suite.
     assert.equal(f.filter((x) => x.rule === 'MODEL_MUTABLE_REMOTE_REFERENCE').length, 3);
     assert.ok(f.some((x) => x.rule === 'MODEL_MUTABLE_RAW_URL'));
     assert.ok(f.some((x) => x.rule === 'MODEL_MUTABLE_DOWNLOAD_PICKLE_LOAD' && x.severity === 'critical'));

--- a/cli/agents/model-scan-agent.js
+++ b/cli/agents/model-scan-agent.js
@@ -53,15 +53,11 @@ const ZIP_MAGIC = Buffer.from([0x50, 0x4b, 0x03, 0x04]); // PyTorch .pt is a zip
 
 // Source-level unsafe loaders.
 const SOURCE_PATTERNS = [
-  {
-    regex: /trust_remote_code\s*=\s*True/g,
-    rule: 'RAG_TRUST_REMOTE_CODE',
-    title: 'Model loaded with trust_remote_code=True',
-    severity: 'high',
-    description: 'The model loader allows executable Python code from the remote model repository.',
-    cwe: 'CWE-829',
-    fix: 'Set trust_remote_code=False and use a model whose code has been reviewed and pinned.',
-  },
+  // trust_remote_code=True is already covered by RAG_TRUST_REMOTE_CODE in
+  // rag-security-agent.js, with the same regex and severity. Emitting it from
+  // here too gave one line of source two findings under one rule ID, with two
+  // different CWEs and categories, which makes the rule impossible to reason
+  // about downstream. RAGSecurityAgent scans .py, so coverage is unchanged.
   {
     regex: /torch\s*\.\s*load\s*\((?![^)]*weights_only\s*=\s*True)/g,
     rule: 'MODEL_TORCH_LOAD_UNSAFE',


### PR DESCRIPTION
Follow-up to #97, which I merged so the contributor keeps credit for the work.

`RAG_TRUST_REMOTE_CODE` already exists in `rag-security-agent.js` with the same regex and the same severity, and that agent scans `.py` too. #97 added a second copy to `ModelScanAgent`, so one `trust_remote_code=True` produced two findings under one rule ID, carrying CWE-829 / supply-chain from one agent and CWE-94 / llm from the other.

Verified coverage is unchanged: the rule still fires exactly once, and the three `MODEL_MUTABLE_*` rules from #97 are untouched. 396 tests pass.