### PR TITLE
Publish a roadmap and open the 10.0 work to contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,54 @@ Before opening a PR, please confirm:
 - [ ] New detector behavior has a test or fixture when practical
 - [ ] Documentation changed if the user-facing behavior changed
 - [ ] No real secrets, tokens, customer data, or private repo URLs were added
+- [ ] The false-positive benchmark was run, if you touched a rule (see below)
+- [ ] Absence rules assert the quiet direction (see below)
+
+### If You Touched a Rule: Run the Benchmark
+
+```bash
+node benchmarks/false-positives/run.mjs --clone   # first time only
+node benchmarks/false-positives/run.mjs
+```
+
+Paste the before and after in your PR. What we look for:
+
+- **Clean corpus should drop or hold.** These are mature, heavily reviewed
+  projects. A finding on one of them is triage work a user inherits.
+- **NodeGoat and DVWA must not move.** They are deliberately vulnerable and
+  exist so a drop in noise cannot be mistaken for progress when it is really
+  lost detection. If they do move, say why in the PR. Sometimes it is correct,
+  but it always needs explaining.
+
+This is not ceremony. Nearly every fix in 9.7.0 came from running this and
+reading the output honestly, including a rule that reported 1,963 findings on a
+single contributor credits file.
+
+### If Your Rule Asserts an Absence, Test the Quiet Direction
+
+A rule that reports something *missing* — no logging, no rate limit, no schema
+validation — has a failure mode a normal detection test never catches. It can
+be structurally incapable of staying quiet.
+
+Written like this, it never fails:
+
+```js
+regex: /tool_call[\s\S]{0,300}(?![\s\S]{0,300}(?:log|audit))/
+```
+
+The gap backtracks until the lookahead succeeds, so the rule degrades into
+"this line contains `tool_call`". That exact pattern shipped and produced 1,904
+findings on one repository.
+
+Prefer a structural check that answers two questions per file: does this file
+do the thing, and does anything here mitigate it. `AGENT_STRUCTURAL_RULES` in
+`cli/agents/agentic-security-agent.js` is the shape to copy.
+
+Then add a case to `cli/__tests__/absence-rules.test.js`: give the rule an
+input where the mitigation is present, and assert it stays silent. Be generous
+about what counts as a mitigation. The finding claims nothing here does X, so
+one instance of X refutes it, and a stingy check trades a loud wrong answer for
+a quiet one.
 
 ### Adding Secret Patterns
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,17 @@ they beat us: **[docs/comparison.md](docs/comparison.md)**
 
 ---
 
