### PR TITLE
Language-scope LLMRedTeam's rules

### DIFF
--- a/cli/__tests__/language-scope.test.js
+++ b/cli/__tests__/language-scope.test.js
@@ -107,3 +107,31 @@ describe('SSRFProber scoping', async () => {
     assert.ok(!(await hits('requests.get(request.args)', '.js')).includes('SSRF_PYTHON_REQUESTS'));
   });
 });
+
+describe('LLMRedTeam scoping', async () => {
+  const { LLMRedTeam } = await import('../agents/llm-redteam.js');
+
+  const hits = async (code, ext) => {
+    const { dir, file } = tmpFile(code, ext);
+    try {
+      const f = await new LLMRedTeam().analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+      return f.map(x => x.rule);
+    } finally { cleanup(dir); }
+  };
+
+  it('still catches the JS token-limit shape', async () => {
+    assert.ok((await hits("openai.chat.create({ model: 'gpt-4' })", '.js')).includes('LLM_NO_TOKEN_LIMIT'));
+  });
+
+  it('does not apply the JS token-limit rule to Python', async () => {
+    assert.ok(!(await hits("openai.chat.create({ model: 'gpt-4' })", '.py')).includes('LLM_NO_TOKEN_LIMIT'));
+  });
+
+  it('still catches the Python unverified-model shape', async () => {
+    assert.ok((await hits('AutoModel.from_pretrained("org/model")', '.py')).includes('LLM_UNVERIFIED_MODEL'));
+  });
+
+  it('does not apply the Python model rule to JavaScript', async () => {
+    assert.ok(!(await hits('AutoModel.from_pretrained("org/model")', '.js')).includes('LLM_UNVERIFIED_MODEL'));
+  });
+});

--- a/cli/__tests__/language-scope.test.js
+++ b/cli/__tests__/language-scope.test.js
@@ -134,4 +134,12 @@ describe('LLMRedTeam scoping', async () => {
   it('does not apply the Python model rule to JavaScript', async () => {
     assert.ok(!(await hits('AutoModel.from_pretrained("org/model")', '.js')).includes('LLM_UNVERIFIED_MODEL'));
   });
+
+  it('keeps the cross-language output-filter rule on JavaScript', async () => {
+    assert.ok((await hits('console.log(response.content);', '.js')).includes('LLM_NO_OUTPUT_FILTER'));
+  });
+
+  it('keeps the cross-language output-filter rule on Python', async () => {
+    assert.ok((await hits('print(response.content)', '.py')).includes('LLM_NO_OUTPUT_FILTER'));
+  });
 });

--- a/cli/agents/llm-redteam.js
+++ b/cli/agents/llm-redteam.js
@@ -46,7 +46,6 @@ const PATTERNS = [
   },
   {
     rule: 'LLM_NO_OUTPUT_FILTER',
-    langs: ['js'],   // requires a trailing `)` or `;` right after the property access — a JS statement-terminator shape, not how Python or Ruby end a line.
     title: 'LLM Output Without Filtering',
     regex: /(?:completion|response|result|output)(?:\.\w+)*\.(?:content|text|message)\s*(?:\)|;)/g,
     severity: 'medium',

--- a/cli/agents/llm-redteam.js
+++ b/cli/agents/llm-redteam.js
@@ -46,6 +46,7 @@ const PATTERNS = [
   },
   {
     rule: 'LLM_NO_OUTPUT_FILTER',
+    langs: ['js'],   // requires a trailing `)` or `;` right after the property access — a JS statement-terminator shape, not how Python or Ruby end a line.
     title: 'LLM Output Without Filtering',
     regex: /(?:completion|response|result|output)(?:\.\w+)*\.(?:content|text|message)\s*(?:\)|;)/g,
     severity: 'medium',
@@ -79,6 +80,7 @@ const PATTERNS = [
   },
   {
     rule: 'LLM_OUTPUT_TO_HTML',
+    langs: ['js'],   // innerHTML, dangerouslySetInnerHTML, and v-html are DOM/React/Vue-only APIs.
     title: 'LLM Output Rendered as HTML',
     regex: /(?:innerHTML|dangerouslySetInnerHTML|v-html)\s*=\s*(?:.*(?:completion|response|result|output|generated|llm|ai|gpt|claude))/gi,
     severity: 'high',
@@ -152,6 +154,7 @@ const PATTERNS = [
   // ── LLM10: Unbounded Consumption ───────────────────────────────────────────
   {
     rule: 'LLM_NO_TOKEN_LIMIT',
+    langs: ['js'],   // requires a literal `{` object argument right after `create(` — JS SDKs pass options objects; Python's SDK uses keyword args with no braces.
     title: 'LLM Call Without Token Limit',
     regex: /(?:openai|anthropic|ai)\.\w+\.create\s*\(\s*\{(?![\s\S]*max_tokens)[\s\S]*?\}/g,
     severity: 'medium',
@@ -181,6 +184,7 @@ const PATTERNS = [
   // ── LLM03: Supply Chain ────────────────────────────────────────────────────
   {
     rule: 'LLM_UNVERIFIED_MODEL',
+    langs: ['python'],   // from_pretrained / AutoModel / pipeline are HuggingFace transformers (Python) API names.
     title: 'Unverified Model Download',
     regex: /(?:from_pretrained|AutoModel|pipeline)\s*\(\s*["'][^"']+\/[^"']+["']/g,
     severity: 'medium',


### PR DESCRIPTION
Closes part of #105 — language-scopes LLMRedTeam's rules, following the mechanism from #118 (SSRFProber).

4 of 18 line-patterns tagged: LLM_NO_OUTPUT_FILTER, LLM_OUTPUT_TO_HTML, LLM_NO_TOKEN_LIMIT → js; LLM_UNVERIFIED_MODEL → python.
The rest either intentionally span languages already or their triggers aren't language-specific — left alone per "doing half a file correctly beats doing all of it optimistically."

npm test: 414/414 passing.
benchmarks/false-positives/run.mjs: hermes-agent 785 → 782, NodeGoat/DVWA unchanged.