### PR TITLE
Release 9.7.0: Calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-## [Unreleased]
+## [9.7.0] — 2026-08-05 — Calibration
+
+This release changes what existing scans report and how `ci` decides to fail.
+
+It came out of pointing the scanner at a large, actively maintained AI agent
+codebase and taking the result seriously. [hermes-agent](https://github.com/NousResearch/hermes-agent)
+at `743dc94` produced **6,948 findings** on the first run and graded 13/F. It
+now produces **785**, an 89% reduction, and every rule changed to get there is
+listed below.
+
+Detection did not move. NodeGoat holds at 74 findings / 9 critical / 18 high
+across the entire release, and the clean corpus improves from 73 findings to 57.
+
+Two things behind the noise turned out to be structural rather than a matter of
+tuning, and both are fixed here: rules that assert an absence could not fail,
+and the score saturated after three to five findings per category. The second
+is why `ci` now gates on severity instead.
 
 ### Added
 - **MCP allowlist bypass detection** in `MCPSecurityAgent`:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-safe",
-  "version": "9.6.4",
+  "version": "9.7.0",
   "description": "AI-powered multi-agent security platform. 29 agents scan 80+ attack classes including AI integration supply chain (Vercel-class attacks), Hermes Agent deployment scanning (ASI-01–ASI-10), tool registry poisoning, function-call injection, skill permission drift, and agent attestation.",
   "main": "cli/index.js",
   "bin": {


### PR DESCRIPTION
Cuts `Unreleased` into 9.7.0. Version bump and changelog header only, no code changes.

## What this release is

It came out of pointing the scanner at [hermes-agent](https://github.com/NousResearch/hermes-agent), ~8,400 files of actively maintained Python, and taking the result seriously. First run: **6,948 findings, 13/F**. Now: **785**.

Fourteen rules recalibrated, and none of them needed a threshold nudged. Every one was a defect:

- Two asserted an absence using a negative lookahead after a variable-length gap. The gap backtracks until the lookahead succeeds, so the assertion could never fail. `AGENT_NO_AUDIT_LOG` was, in effect, "this line contains the string `tool_call`" — 1,904 findings.
- Two read English as code. ``showToast(`Create failed: ${e}`)`` was 24 criticals on a file browser.
- `CODE_INJECTION_EVAL_GENERIC` counted any method named `eval`, so `cdp.eval` fired 126 times.
- `PII_EMAIL_HARDCODED`'s exclusion was anchored to the first domain label, so it never matched GitHub's `users.noreply.github.com` privacy addresses, and it reported a contributor credit map once per entry: 1,963 findings from one file, 28% of the whole report.

## Behaviour changes worth reading

**`ci` gates on severity, not the score.** The score saturated after three to five findings per category and could not distinguish 30 findings from 7,000. Snyk, Trivy and SonarQube all gate on severity. `--threshold` still works and still wins when passed.

**Code quality no longer moves a security score.** New `quality` category, reported but never scored, matching the line SonarQube draws between vulnerabilities and code smells.

**Rules can declare a language.** The abstraction whose absence caused the 9.6.4 Flask false positive.

## Detection held

**NodeGoat did not move by a single finding across the entire release**: 74 findings, 9 critical, 18 high. Clean corpus improved 73 → 57, with express and flask reaching C and requests B.

DVWA's criticals went 6 → 1, which the benchmark README explains rather than buries: all five were `fetch(url, {...})` inside `<script>` blocks in PHP templates, and a client-side browser fetch is not server-side request forgery.

## Release checklist (docs/releasing.md)

- `npm test` — 405 pass
- `npm audit --audit-level=high` — 0 vulnerabilities
- `node cli/bin/ship-safe.js scan .` — clean
- `npm pack --dry-run` — 125 files, no `.env`/`.pem`/`.key`/credentials, no test files
- Changelog matches the version

After merge: create the `v9.7.0` GitHub Release, which triggers `Publish to npm` with provenance.