### PR TITLE
Tag Hermes findings with boundary or hygiene posture (#127)

### DIFF
--- a/cli/__tests__/hermes-posture.test.js
+++ b/cli/__tests__/hermes-posture.test.js
@@ -1,0 +1,83 @@
+/**
+ * Hermes posture
+ * ==============
+ *
+ * Hermes publishes a security policy that names OS-level isolation as the only
+ * boundary and states that in-process heuristics are not boundaries. Its §3.1
+ * lists what it treats as in scope and §3.2 what it does not, and both halves
+ * are worth reporting but not worth reporting identically.
+ *
+ * These assert the classification holds its shape rather than freezing a list,
+ * so adding a rule does not break them but forgetting the field does.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { HermesSecurityAgent, postureFor } from '../agents/hermes-security-agent.js';
+
+function project(content, name = 'agent.js') {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-posture-'));
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, content);
+  return { dir, file };
+}
+const cleanup = (dir) => { try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* */ } };
+
+describe('postureFor', () => {
+  it('classifies credential exfiltration as a boundary class', () => {
+    // §3.1: "leakage of operator credentials ... to a destination outside the
+    // trust envelope, via a mechanism that should have prevented it".
+    for (const rule of [
+      'HERMES_SUB_AGENT_CREDENTIAL_FORWARD',
+      'HERMES_XURL_TOKEN_STORE_EXPOSURE',
+      'HERMES_MEMORY_EXFIL_PATTERN',
+      'HERMES_BROWSER_CLOUD_METADATA_SSRF',
+    ]) {
+      assert.equal(postureFor(rule), 'boundary', rule);
+    }
+  });
+
+  it('classifies in-process heuristics as hygiene', () => {
+    // §2.4 and §3.2: a tool allowlist is not a boundary, and prompt injection
+    // on its own is not a vulnerability under their policy.
+    for (const rule of [
+      'HERMES_FUNCTION_CALL_NO_ALLOWLIST',
+      'HERMES_GOAL_PROMPT_INJECTION',
+      'HERMES_PLAN_USER_INPUT',
+      'HERMES_MANIFEST_NO_VERSION_PIN',
+    ]) {
+      assert.equal(postureFor(rule), 'hygiene', rule);
+    }
+  });
+
+  it('defaults an unknown rule to hygiene', () => {
+    // §3.2 is the larger set. Defaulting the other way would silently inflate
+    // every rule nobody has classified yet.
+    assert.equal(postureFor('HERMES_SOMETHING_NOT_YET_CLASSIFIED'), 'hygiene');
+  });
+});
+
+describe('HermesSecurityAgent tags every finding', () => {
+  it('sets a posture on all findings it emits', async () => {
+    const { dir, file } = project(`
+      const hermes = require('hermes-agent');
+      const registry = loadRegistry(await fetch(process.env.REGISTRY_URL));
+      subAgent.invoke({ credentials: parentCreds, goal: req.body.goal });
+    `);
+    try {
+      const findings = await new HermesSecurityAgent()
+        .analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+
+      assert.ok(findings.length > 0, 'fixture should produce findings');
+      for (const f of findings) {
+        assert.ok(
+          f.posture === 'boundary' || f.posture === 'hygiene',
+          `${f.rule} has no posture`
+        );
+      }
+    } finally { cleanup(dir); }
+  });
+});