+## What's Next
+
+**10.0 is Hermes Agent coverage.** Ship Safe already scans Hermes deployments,
+but against v0.13.0 while Hermes is on v0.20.0 — the ACP adapter, TUI gateway,
+serverless terminal backends, cron blueprints and plugin manifests all shipped
+in between with no coverage.
+
+See the [roadmap](./ROADMAP.md) for what is planned and what is deliberately
+not, and the [10.0 milestone](https://github.com/asamassekou10/ship-safe/milestone/1)
+for claimable work. Everything in it is open to contributors.
+
 ## Contributing
 
 Ship Safe is open source, and the best contributions are small, focused improvements that make AI-assisted development safer.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,112 @@
+# Roadmap
+
+What Ship Safe is working on, what just shipped, and what we are deliberately
+not building. Updated when a release goes out.
+
+If you want to help, the [10.0 milestone](https://github.com/asamassekou10/ship-safe/milestone/1)
+is the current work and everything in it is claimable. Comment on an issue to
+take it.
+
+---
+
+## Just shipped — 9.7.0, Calibration
+
+Pointed the scanner at [hermes-agent](https://github.com/NousResearch/hermes-agent),
+about 8,400 files of actively maintained Python, and took the result seriously.
+First run reported 6,948 findings and graded 13/F. It now reports 785.
+
+Fourteen rules were recalibrated, and none of them needed a threshold nudged.
+Every one was a defect. Two asserted an absence using a construct that could
+never fail. Two read English as code. One counted any method named `eval`.
+
+`ci` now gates on severity rather than the composite score, because the score
+saturated after three to five findings per category and could not distinguish
+30 findings from 7,000.
+
+Detection did not move: NodeGoat held at 74 findings across the entire release.
+
+Full detail in the [changelog](CHANGELOG.md) and the
+[false-positive benchmark](benchmarks/false-positives/).
+
+---
+
+## Now — 10.0, Hermes Agent coverage
+
+Ship Safe already scans Hermes Agent deployments, but the agent that does it
+was written against Hermes **v0.13.0**. Hermes is on **v0.20.0**. Everything
+below arrived in between and has no coverage today.
+
+**Note on scope.** This is coverage we build for our users who run Hermes. It
+is not coordinated with Nous Research, and nothing here should be read as an
+endorsement by them.
+
+### The surfaces
+
+| area | what is uncovered |
+|---|---|
+| plugin manifests | `plugins/*/plugin.yaml`, hook declarations, undeclared network listeners |
+| external surfaces | gateway platform adapters, allowlist handling, non-loopback binds |
+| terminal backends | seven of them, from local to Docker to cloud sandboxes |
+| ACP and TUI gateway | editor and local-IPC surfaces with their own permission models |
+| cron | blueprints and lifecycle guard |
+| credential scoping | environment passthrough to lower-trust components |
+
+### Two ideas shaping the work
+
+**Posture-aware severity.** Hermes publishes an unusually explicit
+[security policy](https://github.com/NousResearch/hermes-agent/blob/main/SECURITY.md).
+It names OS-level isolation as the only real boundary and says plainly that
+in-process heuristics are not boundaries. A report that ignores that is noise
+to anyone who has read it. So Hermes findings will carry a posture: `boundary`
+for classes their policy treats as in scope, `hygiene` for everything else,
+rendered separately.
+
+**Read their policy before writing rules.** See
+[docs/hermes-security-model.md](docs/hermes-security-model.md). A rule that
+flags something their trust model deliberately permits is a false positive no
+matter how clever the regex.
+
+### Also in 10.0
+
+- **Language-scoped rules** ([#105](https://github.com/asamassekou10/ship-safe/issues/105)).
+  Rules can declare `langs: ['js']` and stop being applied to Ruby. The
+  mechanism shipped in 9.7.0; nine agents still need converting, one per pull
+  request. Good first issues.
+- **A2A agent cards** ([#103](https://github.com/asamassekou10/ship-safe/issues/103))
+  and **MCP OAuth** ([#104](https://github.com/asamassekou10/ship-safe/issues/104)).
+  Real 2026 attack surfaces with zero coverage.
+
+---
+
+## Not planned
+
+Saying this out loud so nobody builds it and gets turned away.
+
+- **A new composite score.** The score saturates and we stopped gating on it.
+  Proposals to re-weight it are unlikely to land; severity-based gating is the
+  direction.
+- **Rules without a false-positive story.** Every new rule needs a run of
+  `node benchmarks/false-positives/run.mjs` showing the clean corpus holding
+  and NodeGoat and DVWA unchanged. A rule that fires on a mature codebase is
+  not finished.
+- **Auto-fixing security findings without review.** `agent` and `fix` propose
+  and require approval. That stays.
+- **Runtime or agent-side enforcement.** Ship Safe is a static scanner. It
+  reports; it does not block at runtime.
+
+---
+
+## How to help
+
+Best entry points, roughly by size:
+
+1. **Run the benchmark and tell us what is wrong.** Seriously. Nearly every
+   fix in 9.7.0 came from someone pointing the scanner at a real codebase and
+   looking at the output honestly.
+2. **Convert one agent to language-scoped rules** ([#105](https://github.com/asamassekou10/ship-safe/issues/105)).
+   Self-contained, one file, clear success criteria.
+3. **Take a `good first issue`.** Eight are open and unclaimed.
+4. **Write a Hermes rule.** Read
+   [docs/hermes-security-model.md](docs/hermes-security-model.md) first.
+
+[Contributor guide](CONTRIBUTING.md) has the mechanics.

--- a/docs/hermes-security-model.md
+++ b/docs/hermes-security-model.md
@@ -1,0 +1,95 @@
+# Hermes Agent's security model
+
+Read this before writing a Hermes rule. Hermes publishes an unusually explicit
+[security policy](https://github.com/NousResearch/hermes-agent/blob/main/SECURITY.md),
+and a rule that contradicts it is a false positive no matter how good the regex
+is.
+
+This is our summary for rule authors. Their document is the authority; if the
+two disagree, theirs wins and this file needs updating.
+
+## The one boundary
+
+> The only security boundary against an adversarial LLM is the operating
+> system. Nothing inside the agent process constitutes containment — not the
+> approval gate, not output redaction, not any pattern scanner, not any tool
+> allowlist.
+
+That is a direct quote, and the emphasis is theirs. It has two consequences for
+us.
+
+**We are not containment either.** Ship Safe is a static scanner. Framing a
+finding as if it prevents an attack contradicts their model and ours.
+
+**In-process heuristics are not boundaries.** Their approval gate, output
+redaction, and Skills Guard are review aids by design. A finding that says "the
+approval gate can be bypassed" is describing intended behaviour.
+
+## Two isolation postures
+
+Operators choose one deliberately, and the difference matters for severity.
+
+**Terminal-backend isolation** runs shell and file operations inside a
+container or remote host. It does not confine the code-execution tool, MCP
+subprocesses, plugin loading, hook dispatch, or skill loading, all of which run
+in the agent's own Python process.
+
+**Whole-process wrapping** puts the entire process tree in a sandbox. Every
+path is subject to the same policy.
+
+The interesting finding is a **mismatch**: a repository running the local
+backend while ingesting untrusted input, or running terminal-backend isolation
+while expecting it to confine code paths that never touch the shell. Their
+policy calls that "operating outside the supported security posture", which is
+exactly the sentence a finding should be able to point at.
+
+## What their policy treats as in scope
+
+Rules that find these are finding real, reportable problems:
+
+- Escape from a declared isolation posture
+- A caller outside the configured allowlist dispatching work, receiving output,
+  or resolving approvals
+- Credential exfiltration through a mechanism meant to prevent it
+- Code behaving contrary to a documented stance
+
+That fourth one is broader than it looks. If Hermes documents that a consuming
+layer treats agent output as inert and some path breaks that, it is in scope.
+
+**Adapters that fail open are explicitly named.** Their §2.6 says every enabled
+network-exposed adapter requires an allowlist, and that code paths failing open
+when none is configured are bugs in scope. A static rule that finds those is
+our highest-value Hermes rule.
+
+## What their policy treats as out of scope
+
+Do not write rules whose entire claim is one of these:
+
+- Bypassing an in-process heuristic, including Skills Guard patterns
+- Prompt injection on its own, without a chained outcome
+- Consequences of a posture the operator chose, such as shell reaching host
+  state under the local backend
+- Documented break-glass settings like `--insecure` or disabled approvals
+
+These can still be worth reporting to a user as hygiene. They are not boundary
+findings and should not be severity-inflated to look like they are.
+
+## Posture-aware severity
+
+Every Hermes finding carries a posture:
+
+- `boundary` — a class their policy treats as in scope
+- `hygiene` — a real improvement that their policy does not treat as a
+  vulnerability
+
+Rendered separately, so someone who has read their policy can tell instantly
+which half of the report to act on. This is the difference between a report a
+Hermes operator trusts and one they close.
+
+## Version drift
+
+Rules should note the Hermes version they were written against. `HermesSecurityAgent`
+targeted v0.13.0 for seven minor versions, during which the ACP adapter, the TUI
+gateway, serverless terminal backends, cron blueprints and the `plugin.yaml`
+manifest format all shipped uncovered. Hermes moves weekly. Pin your fixtures to
+a commit and say which one.


### PR DESCRIPTION
Phase 1 of getting the repo ready for people to contribute to the Hermes work.

**ROADMAP.md** — one screen. What 9.7.0 did, what 10.0 is, and a *Not planned* section so nobody builds something that gets turned away. States plainly that the Hermes work is coverage for our users and is not coordinated with Nous Research.

**docs/hermes-security-model.md** — a rule author needs to know that Hermes names OS isolation as the only boundary and says in-process heuristics explicitly are not. Without that, people write rules describing intended behaviour. It also names what their policy *does* treat as in scope, including adapters that fail open with no allowlist configured, which is where our highest-value Hermes rule sits.

**CONTRIBUTING** gains the two conventions that would have caught most of 9.7.0:
- run the false-positive benchmark when you touch a rule, and paste before and after
- if a rule asserts an absence, test the quiet direction, because a detection test only exercises the loud one

**README** gets a short What's Next block linking the roadmap and the milestone.

Also created: the `hermes` label and the [10.0 milestone](https://github.com/asamassekou10/ship-safe/milestone/1), with #103, #104 and #105 attached.

Docs only, no code. 405 tests pass.