### PR TITLE
Add regression test confirming PII_NO_ENCRYPTION_AT_REST stays quiet

### DIFF
--- a/cli/__tests__/absence-rules.test.js
+++ b/cli/__tests__/absence-rules.test.js
@@ -83,6 +83,10 @@ describe('absence rules stay quiet when the mitigation is present', async () => 
   it('AGENT_CHAIN_NO_ISOLATION: permission scoped between chained steps', () =>
     quiet(AgenticSecurityAgent, 'AGENT_CHAIN_NO_ISOLATION',
       'const chain = orchestrateAgents([agent, step], { permission: "scoped", isolat: true });'));
+
+  it('PII_NO_ENCRYPTION_AT_REST: encryption annotation present on the column', () =>
+    quiet(PIIComplianceAgent, 'PII_NO_ENCRYPTION_AT_REST',
+      'CREATE TABLE users (ssn VARCHAR(11) ENCRYPTED);'));
 });
 
 describe('install docs are judged by whose host they point at', async () => {


### PR DESCRIPTION
Probed against #106's 'fragile, not broken' list. Checked this rule against both known failure shapes: the classic variable-length-gap-before-lookahead (AGENT_NO_AUDIT_LOG) and the substring-consumption trap found in #144 and tracked separately in #145, where a greedy alternation can eat a trigger-like substring out of the mitigation text itself.

Neither reproduces here. The negative lookahead is anchored directly after the type-keyword match with no floating gap before it, and a recurring generic trigger ('column') doesn't degrade detection the way AGENT_NO_AUDIT_LOG's did, since the PII field-name alternation (ssn, credit_card, etc.) is specific enough not to match everywhere.

Separately: found that an unrelated nearby mention of 'encrypt' (e.g. a TODO comment) can silence a genuinely unmitigated column, since the lookahead has no way to distinguish a real encryption annotation from incidental text. This is a false-negative risk, not the false-positive class #106/#145 cover, and looks like the accepted 'generous mitigation' tradeoff the project already documents rather than a new bug. Flagging here rather than opening a separate issue -- leaving it to a maintainer to decide if it warrants its own tracking.

Added the quiet-when-mitigated regression per the pattern in absence-rules.test.js (#109/#134/#144).

test-only change, all 12 absence-rule regressions pass.