### PR TITLE
release: v9.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [9.7.4] - 2026-08-09
+
+### Added
+- **Inline GitHub PR findings** — `ship-safe ci --github-inline` can post
+  critical and high findings directly on changed lines, with stable
+  fingerprints that prevent duplicate comments on reruns.
+- **Safer GitHub Action defaults** — the Action can opt into inline comments
+  with `inline: true` and refuses fork `pull_request_target` scans that could
+  execute untrusted checkout content with privileged context.
+
+### Fixed
+- GitHub Action CI output now uses the bundled Ship Safe version, preserves
+  the configured severity gate, and produces SARIF from the primary scan.
+
 ## [9.7.3] - 2026-08-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -200,6 +200,37 @@ jobs:
 
 A GitLab CI version is in [docs/examples/gitlab-security-workflow.yml](docs/examples/gitlab-security-workflow.yml).
 
+### GitHub Action with inline PR findings
+
+Use the Action from a `pull_request` workflow when you want critical and high
+findings attached to the changed lines. Keep `pull_request_target` out of this
+path for forked contributions: Ship Safe refuses that privileged combination
+because the checkout may contain untrusted code.
+
+```yaml
+name: Ship Safe
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+  security-events: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: asamassekou10/ship-safe@v9.7.4
+        with:
+          fail-on: high
+          inline: true
+```
+
+Inline comments are opt-in and only post critical/high findings. Re-running
+the job updates the summary without creating duplicate inline comments.
+
 ---
 
 ## LLM Support

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ship-safe",
-  "version": "9.7.3",
+  "version": "9.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ship-safe",
-      "version": "9.7.3",
+      "version": "9.7.4",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-safe",
-  "version": "9.7.3",
+  "version": "9.7.4",
   "description": "AI-powered multi-agent security platform. 29 agents scan 80+ attack classes including AI integration supply chain (Vercel-class attacks), Hermes Agent deployment scanning (ASI-01–ASI-10), tool registry poisoning, function-call injection, skill permission drift, and agent attestation.",
   "main": "cli/index.js",
   "bin": {


### PR DESCRIPTION
## Release v9.7.4

- Add safe inline GitHub PR findings with stable deduplication
- Refuse fork `pull_request_target` scans with privileged context
- Document the GitHub Action setup and inline review flow
- Align package metadata and changelog at `9.7.4`

## Verification
- 467 tests pass
- `npm run lint` passes with existing warnings only
- `npm audit --audit-level=high` reports 0 vulnerabilities
- `npm pack --dry-run` verified package contents

Publishing is intentionally held until this release PR is reviewed.