### PR TITLE
Add regression test confirming AGENT_CHAIN_NO_ISOLATION stays quiet

### DIFF
--- a/cli/__tests__/absence-rules.test.js
+++ b/cli/__tests__/absence-rules.test.js
@@ -79,6 +79,10 @@ describe('absence rules stay quiet when the mitigation is present', async () => 
   it('MCP_REMOTE_UNPINNED: version pinned on the entry', () =>
     quiet(MCPSecurityAgent, 'MCP_REMOTE_UNPINNED',
       'const mcpServers = {\n  docs: { command: "npx mcp-docs", version: "1.4.2" }\n};\n'));
+
+  it('AGENT_CHAIN_NO_ISOLATION: permission scoped between chained steps', () =>
+    quiet(AgenticSecurityAgent, 'AGENT_CHAIN_NO_ISOLATION',
+      'const chain = orchestrateAgents([agent, step], { permission: "scoped", isolat: true });'));
 });
 
 describe('install docs are judged by whose host they point at', async () => {


### PR DESCRIPTION
Adds the quiet-when-mitigated regression for AGENT_CHAIN_NO_ISOLATION per #106's fragile-rules list, following the pattern from #109/#134.

Worth flagging: this rule's regex can misfire two ways, not just the variable-length-gap shape described in #106. The greedy (?:agent|step|task) alternation has no word boundary, so it can consume a substring match inside the mitigation text itself — e.g. matching "step" out of "per-step" — leaving nothing left for the negative lookahead to find. First test attempt actually tripped this and failed for real, which is how it surfaced. Worth keeping in mind for any other rules using this alternation pattern.

Test-only change, all 12 absence-rule regressions pass locally.