--- a/cli/agents/hermes-security-agent.js
+++ b/cli/agents/hermes-security-agent.js
@@ -52,6 +52,63 @@ const HERMES_FILE_PATTERNS = [
 // SINGLE-LINE REGEX PATTERNS
 // =============================================================================
 
+// =============================================================================
+// POSTURE — which half of Hermes's own security policy a finding falls under
+// =============================================================================
+
+/**
+ * Hermes publishes an unusually explicit security policy, and it draws a hard
+ * line we should respect rather than paper over.
+ *
+ * SECURITY.md §2.2: "The only security boundary against an adversarial LLM is
+ * the operating system. Nothing inside the agent process constitutes
+ * containment — not the approval gate, not output redaction, not any pattern
+ * scanner, not any tool allowlist."
+ *
+ * §3.1 lists what they treat as in scope: escape from a declared isolation
+ * posture, unauthorized external-surface access, credential exfiltration
+ * through a mechanism meant to prevent it, and code contradicting a documented
+ * stance. §3.2 lists what they do not: bypasses of in-process heuristics,
+ * prompt injection on its own without a chained §3.1 outcome, consequences of
+ * a posture the operator chose, and documented break-glass settings.
+ *
+ * Both halves are worth reporting. They are not worth reporting identically. A
+ * Hermes operator who has read their policy and sees our `critical` next to
+ * something their maintainers would close as out of scope concludes, fairly,
+ * that we did not do the reading.
+ *
+ * So every Hermes finding carries a posture:
+ *
+ *   'boundary' — a class §3.1 treats as in scope. Act on these.
+ *   'hygiene'  — a real improvement their model does not call a vulnerability.
+ *
+ * Default is 'hygiene', because §3.2 is by far the larger set and defaulting
+ * the other way would quietly inflate everything we have not thought about.
+ *
+ * See docs/hermes-security-model.md.
+ */
+const BOUNDARY_RULES = new Set([
+  // Credential exfiltration to a destination outside the trust envelope (§3.1).
+  'HERMES_MEMORY_EXFIL_PATTERN',
+  'HERMES_SUB_AGENT_CREDENTIAL_FORWARD',
+  'HERMES_XURL_TOKEN_STORE_EXPOSURE',
+  'HERMES_FULL_TOOL_CONTEXT_FORWARD',
+  // Reaching cloud metadata is the canonical credential-theft path, and it
+  // crosses out of whatever the posture confined.
+  'HERMES_BROWSER_CLOUD_METADATA_SSRF',
+  // A check that can be raced is a mechanism that should have prevented
+  // something and does not, rather than a heuristic being imperfect.
+  'HERMES_AUTH_JSON_TOCTOU',
+  // Escapes the agent process into the host through a path the shell-level
+  // posture never covered (§2.2, "does not confine ... code-execution").
+  'HERMES_XURL_SUBPROCESS_INJECTION',
+]);
+
+/** Which half of Hermes's policy a rule falls under. */
+export function postureFor(rule) {
+  return BOUNDARY_RULES.has(rule) ? 'boundary' : 'hygiene';
+}
+
 const PATTERNS = [
 
   // ────────────────────────────────────────────────────────────────────────────
@@ -747,6 +804,13 @@ export class HermesSecurityAgent extends BaseAgent {
       findings.push(...checkBrowserCloudMetadataFloor(content, filePath, this));
       // xurl skill / X API integration coverage
       findings.push(...checkXurlReadWriteLoop(content, filePath, this));
+    }
+
+    // Tag every finding with which half of Hermes's own policy it falls under.
+    // Done once here rather than on each rule so a new rule cannot forget, and
+    // so the default is visible in one place.
+    for (const finding of findings) {
+      finding.posture = postureFor(finding.rule);
     }
 
     return findings;

--- a/cli/commands/audit.js
+++ b/cli/commands/audit.js
@@ -704,6 +704,7 @@ function buildRemediationPlan(findings, depVulns, rootPath) {
         file: `${path.relative(rootPath, f.file).replace(/\\/g, '/')}:${f.line}`,
         action: f.aiFix || f.fix || f.description,
         effort: EFFORT_MAP[f.category] || 'medium',
+        posture: f.posture || null,
       });
     }
 
@@ -794,10 +795,21 @@ function printReport(scoreResult, findings, depVulns, recon, plan, rootPath, fil
         console.log(chalk.gray('  ' + '─'.repeat(56)));
       }
 
