### PR TITLE
fix(cli): support directories in scan-mcp

### DIFF
--- a/cli/__tests__/scan-mcp-directory.test.js
+++ b/cli/__tests__/scan-mcp-directory.test.js
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const cliPath = path.join(repoRoot, 'cli', 'bin', 'ship-safe.js');
+
+function withTempDirectory(callback) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-scan-mcp-'));
+  try {
+    return callback(directory);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function scan(target) {
+  return spawnSync(process.execPath, [cliPath, 'scan-mcp', target, '--json'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+}
+
+function parseJson(result) {
+  assert.equal(result.error, undefined, result.error?.message);
+  const json = result.stdout.match(/\n(\{[\s\S]*\})\s*$/);
+  assert.ok(json, `Expected JSON output, got:\n${result.stdout}`);
+  return JSON.parse(json[1]);
+}
+
+test('scans an empty directory without reading it as a manifest', () => {
+  withTempDirectory(directory => {
+    const result = scan(directory);
+    const report = parseJson(result);
+
+    assert.equal(result.status, 0);
+    assert.ok(result.stdout.includes(`No MCP configuration files found in ${directory}`));
+    assert.match(result.stdout, /mcp\.json/);
+    assert.deepEqual(report.configs, []);
+    assert.equal(report.configCount, 0);
+    assert.deepEqual(report.findings, []);
+    assert.deepEqual(report.summary, { total: 0, critical: 0, high: 0, medium: 0 });
+  });
+});
+
+test('discovers editor MCP configs in canonical order with relative findings', () => {
+  withTempDirectory(directory => {
+    fs.mkdirSync(path.join(directory, '.vscode'));
+    fs.mkdirSync(path.join(directory, '.cursor'));
+    fs.writeFileSync(path.join(directory, '.vscode', 'mcp.json'), '{}');
+    fs.writeFileSync(path.join(directory, '.cursor', 'mcp.json'), JSON.stringify({
+      mcpServers: {
+        unsafe: { command: 'npx', args: ['@modelcontextprotocol/server-filesyste'] },
+      },
+    }));
+
+    const result = scan(directory);
+    const report = parseJson(result);
+
+    assert.equal(result.status, 1);
+    assert.deepEqual(report.configs, ['.cursor/mcp.json', '.vscode/mcp.json']);
+    assert.equal(report.configCount, 2);
+    assert.ok(report.findings.length > 0);
+    assert.ok(report.findings.every(finding => finding.file === '.cursor/mcp.json'));
+    assert.equal(report.summary.critical > 0, true);
+  });
+});
+
+test('preserves regular manifest tool counts', () => {
+  withTempDirectory(directory => {
+    const manifest = path.join(directory, 'manifest.json');
+    fs.writeFileSync(manifest, JSON.stringify({ tools: [{ name: 'search', description: 'Search documents.' }] }));
+
+    const result = scan(manifest);
+    const report = parseJson(result);
+
+    assert.equal(result.status, 0);
+    assert.equal(report.toolCount, 1);
+  });
+});
+
+test('reports a missing scan target readably', () => {
+  withTempDirectory(directory => {
+    const missing = path.join(directory, 'missing.json');
+    const result = scan(missing);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /File not found:/);
+    assert.ok(result.stdout.includes(missing));
+  });
+});

--- a/cli/agents/mcp-security-agent.js
+++ b/cli/agents/mcp-security-agent.js
@@ -223,7 +223,7 @@ const PATTERNS = [
 // STRUCTURAL CHECKS (beyond line-by-line regex)
 // =============================================================================
 
-const MCP_CONFIG_FILES = [
+export const MCP_CONFIG_FILES = [
   'mcp.json',
   '.mcp.json',
   'mcp-config.json',

--- a/cli/commands/scan-mcp.js
+++ b/cli/commands/scan-mcp.js
@@ -8,7 +8,7 @@
  *
  * USAGE:
  *   ship-safe scan-mcp <url>        Analyze a remote MCP server
- *   ship-safe scan-mcp <path>       Analyze a local MCP manifest file
+ *   ship-safe scan-mcp <path>       Analyze a local MCP manifest file or project directory
  *
  * The command connects to the server's /tools endpoint (or reads the manifest
  * JSON directly) and inspects every tool definition for attack patterns.
@@ -23,6 +23,7 @@ import chalk from 'chalk';
 import { createHash } from 'crypto';
 import * as output from '../utils/output.js';
 import { ThreatIntel } from '../utils/threat-intel.js';
+import { MCPSecurityAgent, MCP_CONFIG_FILES } from '../agents/mcp-security-agent.js';
 
 // =============================================================================
 // MCP TOOL DESCRIPTION PATTERNS
@@ -216,6 +217,23 @@ export async function scanMcpCommand(target, options = {}) {
       output.error(`File not found: ${filePath}`);
       process.exit(1);
     }
+
+    let stats;
+    try {
+      stats = fs.statSync(filePath);
+    } catch (err) {
+      output.error(`Failed to inspect MCP target ${filePath}: ${err.message}`);
+      process.exit(1);
+    }
+
+    if (stats.isDirectory()) {
+      return scanMcpDirectory(filePath, options);
+    }
+    if (!stats.isFile()) {
+      output.error(`Unsupported MCP target: ${filePath} (expected a regular file or directory)`);
+      process.exit(1);
+    }
+
     try {
       manifest = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
       serverName = path.basename(filePath);
@@ -248,6 +266,103 @@ export async function scanMcpCommand(target, options = {}) {
   if (getSummary(findings).critical > 0) {
     process.exit(1);
   }
+}
+
+async function scanMcpDirectory(rootPath, options) {
+  const configFiles = discoverMcpConfigFiles(rootPath);
+  const configPaths = configFiles.map(filePath => projectRelativePath(rootPath, filePath));
+  const scanner = new MCPSecurityAgent();
+  const findings = normalizeDirectoryFindings(rootPath, await scanner.analyze({
+    rootPath,
+    files: configFiles,
+    options: { checkGlobalAgents: false },
+  }));
+  const summary = getSummary(findings);
+
+  if (configFiles.length === 0) {
+    renderEmptyDirectoryWarning(rootPath);
+  }
+
+  if (options.json) {
+    printDirectoryJson(rootPath, configPaths, findings);
+  } else {
+    renderDirectoryFindings(rootPath, configPaths, findings);
+  }
+
+  if (summary.critical > 0) {
+    process.exit(1);
+  }
+}
+
+function discoverMcpConfigFiles(rootPath) {
+  return MCP_CONFIG_FILES
+    .map(relativePath => path.join(rootPath, relativePath))
+    .filter(filePath => {
+      try {
+        return fs.statSync(filePath).isFile();
+      } catch {
+        return false;
+      }
+    });
+}
+
+function projectRelativePath(rootPath, filePath) {
+  return path.relative(rootPath, filePath).replace(/\\/g, '/');
+}
+
+function normalizeDirectoryFindings(rootPath, findings) {
+  return findings.map(finding => finding.file
+    ? { ...finding, file: projectRelativePath(rootPath, finding.file) }
+    : finding);
+}
+
+function renderEmptyDirectoryWarning(rootPath) {
+  output.warning(`No MCP configuration files found in ${rootPath}. Searched: ${MCP_CONFIG_FILES.join(', ')}`);
+}
+
+function renderDirectoryFindings(rootPath, configPaths, findings) {
+  if (configPaths.length === 0) return;
+
+  const project = path.basename(rootPath);
+  console.log(chalk.gray(`  Project: ${project}`));
+  console.log(chalk.gray(`  Configs found: ${configPaths.length}`));
+  console.log();
+
+  const grouped = new Map(configPaths.map(configPath => [configPath, []]));
+  for (const finding of findings) {
+    if (!grouped.has(finding.file)) grouped.set(finding.file, []);
+    grouped.get(finding.file).push(finding);
+  }
+
+  for (const [configPath, configFindings] of grouped) {
+    console.log(chalk.cyan(`  Config: ${configPath}`));
+    if (configFindings.length === 0) {
+      console.log(chalk.gray('    No findings.'));
+      console.log();
+      continue;
+    }
+    for (const finding of configFindings) {
+      const sevColor = finding.severity === 'critical' ? chalk.red.bold
+        : finding.severity === 'high' ? chalk.yellow
+        : chalk.blue;
+      console.log(`    ${sevColor(`[${finding.severity.toUpperCase()}]`)} ${chalk.white(finding.title || finding.rule)}`);
+      if (finding.matched) console.log(chalk.gray(`      ${String(finding.matched).slice(0, 120)}`));
+    }
+    console.log();
+  }
+
+  const summary = getSummary(findings);
+  if (summary.total === 0) {
+    console.log(chalk.green.bold(`  ✔ ${project}: No security issues found across ${configPaths.length} MCP config(s).`));
+    console.log();
+  } else if (summary.critical > 0) {
+    console.log(chalk.red.bold('    ⚠ Critical security issues detected.'));
+    console.log();
+  }
+}
+
+function printDirectoryJson(rootPath, configPaths, findings) {
+  console.log(JSON.stringify({ project: path.basename(rootPath), source: rootPath, configCount: configPaths.length, configs: configPaths, findings, summary: getSummary(findings) }, null, 2));
 }
 
 // =============================================================================


### PR DESCRIPTION
## Description

`scan-mcp` now accepts a project directory, discovers the six canonical project-local MCP config files, and scans each discovered file without including global agent configuration. Direct manifest-file and URL inputs keep their existing behavior.

Directory results use project-relative paths and deterministic discovery order, including in JSON output.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New security agent
- [ ] New security rule
- [ ] New secret detection pattern
- [ ] New security config/checklist
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I've tested my changes locally
- [x] I've added or updated tests when behavior changed
- [x] No security finding copy or remediation changed; this is input discovery only
- [x] No documentation update was needed for the issue's expected invocation
- [x] My code follows the project's style
- [x] No detector behavior changed, so the false-positive benchmark is not applicable
- [x] I did not add real secrets, tokens, customer data, or private repo URLs

## Testing Done

- `node --test cli/__tests__/scan-mcp-directory.test.js` (4/4 passed)
- `npm run lint -- --quiet` (passed)
- `npm test` (410/413 passed; the only failures are the three existing Windows symlink cases in `trust-boundary-agent.test.js`, all with `EPERM`)

## Related Issues

Fixes #115

## Additional Notes

Directory discovery is limited to the canonical project-local config list already owned by `MCPSecurityAgent`.
