### PR TITLE
Fix two false negatives, two duplicate rule IDs, add a detection floor

### DIFF
--- a/benchmarks/false-positives/results/latest.json
+++ b/benchmarks/false-positives/results/latest.json
@@ -1,6 +1,6 @@
 {
   "tool": "ship-safe",
-  "version": "9.6.4",
+  "version": "9.7.0",
   "methodology": "Findings reported by `ship-safe ci --no-deps` against pinned checkouts. Clean corpus: mature projects with no known active vulnerabilities, where every finding is triage a user inherits. Vulnerable corpus: deliberately insecure applications, present so a reduction in noise cannot be mistaken for lost detection. Counts are a proxy for a false-positive rate, not a verified one.",
   "clean": [
     {
@@ -47,9 +47,9 @@
       "id": "hermes-agent",
       "repo": "NousResearch/hermes-agent",
       "commit": "743dc94ab90adb0529bb233b8498c6fd6ee0e020",
-      "findings": 785,
+      "findings": 787,
       "critical": 101,
-      "high": 225,
+      "high": 227,
       "score": 20.9,
       "grade": "F"
     }
@@ -74,7 +74,7 @@
   ],
   "summary": {
     "cleanProjects": 5,
-    "cleanFindings": 842,
+    "cleanFindings": 844,
     "cleanCriticalFindings": 102,
     "vulnerableProjects": 2,
     "vulnerableFindings": 145

--- a/cli/__tests__/agents.test.js
+++ b/cli/__tests__/agents.test.js
@@ -1107,10 +1107,35 @@ describe('Vibe Code Detection', async () => {
   const agent = new InjectionTester();
 
   it('detects TODO to add authentication', async () => {
+    // VIBE_TODO_AUTH lives in VibeCodingAgent, which owns the VIBE_ prefix.
+    // InjectionTester used to carry a duplicate under the same rule ID, which
+    // meant one comment produced two findings.
+    const { VibeCodingAgent } = await import('../agents/vibe-coding-agent.js');
     const { dir, file } = writeTempFile('// TODO: add authentication\napp.post("/api/admin", handler);');
     try {
-      const findings = await agent.analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+      const findings = await new VibeCodingAgent()
+        .analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
       assert.ok(findings.some(f => f.rule === 'VIBE_TODO_AUTH'), 'Should detect TODO auth');
+    } finally { cleanup(dir); }
+  });
+
+  it('reports a TODO comment exactly once', async () => {
+    // The duplicate produced two findings under one rule ID, and
+    // VIBE_TODO_VALIDATION arrived at two different severities depending on
+    // which agent found it.
+    const { VibeCodingAgent } = await import('../agents/vibe-coding-agent.js');
+    const { InjectionTester: IT } = await import('../agents/injection-tester.js');
+    const { dir, file } = writeTempFile('// TODO: add authentication\n// TODO: add validation\n');
+    try {
+      const ctx = { rootPath: dir, files: [file], recon: {}, options: {} };
+      const all = [
+        ...await new VibeCodingAgent().analyze(ctx),
+        ...await new IT().analyze(ctx),
+      ];
+      for (const rule of ['VIBE_TODO_AUTH', 'VIBE_TODO_VALIDATION']) {
+        const hits = all.filter(f => f.rule === rule);
+        assert.equal(hits.length, 1, `${rule} reported ${hits.length} times`);
+      }
     } finally { cleanup(dir); }
   });
 

--- a/cli/__tests__/canonical-detection.test.js
+++ b/cli/__tests__/canonical-detection.test.js
@@ -1,0 +1,91 @@
+/**
+ * Canonical detection
+ * ===================
+ *
+ * The false-positive benchmark measures noise. Nothing measured the other
+ * direction, and that asymmetry is how two real gaps sat undetected: CORS
+ * wildcard set through `res.setHeader` was invisible because the rule required
+ * `:` or `=` before the wildcard, and prototype pollution via computed key
+ * assignment was never covered at all.
+ *
+ * This is the floor. Each case is a vulnerability a security scanner is
+ * expected to find, written the way people actually write it. A change that
+ * silences one of these has lost detection, whatever the benchmark says about
+ * noise.
+ *
+ * Add a case whenever a false-negative turns up in the wild. Do not delete one
+ * to make a change pass.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { buildOrchestrator } from '../agents/index.js';
+
+const orchestrator = buildOrchestrator();
+
+async function detects(filename, source) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-canon-'));
+  fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(dir, filename), source);
+  // A second, boring file so recon sees a normal project rather than one file.
+  fs.writeFileSync(path.join(dir, 'src', 'index.js'), 'export const x = 1;\n');
+  try {
+    const res = await orchestrator.runAll(dir, { quiet: true, includeTests: true });
+    return (res.findings || []).filter(f => f.file && f.file.endsWith(filename));
+  } finally {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* */ }
+  }
+}
+
+const cases = [
+  ['command injection, template',  'a.js', 'const {execSync}=require("child_process");\nexecSync(`ls ${req.body.dir}`);\n'],
+  ['SQL injection, template',      'b.js', 'db.query(`SELECT * FROM users WHERE id = ${req.params.id}`);\n'],
+  ['eval of request input',        'c.js', 'eval(req.body.code);\n'],
+  ['SSRF via fetch',               'd.js', 'await fetch(req.query.url);\n'],
+  ['XSS via innerHTML',            'e.js', 'el.innerHTML = req.query.name;\n'],
+  ['JWT alg none',                 'f.js', 'jwt.verify(t, k, { algorithms: ["none"] });\n'],
+  ['weak crypto MD5',              'g.js', 'crypto.createHash("md5").update(pw).digest("hex");\n'],
+  ['SQL injection, f-string',      'h.py', 'cursor.execute(f"SELECT * FROM users WHERE name = {name}")\n'],
+  ['subprocess shell=True',        'i.py', 'subprocess.run(cmd, shell=True)\n'],
+  ['pickle of untrusted data',     'j.py', 'import pickle\ndata = pickle.loads(untrusted)\n'],
+  ['yaml.load without SafeLoader', 'k.py', 'import yaml\ncfg = yaml.load(f)\n'],
+  ['SSRF via requests',            'l.py', 'import requests\nrequests.get(request.args["u"])\n'],
+  ['cloud metadata endpoint',      'm.py', 'import requests\nrequests.get("http://169.254.169.254/latest/meta-data/")\n'],
+  ['torch.load without weights_only', 'n.py', 'import torch\nm = torch.load("model.pt")\n'],
+  ['MCP wildcard tool allowlist',  '.mcp.json', '{"mcpServers":{"fs":{"command":"x","allowedTools":["*"]}}}\n'],
+
+  // The two gaps this file was written for.
+  ['CORS wildcard via setHeader',  'o.js', 'res.setHeader("Access-Control-Allow-Origin", "*");\n'],
+  ['CORS wildcard via header',     'p.js', 'res.header("Access-Control-Allow-Origin", "*");\n'],
+  ['prototype pollution, computed key', 'q.js', 'obj[req.body.key] = req.body.value;\n'],
+  ['prototype pollution, wrapped source', 'r.js', 'Object.assign(target, JSON.parse(req.body.raw));\n'],
+];
+
+describe('canonical vulnerabilities are still detected', () => {
+  for (const [label, filename, source] of cases) {
+    it(label, async () => {
+      const findings = await detects(filename, source);
+      assert.ok(
+        findings.length > 0,
+        `no finding for ${label}. If this is intentional, the case is wrong or detection was lost.`
+      );
+    });
+  }
+});
+
+describe('the safe form of each stays quiet', () => {
+  it('specific CORS origin with credentials is fine', async () => {
+    const findings = await detects('s.js',
+      'res.setHeader("Access-Control-Allow-Origin", "https://app.example.com");\n' +
+      'res.setHeader("Access-Control-Allow-Credentials", "true");\n');
+    assert.equal(findings.filter(f => f.rule.startsWith('CORS')).length, 0);
+  });
+
+  it('assignment through a non-request key is fine', async () => {
+    const findings = await detects('t.js', 'const safe = allowlist[key];\nobj[safe] = value;\n');
+    assert.equal(findings.filter(f => f.rule === 'PROTOTYPE_POLLUTION').length, 0);
+  });
+});

--- a/cli/agents/config-auditor.js
+++ b/cli/agents/config-auditor.js
@@ -86,7 +86,12 @@ const CONFIG_PATTERNS = [
   {
     rule: 'CORS_WILDCARD',
     title: 'CORS Wildcard Origin',
-    regex: /(?:Access-Control-Allow-Origin|origin)\s*[:=]\s*['"]?\*['"]?/g,
+    // The header-function form was invisible. `origin: "*"` matched, but
+    // `res.setHeader("Access-Control-Allow-Origin", "*")` and
+    // `res.header(..., "*")` did not, because the rule required `:` or `=`
+    // before the wildcard. That is the most common way to set this header in
+    // Express, so the rule missed the shape it exists for.
+    regex: /(?:Access-Control-Allow-Origin|origin)\s*(?:[:=]|['"]\s*,)\s*['"]?\*['"]?/g,
     severity: 'high',
     cwe: 'CWE-942',
     owasp: 'A05:2021',
@@ -96,6 +101,10 @@ const CONFIG_PATTERNS = [
   {
     rule: 'CORS_CREDENTIALS_WILDCARD',
     title: 'CORS Credentials with Wildcard',
+    // Same-line cors() options form only. The header-pair form spans two
+    // lines and pattern scanning is per line, so it is handled by
+    // _checkCorsCredentialHeaders below rather than by a longer regex that
+    // could never match.
     regex: /credentials\s*:\s*true.*origin\s*:\s*true|origin\s*:\s*true.*credentials\s*:\s*true/g,
     severity: 'critical',
     cwe: 'CWE-942',
@@ -576,9 +585,58 @@ export class ConfigAuditor extends BaseAgent {
     );
     for (const file of codeFiles) {
       findings = findings.concat(this.scanFileWithPatterns(file, generalPatterns));
+      findings = findings.concat(this._checkCorsCredentialHeaders(file));
     }
 
     return findings;
+  }
+
+  /**
+   * Wildcard origin combined with credentials, set as separate headers.
+   *
+   * This is the dangerous CORS combination and it is normally written across
+   * two lines:
+   *
+   *   res.setHeader('Access-Control-Allow-Origin', '*');
+   *   res.setHeader('Access-Control-Allow-Credentials', 'true');
+   *
+   * Pattern scanning runs per line, so no regex in CONFIG_PATTERNS can see
+   * both. A file-level check can.
+   *
+   * Browsers reject exactly this pair, which is why it often survives review:
+   * it looks permissive rather than broken. It matters because a server that
+   * reflects the request origin instead of literal `*` has the same shape and
+   * does work, and that is credential theft from any site.
+   */
+  _checkCorsCredentialHeaders(filePath) {
+    const content = this.readFile(filePath);
+    if (!content) return [];
+
+    const wildcardOrigin = /Access-Control-Allow-Origin['"]?\s*(?:[:=,]|['"]\s*,)\s*['"]?\*/i;
+    const allowsCredentials = /Access-Control-Allow-Credentials['"]?\s*(?:[:=,]|['"]\s*,)\s*['"]?true/i;
+    if (!wildcardOrigin.test(content) || !allowsCredentials.test(content)) return [];
+
+    const lines = content.split('\n');
+    const idx = lines.findIndex(l => allowsCredentials.test(l));
+    const line = idx === -1 ? 1 : idx + 1;
+    const matched = (lines[line - 1] || '').trim().slice(0, 180);
+    if (this.isSuppressed(matched, 'critical')) return [];
+
+    return [createFinding({
+      file: filePath,
+      line,
+      column: 1,
+      severity: 'critical',
+      category: this.category,
+      rule: 'CORS_CREDENTIALS_WILDCARD',
+      title: 'CORS Credentials with Wildcard',
+      description: 'This file sets a wildcard Access-Control-Allow-Origin and also allows credentials. If the origin is ever reflected from the request rather than sent literally, any site can read authenticated responses.',
+      matched,
+      confidence: 'high',
+      cwe: 'CWE-942',
+      owasp: 'A05:2021',
+      fix: 'Send a specific origin from an allowlist whenever Access-Control-Allow-Credentials is true.',
+    })];
   }
 
   /**

--- a/cli/agents/injection-tester.js
+++ b/cli/agents/injection-tester.js
@@ -392,7 +392,20 @@ const PATTERNS = [
   {
     rule: 'PROTOTYPE_POLLUTION',
     title: 'Prototype Pollution',
-    regex: /(?:Object\.assign|_\.merge|_\.extend|_\.defaultsDeep|lodash\.merge)\s*\(\s*(?:\{\}|[a-zA-Z]+),\s*(?:req\.|request\.|ctx\.|body|query|params|input|data)/g,
+    // Prototype pollution is a JavaScript concept, so the rule says so. The
+    // first version of this extension matched `d[ctx.session_key] = ...` in
+    // Python, where dictionaries have no prototype and the finding is
+    // meaningless. That is the same mistake language scoping exists to
+    // prevent, caught by the corpus.
+    langs: ['js'],
+    // Two shapes were missing. A merge source arriving through a wrapper call,
+    // `Object.assign(target, JSON.parse(req.body.raw))`, and computed key
+    // assignment, `obj[req.body.key] = value`, which is the __proto__
+    // injection path and involves no merge helper at all.
+    //
+    // `ctx.` and a bare `data` are deliberately not accepted: both matched
+    // ordinary application state rather than request input.
+    regex: /(?:Object\.assign|_\.merge|_\.extend|_\.defaultsDeep|lodash\.merge)\s*\(\s*(?:\{\}|[a-zA-Z]+)\s*,\s*[^)\n]{0,80}?(?:req\.|request\.|\bbody\b|\bquery\b|\bparams\b)|\[\s*(?:req|request)\.[\w.[\]'"]+\s*\]\s*=(?!=)/g,
     severity: 'high',
     cwe: 'CWE-1321',
     owasp: 'A03:2021',
@@ -446,29 +459,12 @@ const PATTERNS = [
   },
 
   // ── Vibe Code Detection (AI-generated code with security gaps) ──────────
-  {
-    rule: 'VIBE_TODO_AUTH',
-    title: 'Vibe Code: TODO to Add Authentication',
-    regex: /(?:\/\/|#|\/\*)\s*(?:TODO|FIXME|HACK|XXX)\s*:?\s*(?:add|implement|fix|handle)\s*(?:auth|authentication|authorization|permission|access.?control|login|session)/gi,
-    severity: 'high',
-    cwe: 'CWE-306',
-    owasp: 'A07:2021',
-    confidence: 'high',
-    description: 'TODO comment indicates missing authentication/authorization. Common in AI-generated code that creates endpoints without security.',
-    fix: 'Implement the missing authentication before shipping. Do not leave security TODOs in production code.',
-  },
-  {
-    rule: 'VIBE_TODO_VALIDATION',
-    title: 'Vibe Code: TODO to Add Input Validation',
-    regex: /(?:\/\/|#|\/\*)\s*(?:TODO|FIXME|HACK|XXX)\s*:?\s*(?:add|implement|fix|handle)\s*(?:valid|sanitiz|escap|filter|check.?input|input.?valid)/gi,
-    severity: 'medium',
-    cwe: 'CWE-20',
-    owasp: 'A03:2021',
-    confidence: 'high',
-    description: 'TODO comment indicates missing input validation. AI-generated code often creates the happy path without validation.',
-    fix: 'Implement input validation before shipping. Add schema validation (Zod, Joi) for all user inputs.',
-  },
-  {
+  // VIBE_TODO_AUTH and VIBE_TODO_VALIDATION used to be duplicated here. Both
+  // are owned by vibe-coding-agent.js, which holds the VIBE_ prefix. Emitting
+  // them from two agents gave one comment two findings under one rule ID, and
+  // VIBE_TODO_VALIDATION arrived at two different severities depending on
+  // which agent produced it, which makes the ID useless for suppression.
+      {
     rule: 'VIBE_PLACEHOLDER_SECRET',
     title: 'Vibe Code: Placeholder Secret Left in Code',
     regex: /(?:api[_-]?key|secret|password|token)\s*[:=]\s*['"](?:your[_-]?(?:api[_-]?)?key[_-]?here|sk[_-]xxx|changeme|password123|test123|replace[_-]?me|insert[_-]?here|placeholder|example|CHANGE_ME|YOUR_SECRET)['"]/gi,

--- a/cli/agents/vibe-coding-agent.js
+++ b/cli/agents/vibe-coding-agent.js
@@ -55,7 +55,10 @@ const PATTERNS = [
   {
     rule: 'VIBE_TODO_AUTH',
     title: 'Vibe Code: TODO — Add Authentication',
-    regex: /\/\/\s*(?:TODO|FIXME|HACK|XXX)\s*:?\s*(?:add|implement|fix|enable|require)\s+(?:auth(?:entication|orization)?|login|session|jwt|token|middleware|permission|rbac|access.?control)/gi,
+    // Comment styles beyond `//` come from the duplicate copy that used to
+    // live in injection-tester.js under the same rule ID. Python and block
+    // comments carry these TODOs just as often.
+    regex: /(?:\/\/|#|\/\*)\s*(?:TODO|FIXME|HACK|XXX)\s*:?\s*(?:add|implement|fix|enable|require|handle)\s+(?:auth(?:entication|orization)?|login|session|jwt|token|middleware|permission|rbac|access.?control)/gi,
     severity: 'high',
     cwe: 'CWE-306',
     owasp: 'A01:2021',
@@ -65,7 +68,7 @@ const PATTERNS = [
   {
     rule: 'VIBE_TODO_VALIDATION',
     title: 'Vibe Code: TODO — Add Input Validation',
-    regex: /\/\/\s*(?:TODO|FIXME|HACK|XXX)\s*:?\s*(?:add|implement|fix|enable)\s+(?:valid(?:ation|ate)|sanitiz(?:e|ation)|escap(?:e|ing)|input.?check|type.?check)/gi,
+    regex: /(?:\/\/|#|\/\*)\s*(?:TODO|FIXME|HACK|XXX)\s*:?\s*(?:add|implement|fix|enable|handle)\s+(?:valid(?:ation|ate)|sanitiz(?:e|ation)|escap(?:e|ing)|filter|input.?check|check.?input|type.?check)/gi,
     severity: 'high',
     cwe: 'CWE-20',
     owasp: 'A03:2021',


### PR DESCRIPTION
A deep review pass from three angles: what a week of false-positive work might have cost, what was never caught to begin with, and whether the code holds up under abuse.

## What held up

No ReDoS: every rule regex tested against nine adversarial inputs, none over 150ms, including this week's lookbehinds. No crashes on binary files, 900KB single lines, invalid UTF-16, malformed JSON or dangling symlinks. Scoring never throws or leaves range across seven edge cases including 50,000 findings. Every quote of Hermes's SECURITY.md verifies verbatim. `npm audit` clean.

Mutation testing: 13 of this week's fixes reverted one at a time, **all 13 caught** by the suite.

## What did not

**CORS wildcard through a header function was invisible.**

```js
app.use(cors({ origin: "*" }))                     // detected
res.setHeader("Access-Control-Allow-Origin", "*")  // MISSED
res.header("Access-Control-Allow-Origin", "*")     // MISSED
```

The rule required `:` or `=` before the wildcard. The header-function form is how this is normally written in Express, so the rule missed the shape it exists for. `CORS_CREDENTIALS_WILDCARD` had the same gap, and its header form spans two lines — which per-line pattern scanning can never see, so it is now a file-level check.

**Prototype pollution missed two shapes**: a merge source arriving through a wrapper call, `Object.assign(target, JSON.parse(req.body.raw))`, and computed key assignment, `obj[req.body.key] = value`, which is the `__proto__` path and involves no merge helper at all.

**Two more duplicate rule IDs.** `VIBE_TODO_AUTH` and `VIBE_TODO_VALIDATION` were emitted by both `InjectionTester` and `VibeCodingAgent`. One comment produced two findings, and `VIBE_TODO_VALIDATION` arrived at `medium` from one agent and `high` from the other. A rule ID that means different things depending on which agent found it is unusable for suppression, triage or SARIF consumers. Same class as the one fixed in #119.

## A mistake worth recording

My first prototype-pollution fix matched `d[ctx.session_key] = ...` in `gateway/run.py`. Python dictionaries have no prototype, so the finding is meaningless.

That is exactly the mistake language scoping exists to prevent, made in the same week we built the mechanism. The corpus caught it, which is the argument for running the corpus. The rule now declares `langs: ['js']`, and `ctx.` and a bare `data` are no longer accepted as request input since both matched ordinary application state.

## The structural fix

`cli/__tests__/canonical-detection.test.js` — 19 vulnerabilities that must stay detected, written the way people actually write them.

The false-positive benchmark measures noise in one direction only. Nothing measured the other, and that asymmetry is precisely how these gaps survived a week of intense attention to this file. Cases get added when a false negative turns up; they do not get deleted to make a change pass.

## Numbers

| project | before | after | |
|---|---|---|---|
| express, flask, chalk, requests | | | unchanged |
| NodeGoat | 74 / 9C | 74 / 9C | unchanged |
| DVWA | 71 / 1C | 71 / 1C | unchanged |
| hermes-agent | 785 | 787 | +2 |

Both new hermes findings are genuine `res.setHeader('Access-Control-Allow-Origin', '*')`, in `apps/desktop/e2e/mock-server.ts` and `scripts/dev-mock.mjs`. True positives for the rule, low real-world severity given they are dev servers, and 2 findings across 8,400 files is an acceptable trade for closing the gap.

431 tests pass, lint clean, ReDoS re-checked after the changes.