### PR TITLE
fix: harden GitHub Action CI contract

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,10 @@ inputs:
     description: 'Post scan summary as PR comment'
     required: false
     default: 'true'
+  inline:
+    description: 'Post critical/high findings as inline PR review comments (pull_request only)'
+    required: false
+    default: 'false'
   token:
     description: 'GitHub token for PR comments and SARIF upload (default: github.token)'
     required: false
@@ -72,6 +76,13 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Protect fork pull_request_target scans
+      if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
+      shell: bash
+      run: |
+        echo "::error::Ship Safe refuses fork pull_request_target scans because the checked-out PR may be untrusted code running with privileged context. Use pull_request instead."
+        exit 1
+
     - name: Setup Node.js
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
@@ -91,6 +102,8 @@ runs:
         SHIP_SAFE_DEPS: ${{ inputs.deps }}
         SHIP_SAFE_BASELINE: ${{ inputs.baseline }}
         SHIP_SAFE_SARIF: ${{ inputs.sarif }}
+        SHIP_SAFE_INLINE: ${{ inputs.inline }}
+        GH_TOKEN: ${{ inputs.token }}
       run: |
         VERSION=$(node -p "require(process.env.GITHUB_ACTION_PATH + '/package.json').version")
         npm install -g "ship-safe@$VERSION"
@@ -111,6 +124,9 @@ runs:
         fi
         if [ "$SHIP_SAFE_SARIF" = "true" ]; then
           FLAGS+=(--sarif /tmp/ship-safe-results.sarif)
