### PR TITLE
docs: add GitLab CI security gate example

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ jobs:
           sarif_file: results.sarif
 ```
 
+A GitLab CI version is in [docs/examples/gitlab-security-workflow.yml](docs/examples/gitlab-security-workflow.yml).
+
 ---
 
 ## LLM Support

--- a/docs/examples/gitlab-security-workflow.yml
+++ b/docs/examples/gitlab-security-workflow.yml
@@ -1,0 +1,24 @@
+# Example GitLab CI security gate
+#
+# Copy the security-gate job into your project's .gitlab-ci.yml, or include this
+# file and override the threshold in your own settings if you use CI/CD includes.
+#
+# Tune --threshold for your team. Lower values are less strict; higher values
+# require the scan to miss fewer findings before the pipeline passes.
+
+stages:
+  - security
+
+security-gate:
+  stage: security
+  image: node:20
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+  script:
+    - npx --yes ship-safe@latest ci . --threshold 75 --sarif ship-safe.sarif
+  artifacts:
+    when: always
+    expire_in: 30 days
+    paths:
+      - ship-safe.sarif

--- a/docs/examples/gitlab-security-workflow.yml
+++ b/docs/examples/gitlab-security-workflow.yml
@@ -4,7 +4,7 @@
 # file and override the threshold in your own settings if you use CI/CD includes.
 #
 # Tune --threshold for your team. Lower values are less strict; higher values
-# require the scan to miss fewer findings before the pipeline passes.
+# require a higher security score before the pipeline passes.
 
 stages:
   - security


### PR DESCRIPTION
Closes #58

## Summary

Adds a copy-pasteable GitLab CI security gate example:

- runs on merge requests and default branch pushes;
- installs Node via the `node:20` image;
- runs `npx ship-safe ci . --threshold 75 --sarif ship-safe.sarif`;
- preserves the SARIF output as a CI artifact, including on failure;
- includes comments explaining where teams should tune the threshold.

Links the example from the README CI/CD section.

## Verification

- `docs/examples/gitlab-security-workflow.yml` parses as valid YAML.
- The README link resolves to the new example file.

Docs-only change.

Signed off with DCO.
