### PR TITLE
test: keep release versions consistent

### DIFF
--- a/cli/__tests__/version-consistency.test.js
+++ b/cli/__tests__/version-consistency.test.js
@@ -1,0 +1,22 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { MCP_SERVER_VERSION } from '../commands/mcp.js';
+import { PACKAGE_VERSION } from '../utils/package-version.js';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const readJson = (name) => JSON.parse(fs.readFileSync(path.join(root, name), 'utf8'));
+
+describe('release version consistency', () => {
+  it('keeps package.json, package-lock.json, and MCP metadata aligned', () => {
+    const packageJson = readJson('package.json');
+    const packageLock = readJson('package-lock.json');
+
+    assert.equal(packageLock.version, packageJson.version);
+    assert.equal(packageLock.packages[''].version, packageJson.version);
+    assert.equal(PACKAGE_VERSION, packageJson.version);
+    assert.equal(MCP_SERVER_VERSION, packageJson.version);
+  });
+});

--- a/cli/commands/mcp.js
+++ b/cli/commands/mcp.js
@@ -53,6 +53,9 @@ import { buildOrchestrator } from '../agents/index.js';
 import { ScoringEngine } from '../agents/scoring-engine.js';
 import { autoDetectProvider } from '../providers/llm-provider.js';
 import { DeepAnalyzer } from '../agents/deep-analyzer.js';
+import { PACKAGE_VERSION } from '../utils/package-version.js';
+
+export const MCP_SERVER_VERSION = PACKAGE_VERSION;
 
 const MAX_MCP_FINDINGS = 200;
 
@@ -607,7 +610,7 @@ async function handleRequest(request) {
       return respond({
         protocolVersion: '2024-11-05',
         capabilities: { tools: {} },
-        serverInfo: { name: 'ship-safe', version: '9.7.2' },
+        serverInfo: { name: 'ship-safe', version: MCP_SERVER_VERSION },
       });
 
     case 'tools/list':

--- a/cli/utils/package-version.js
+++ b/cli/utils/package-version.js
@@ -1,0 +1,10 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { version } = require('../../package.json');
+
+if (typeof version !== 'string' || version.length === 0) {
+  throw new Error('ship-safe package.json must define a non-empty version');
+}
+
+export const PACKAGE_VERSION = version;


### PR DESCRIPTION
## Summary
- read the MCP server version from package.json
- add a release version consistency test for package.json, package-lock.json, and MCP metadata

## Verification
- node --test cli/__tests__/version-consistency.test.js
- npm test
- npm run lint
- git diff --check

The existing lint warnings remain unchanged; there are no lint errors.