+        fi
+        if [ "$SHIP_SAFE_INLINE" = "true" ] && [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+          FLAGS+=(--github-inline)
         fi
 
         # Run scan and capture output

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Ship Safe Security Scan'
-description: 'Scan your codebase for secrets, vulnerabilities, CVEs, and misconfigurations with 16 AI security agents'
+description: 'Scan your codebase for secrets, vulnerabilities, CVEs, and misconfigurations with 29 security agents'
 author: 'Ship Safe'
 
 branding:
@@ -47,18 +47,25 @@ inputs:
 outputs:
   score:
     description: 'Security score (0-100)'
+    value: ${{ steps.scan.outputs.score }}
   grade:
     description: 'Letter grade (A-F)'
+    value: ${{ steps.scan.outputs.grade }}
   findings:
     description: 'Total number of findings'
+    value: ${{ steps.scan.outputs.findings }}
   secrets:
     description: 'Number of secrets detected'
+    value: ${{ steps.scan.outputs.secrets }}
   vulns:
     description: 'Number of code vulnerabilities'
+    value: ${{ steps.scan.outputs.vulns }}
   cves:
     description: 'Number of dependency CVEs'
+    value: ${{ steps.scan.outputs.cves }}
   sarif-file:
     description: 'Path to SARIF file (if generated)'
+    value: ${{ steps.scan.outputs.sarif_file }}
   report-url:
     description: 'URL to the scan report (if available)'
 
@@ -70,10 +77,6 @@ runs:
       with:
         node-version: '20'
 
-    - name: Install Ship Safe
-      shell: bash
-      run: npm install -g ship-safe@latest
-
     - name: Run security scan
       id: scan
       shell: bash
@@ -81,16 +84,38 @@ runs:
         ANTHROPIC_API_KEY: ${{ env.ANTHROPIC_API_KEY }}
         OPENAI_API_KEY: ${{ env.OPENAI_API_KEY }}
         GOOGLE_AI_API_KEY: ${{ env.GOOGLE_AI_API_KEY }}
+        SHIP_SAFE_PATH: ${{ inputs.path }}
+        SHIP_SAFE_THRESHOLD: ${{ inputs.threshold }}
+        SHIP_SAFE_FAIL_ON: ${{ inputs.fail-on }}
+        SHIP_SAFE_DEEP: ${{ inputs.deep }}
+        SHIP_SAFE_DEPS: ${{ inputs.deps }}
+        SHIP_SAFE_BASELINE: ${{ inputs.baseline }}
+        SHIP_SAFE_SARIF: ${{ inputs.sarif }}
       run: |
+        VERSION=$(node -p "require(process.env.GITHUB_ACTION_PATH + '/package.json').version")
+        npm install -g "ship-safe@$VERSION"
+
         # Build flags
-        FLAGS="--json"
-        if [ "${{ inputs.deep }}" = "true" ]; then FLAGS="$FLAGS --deep"; fi
-        if [ "${{ inputs.deps }}" = "true" ]; then FLAGS="$FLAGS --deps"; fi
-        if [ "${{ inputs.baseline }}" = "true" ]; then FLAGS="$FLAGS --baseline"; fi
+        FLAGS=(--json)
+        if [ "$SHIP_SAFE_DEEP" = "true" ]; then FLAGS+=(--deep); fi
+        if [ "$SHIP_SAFE_DEPS" = "true" ]; then
+          FLAGS+=(--deps)
+        else
+          FLAGS+=(--no-deps)
+        fi
+        if [ "$SHIP_SAFE_BASELINE" = "true" ]; then FLAGS+=(--baseline); fi
+        if [ -n "$SHIP_SAFE_FAIL_ON" ]; then
+          FLAGS+=(--fail-on "$SHIP_SAFE_FAIL_ON")
+        else
+          FLAGS+=(--threshold "$SHIP_SAFE_THRESHOLD")
+        fi
+        if [ "$SHIP_SAFE_SARIF" = "true" ]; then
+          FLAGS+=(--sarif /tmp/ship-safe-results.sarif)
+        fi
 
         # Run scan and capture output
         set +e
-        RESULT=$(ship-safe ci "${{ inputs.path }}" --threshold "${{ inputs.threshold }}" $FLAGS 2>&1)
+        RESULT=$(ship-safe ci "$SHIP_SAFE_PATH" "${FLAGS[@]}" 2>&1)
         EXIT_CODE=$?
         set -e
 
@@ -107,8 +132,8 @@ runs:
         SCORE=$(echo "$JSON_LINE" | jq -r '.score // 0')
         GRADE=$(echo "$JSON_LINE" | jq -r '.grade // "F"')
         FINDINGS=$(echo "$JSON_LINE" | jq -r '.totalFindings // 0')
-        SECRETS=$(echo "$JSON_LINE" | jq -r '.categories.secrets.findingCount // 0')
-        VULNS=$(echo "$JSON_LINE" | jq -r '((.categories.injection.findingCount // 0) + (.categories.auth.findingCount // 0))')
+        SECRETS=$(echo "$JSON_LINE" | jq -r '[.findings[]? | select(.category == "secrets")] | length')
+        VULNS=$(echo "$JSON_LINE" | jq -r '[.findings[]? | select(.category == "injection" or .category == "auth")] | length')
         CVES=$(echo "$JSON_LINE" | jq -r '.totalDepVulns // 0')
 
         # Set outputs
@@ -118,6 +143,9 @@ runs:
         echo "secrets=$SECRETS" >> $GITHUB_OUTPUT
         echo "vulns=$VULNS" >> $GITHUB_OUTPUT
         echo "cves=$CVES" >> $GITHUB_OUTPUT
+        if [ "$SHIP_SAFE_SARIF" = "true" ] && [ -f /tmp/ship-safe-results.sarif ]; then
+          echo "sarif_file=/tmp/ship-safe-results.sarif" >> $GITHUB_OUTPUT
+        fi
 
         # Save full JSON for later steps
         echo "$JSON_LINE" > /tmp/ship-safe-report.json
@@ -148,32 +176,22 @@ runs:
 
         # Determine pass/fail
         FAIL=0
-        if [ -n "${{ inputs.fail-on }}" ]; then
-          SEVERITY="${{ inputs.fail-on }}"
+        if [ -n "$SHIP_SAFE_FAIL_ON" ]; then
+          SEVERITY="$SHIP_SAFE_FAIL_ON"
           COUNT=$(echo "$JSON_LINE" | jq -r "[.findings[]? | select(.severity == \"$SEVERITY\")] | length")
           if [ "$COUNT" -gt 0 ]; then
             echo "::error::Found $COUNT $SEVERITY findings"
             FAIL=1
           fi
-        elif [ "$SCORE" -lt "${{ inputs.threshold }}" ]; then
-          echo "::error::Security score $SCORE is below threshold ${{ inputs.threshold }}"
+        elif [ "$SCORE" -lt "$SHIP_SAFE_THRESHOLD" ]; then
+          echo "::error::Security score $SCORE is below threshold $SHIP_SAFE_THRESHOLD"
           FAIL=1
         fi
 
         echo "fail=$FAIL" >> $GITHUB_OUTPUT
 
-    - name: Generate SARIF
-      if: inputs.sarif == 'true'
-      shell: bash
-      run: |
-        # Generate SARIF from the scan results
-        ship-safe ci "${{ inputs.path }}" --sarif /tmp/ship-safe-results.sarif --threshold 0 --deps 2>/dev/null || true
-        if [ -f /tmp/ship-safe-results.sarif ]; then
-          echo "sarif-file=/tmp/ship-safe-results.sarif" >> $GITHUB_OUTPUT
-        fi
-
     - name: Upload SARIF to GitHub Code Scanning
-      if: inputs.sarif == 'true' && hashFiles('/tmp/ship-safe-results.sarif') != ''
+      if: inputs.sarif == 'true' && steps.scan.outputs.sarif_file != ''
       uses: github/codeql-action/upload-sarif@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3
       with:
         sarif_file: /tmp/ship-safe-results.sarif
@@ -185,6 +203,8 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
+        SHIP_SAFE_THRESHOLD: ${{ inputs.threshold }}
+        SHIP_SAFE_FAIL_ON: ${{ inputs.fail-on }}
       run: |
         SCORE="${{ steps.scan.outputs.score }}"
         GRADE="${{ steps.scan.outputs.grade }}"
@@ -192,7 +212,11 @@ runs:
         SECRETS="${{ steps.scan.outputs.secrets }}"
         VULNS="${{ steps.scan.outputs.vulns }}"
         CVES="${{ steps.scan.outputs.cves }}"
-        THRESHOLD="${{ inputs.threshold }}"
+        if [ -n "$SHIP_SAFE_FAIL_ON" ]; then
+          GATE="severity: $SHIP_SAFE_FAIL_ON"
+        else
+          GATE="score threshold: $SHIP_SAFE_THRESHOLD"
+        fi
 
         # Grade emoji
         case "$GRADE" in
@@ -212,20 +236,20 @@ runs:
         | **Secrets** | $SECRETS |
         | **Code Vulns** | $VULNS |
         | **CVEs** | $CVES |
-        | **Threshold** | $THRESHOLD |
+        | **Gate** | $GATE |
 
         "
 
-        if [ "$SCORE" -ge "$THRESHOLD" ]; then
-          BODY="$BODY> ✅ **Passed** — score meets the threshold of $THRESHOLD"
+        if [ "${{ steps.scan.outputs.fail }}" = "0" ]; then
+          BODY="$BODY> ✅ **Passed** — the configured security gate passed"
         else
-          BODY="$BODY> ❌ **Failed** — score $SCORE is below threshold $THRESHOLD"
+          BODY="$BODY> ❌ **Failed** — the configured security gate did not pass"
         fi
 
         BODY="$BODY
 
         ---
-        <sub>🛡️ Scanned by [Ship Safe](https://shipsafe.dev) — Security toolkit for vibe coders</sub>"
+        <sub>🛡️ Scanned by [Ship Safe](https://shipsafe.sh) — Security toolkit for AI-generated and agentic code</sub>"
 
         # Find and update existing comment, or create new one
         PR_NUMBER="${{ github.event.pull_request.number }}"

--- a/cli/__tests__/action-contract.test.js
+++ b/cli/__tests__/action-contract.test.js
@@ -1,0 +1,26 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const ACTION = fs.readFileSync(path.join(ROOT, 'action.yml'), 'utf8');
+
+describe('GitHub Action contract', () => {
+  it('installs the version bundled with the action instead of latest', () => {
+    assert.match(ACTION, /GITHUB_ACTION_PATH.*package\.json/);
+    assert.match(ACTION, /npm install -g "ship-safe@\$VERSION"/);
+    assert.doesNotMatch(ACTION, /ship-safe@latest/);
+  });
+
+  it('generates SARIF during the primary scan', () => {
+    assert.match(ACTION, /--sarif \/tmp\/ship-safe-results\.sarif/);
+    assert.doesNotMatch(ACTION, /name: Generate SARIF/);
+    assert.match(ACTION, /steps\.scan\.outputs\.sarif_file/);
+  });
+
+  it('passes fail-on through to the CLI gate', () => {
+    assert.match(ACTION, /FLAGS\+=\(--fail-on "\$SHIP_SAFE_FAIL_ON"\)/);
+  });
+});

--- a/cli/__tests__/action-contract.test.js
+++ b/cli/__tests__/action-contract.test.js
@@ -23,4 +23,17 @@ describe('GitHub Action contract', () => {
   it('passes fail-on through to the CLI gate', () => {
     assert.match(ACTION, /FLAGS\+=\(--fail-on "\$SHIP_SAFE_FAIL_ON"\)/);
   });
+
+  it('fails closed for fork pull_request_target scans', () => {
+    assert.match(ACTION, /Protect fork pull_request_target scans/);
+    assert.match(ACTION, /github\.event_name == 'pull_request_target'/);
+    assert.match(ACTION, /Use pull_request instead/);
+  });
+
+  it('offers opt-in inline PR comments through ci', () => {
+    assert.match(ACTION, /inline:/);
+    assert.match(ACTION, /SHIP_SAFE_INLINE/);
+    assert.match(ACTION, /GITHUB_EVENT_NAME.*pull_request/);
+    assert.match(ACTION, /FLAGS\+=\(--github-inline\)/);
+  });
 });

--- a/cli/__tests__/ci-gate.test.js
+++ b/cli/__tests__/ci-gate.test.js
@@ -86,4 +86,17 @@ describe('ci gate', () => {
       assert.match(res.stdout, /threshold/);
     } finally { cleanup(dir); }
   });
+
+  it('--json emits one machine-readable line for CI integrations', () => {
+    const dir = project(CLEAN);
+    try {
+      const res = run(dir, '--json');
+      assert.equal(res.status, 0, `expected pass\n${res.stdout}${res.stderr}`);
+      const lines = res.stdout.trim().split('\n').filter(Boolean);
+      assert.equal(lines.length, 1, `expected one JSON line, got ${lines.length}`);
+      const report = JSON.parse(lines[0]);
+      assert.equal(report.totalFindings, 0);
+      assert.equal(report.pass, true);
+    } finally { cleanup(dir); }
+  });
 });