+      // A `hygiene` tag marks a finding that the target's own security policy
+      // does not treat as a vulnerability. Currently only Hermes findings
+      // carry a posture; see docs/hermes-security-model.md. Marking the
+      // weaker half is less noisy than decorating every line, and it stops a
+      // policy-aware reader from dismissing the whole report when they hit an
+      // item their maintainers would close as out of scope.
+      const postureTag = item.posture === 'hygiene'
+        ? chalk.gray.dim(' (hygiene)')
+        : '';
+
       console.log(
         chalk.white(`  ${String(item.priority).padStart(2)}.`) +
         chalk.gray(` [${item.categoryLabel}] `) +
-        chalk.white(item.title)
+        chalk.white(item.title) +
+        postureTag
       );
       console.log(
         chalk.gray(`      ${item.file}`) +

--- a/cli/commands/ci.js
+++ b/cli/commands/ci.js
@@ -284,6 +284,10 @@ function buildSARIF(findings, rootPath) {
             region: { startLine: Math.max(1, f.line || 1), startColumn: f.column || 1 },
           },
         }],
+        // Carried into SARIF so a policy-aware consumer can filter on it. Only
+        // findings whose target publishes a trust model have one today, so the
+        // key is omitted rather than defaulted when absent.
+        ...(f.posture ? { properties: { posture: f.posture } } : {}),
       })),
     }],
   };


### PR DESCRIPTION
Closes #127. Infrastructure the rest of the Hermes work builds on, so it goes first.

## The problem

Hermes publishes an unusually explicit [security policy](https://github.com/NousResearch/hermes-agent/blob/main/SECURITY.md), and our report ignored it.

§2.2 names OS-level isolation as the only boundary and says plainly that in-process heuristics — the approval gate, output redaction, tool allowlists — are **not** boundaries. §3.1 lists what they treat as in scope; §3.2 lists what they do not, including heuristic bypasses and prompt injection on its own.

Both halves are worth reporting to a user. They are not worth reporting identically. A Hermes operator who has read their own policy, and sees our `critical` sitting next to something their maintainers would close as out of scope, reasonably concludes we did not do the reading.

## What this does

Every Hermes finding carries `posture`:

- **`boundary`** — a class §3.1 treats as in scope
- **`hygiene`** — a real improvement their model does not call a vulnerability

Seven rules are classified `boundary`: credential exfiltration (`HERMES_SUB_AGENT_CREDENTIAL_FORWARD`, `HERMES_XURL_TOKEN_STORE_EXPOSURE`, `HERMES_MEMORY_EXFIL_PATTERN`, `HERMES_FULL_TOOL_CONTEXT_FORWARD`), cloud-metadata reach, a raceable auth check, and a subprocess path out of the agent process.

Everything else defaults to `hygiene`. §3.2 is by far the larger set, and defaulting the other way would silently inflate every rule nobody has classified yet.

Tagging happens once in `analyze` rather than per rule, so a new rule cannot forget.

Against the real Hermes tree: **6 boundary, 1 hygiene**.

## The three design questions from the issue, answered

**Hermes-only, or every finding?** Hermes-only. A general split might be useful, but generalising it with one consumer is speculative, and the field only means something when the target publishes a trust model to measure against.

**Does it change `ci --fail-on`?** Not here, deliberately. Most of our critical-severity Hermes rules classify as `hygiene` — `HERMES_GOAL_PROMPT_INJECTION`, `HERMES_PLAN_USER_INPUT`, `HERMES_FUNCTION_CALL_NO_ALLOWLIST` are all critical today. Letting posture affect gating would therefore be a large behaviour change dressed as a display tweak, one release after we already changed the gate. It deserves its own PR with its own numbers.

**Does it change scoring?** Same answer, same reason.

## Rendering

`audit` marks the weaker half with a dim `(hygiene)` tag rather than decorating every line, and SARIF carries `properties.posture` so policy-aware tooling can filter.

I did **not** restructure the audit output into separate BOUNDARY and HYGIENE blocks as the issue sketched. That plan is severity-grouped and reworking it is a bigger change than this warrants with seven boundary rules in existence. Worth revisiting once there are enough Hermes rules to fill two blocks.

## Verification

409 tests, 4 new. They assert the classification's shape rather than freezing a list, so adding a rule does not break them but forgetting to tag one does.

Benchmark unchanged across all seven corpus projects, as expected for a metadata change.