--- a/cli/__tests__/finding-fingerprint.test.js
+++ b/cli/__tests__/finding-fingerprint.test.js
@@ -1,0 +1,30 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { findingFingerprint, fingerprintMarker, extractFingerprint } from '../utils/finding-fingerprint.js';
+
+const ROOT = '/tmp/project';
+
+describe('finding fingerprints', () => {
+  it('stays stable when line numbers change', () => {
+    const base = { file: '/tmp/project/src/app.js', line: 4, rule: 'SHELL_INJECTION', title: 'Shell injection', matched: 'exec(userInput)' };
+    assert.equal(
+      findingFingerprint(base, ROOT),
+      findingFingerprint({ ...base, line: 88 }, ROOT),
+    );
+  });
+
+  it('changes when the rule, file, or matched code changes', () => {
+    const base = { file: '/tmp/project/src/app.js', rule: 'RULE_A', title: 'Issue', matched: 'value' };
+    const fingerprint = findingFingerprint(base, ROOT);
+    assert.notEqual(fingerprint, findingFingerprint({ ...base, rule: 'RULE_B' }, ROOT));
+    assert.notEqual(fingerprint, findingFingerprint({ ...base, file: '/tmp/project/src/other.js' }, ROOT));
+    assert.notEqual(fingerprint, findingFingerprint({ ...base, matched: 'other' }, ROOT));
+  });
+
+  it('round-trips the hidden GitHub comment marker', () => {
+    const fingerprint = 'v1-0123456789abcdef';
+    const body = `${fingerprintMarker(fingerprint)}\n**Finding**`;
+    assert.equal(extractFingerprint(body), fingerprint);
+    assert.equal(extractFingerprint('ordinary comment'), null);
+  });
+});

--- a/cli/bin/ship-safe.js
+++ b/cli/bin/ship-safe.js
@@ -463,6 +463,7 @@ program
   .option('--no-deps', 'Skip dependency audit')
   .option('--baseline', 'Only check new findings (not in baseline)')
   .option('--github-pr', 'Post findings as a GitHub PR comment (requires gh CLI)')
+  .option('--github-inline', 'Post critical/high findings as deduplicated inline PR comments (requires gh CLI)')
   .action(ciCommand);
 
 // -----------------------------------------------------------------------------

--- a/cli/commands/ci.js
+++ b/cli/commands/ci.js
@@ -49,6 +49,7 @@ import {
 } from '../utils/patterns.js';
 import { projectFindings } from '../agents/base-agent.js';
 import { isHighEntropyMatch, getConfidence } from '../utils/entropy.js';
+import { postPRComments } from './watch.js';
 import fg from 'fast-glob';
 
 // =============================================================================
@@ -205,6 +206,16 @@ export async function ciCommand(targetPath = '.', options = {}) {
       postPRComment(scoreResult, allFindings, depVulns, absolutePath, duration);
     } catch (err) {
       console.log(`[ship-safe] Warning: Could not post PR comment: ${err.message}`);
+    }
+  }
+
+  // Inline comments are opt-in because they require pull request write
+  // permission and should never be enabled accidentally on untrusted events.
+  if (options.githubInline) {
+    try {
+      await postPRComments(projectFindings(allFindings), absolutePath, 'ci');
+    } catch (err) {
+      console.log(`[ship-safe] Warning: Could not post inline PR comments: ${err.message}`);
     }
   }
 

--- a/cli/commands/ci.js
+++ b/cli/commands/ci.js
@@ -173,10 +173,11 @@ export async function ciCommand(targetPath = '.', options = {}) {
       high: allFindings.filter(f => f.severity === 'high').length,
       medium: allFindings.filter(f => f.severity === 'medium').length,
       low: allFindings.filter(f => f.severity === 'low').length,
+      findings: projectFindings(allFindings),
       threshold,
       pass: determinePass(scoreResult, allFindings, threshold, failOn),
       duration: `${duration}s`,
-    }, null, 2));
+      }));
   } else {
     // ── Compact CI Summary ───────────────────────────────────────────────
     const critical = allFindings.filter(f => f.severity === 'critical').length;

--- a/cli/commands/watch.js
+++ b/cli/commands/watch.js
@@ -637,7 +637,7 @@ async function postSlackAlert(webhookUrl, findings, scoreResult, rootPath) {
  *
  * Posts a review comment for each critical/high finding in a changed file.
  */
-async function postPRComments(findings, rootPath) {
+export async function postPRComments(findings, rootPath, source = 'watch') {
   // Check if gh is available
   try {
     execFileSync('gh', ['--version'], { stdio: 'pipe' });
@@ -702,7 +702,7 @@ async function postPRComments(findings, rootPath) {
       '',
       f.remediation ? `**Fix:** ${f.remediation}` : '',
       '',
-      `_[${f.rule}] — detected by ship-safe watch_`,
+      `_[${f.rule}] — detected by ship-safe ${source}_`,
     ].filter(l => l !== undefined).join('\n');
 
     try {

--- a/cli/commands/watch.js
+++ b/cli/commands/watch.js
@@ -14,6 +14,7 @@ import fs from 'fs';
 import path from 'path';
 import chalk from 'chalk';
 import { execFileSync } from 'child_process';
+import { findingFingerprint, fingerprintMarker, extractFingerprint } from '../utils/finding-fingerprint.js';
 import { SKIP_DIRS, SKIP_EXTENSIONS, SKIP_FILENAMES, SECRET_PATTERNS, SECURITY_PATTERNS } from '../utils/patterns.js';
 import { isHighEntropyMatch, getConfidence } from '../utils/entropy.js';
 import * as output from '../utils/output.js';
@@ -666,13 +667,34 @@ async function postPRComments(findings, rootPath) {
     return;
   }
 
+  // Review comments survive reruns, so use a hidden marker rather than the
+  // rendered text to keep repeated watch scans idempotent.
+  const existingFingerprints = new Set();
+  try {
+    const commentsJson = execFileSync('gh', [
+      'api', `repos/{owner}/{repo}/pulls/${prNumber}/comments`,
+      '--paginate', '--slurp',
+    ], { cwd: rootPath, encoding: 'utf-8', stdio: 'pipe' });
+    const pages = JSON.parse(commentsJson || '[]');
+    for (const comment of pages.flat()) {
+      const fingerprint = extractFingerprint(comment.body);
+      if (fingerprint) existingFingerprints.add(fingerprint);
+    }
+  } catch {
+    // If the lookup fails, continue with posting. A failed dedup lookup must
+    // never prevent a security alert from being delivered.
+  }
+
   const criticalOrHigh = findings.filter(f =>
     (f.severity === 'critical' || f.severity === 'high') && f.file && f.line
   ).slice(0, 10); // Max 10 comments per scan
 
   for (const f of criticalOrHigh) {
     const relFile = path.relative(rootPath, f.file).replace(/\\/g, '/');
+    const fingerprint = findingFingerprint(f, rootPath);
+    if (existingFingerprints.has(fingerprint)) continue;
     const body = [
+      fingerprintMarker(fingerprint),
       `**Ship Safe — ${f.severity.toUpperCase()} finding**`,
       '',
       `**${f.title}**`,
@@ -694,6 +716,7 @@ async function postPRComments(findings, rootPath) {
         '--field', `line=${f.line}`,
         '--field', 'side=RIGHT',
       ], { cwd: rootPath, stdio: 'pipe' });
+      existingFingerprints.add(fingerprint);
     } catch { /* individual comment failure is non-fatal */ }
   }
 

--- a/cli/utils/finding-fingerprint.js
+++ b/cli/utils/finding-fingerprint.js
@@ -1,0 +1,28 @@
+import crypto from 'crypto';
+import path from 'path';
+
+/**
+ * Return a stable identifier for a finding.
+ *
+ * Line numbers and scan order are intentionally excluded so a harmless edit
+ * above a finding does not create a second GitHub review comment.
+ */
+export function findingFingerprint(finding, rootPath = process.cwd()) {
+  const relFile = path.relative(rootPath, finding?.file || '').replace(/\\/g, '/');
+  const canonical = [
+    finding?.rule || 'unknown-rule',
+    relFile,
+    finding?.title || '',
+    finding?.matched || '',
+  ].join('|');
+
+  return `v1-${crypto.createHash('sha256').update(canonical).digest('hex').slice(0, 16)}`;
+}
+
+export function fingerprintMarker(fingerprint) {
+  return `<!-- ship-safe:fingerprint=${fingerprint} -->`;
+}
+
+export function extractFingerprint(body = '') {
+  return String(body).match(/ship-safe:fingerprint=([a-z0-9-]+)/i)?.[1] || null;
+}


### PR DESCRIPTION
## Summary
- install the action's bundled Ship Safe version instead of `latest`
- make CI JSON machine-readable and include findings for downstream gates
- generate SARIF during the primary scan and wire action outputs correctly
- honor severity gates, dependency toggles, baselines, and safe input passing

## Verification
- `npm test`
- `npm run lint`
- `npm audit --audit-level=high`
- `npm pack --dry-run`

This is the first slice of the PR review foundation: reliable, reproducible CI output before adding inline PR findings.