### PR TITLE
fix: flush large CI JSON output before exit

### DIFF
--- a/cli/__tests__/ci-json-output.test.js
+++ b/cli/__tests__/ci-json-output.test.js
@@ -10,7 +10,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 
 describe('ci JSON output', () => {
   it('emits parseable JSON for a large finding set', () => {
@@ -45,6 +45,54 @@ describe('ci JSON output', () => {
       assert.equal(report.totalFindings, report.findings.length);
       assert.ok(report.totalFindings >= 1800,
         `expected all generated findings, got ${report.totalFindings}`);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails instead of hanging when stdout is not drained', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-ci-json-stalled-'));
+    const cli = path.resolve('cli/bin/ship-safe.js');
+
+    try {
+      for (let i = 0; i < 180; i++) {
+        fs.writeFileSync(path.join(dir, `generated-${i}.js`),
+          Array.from({ length: 10 }, (_, line) => `eval(userInput${i}_${line});`).join('\n'));
+      }
+
+      const child = spawn(process.execPath, [
+        cli, 'ci', dir, '--json', '--threshold', '0', '--no-deps',
+      ], {
+        cwd: path.resolve('.'),
+        env: {
+          ...process.env,
+          NO_COLOR: '1',
+          SHIP_SAFE_STDOUT_TIMEOUT_MS: '100',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      // Intentionally leave child.stdout unread to model a stalled CI collector.
+      const stderr = [];
+      child.stderr.setEncoding('utf8');
+      child.stderr.on('data', (chunk) => stderr.push(chunk));
+
+      const result = await new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          child.kill('SIGKILL');
+          reject(new Error('ci command hung with a stalled stdout consumer'));
+        }, 5_000);
+
+        child.once('error', reject);
+        child.once('exit', (code, signal) => {
+          clearTimeout(timer);
+          resolve({ code, signal });
+        });
+      });
+
+      assert.equal(result.signal, null);
+      assert.equal(result.code, 1);
+      assert.match(stderr.join(''), /Timed out writing JSON output to stdout/);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/cli/__tests__/ci-json-output.test.js
+++ b/cli/__tests__/ci-json-output.test.js
@@ -1,0 +1,52 @@
+/**
+ * CI JSON transport regression.
+ *
+ * `ci --json` is consumed by benchmark runners and automation, so the child
+ * process must not exit while a large stdout write is still buffered.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+describe('ci JSON output', () => {
+  it('emits parseable JSON for a large finding set', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-ci-json-'));
+    const file = path.join(dir, 'generated-findings.js');
+    const cli = path.resolve('cli/bin/ship-safe.js');
+
+    try {
+      // Spread findings across files so the scanner exercises a large report
+      // without making one file's context analysis quadratic.
+      fs.rmSync(file, { force: true });
+      for (let i = 0; i < 180; i++) {
+        fs.writeFileSync(path.join(dir, `generated-${i}.js`),
+          Array.from({ length: 10 }, (_, line) => `eval(userInput${i}_${line});`).join('\n'));
+      }
+
+      const result = spawnSync(process.execPath, [
+        cli, 'ci', dir, '--json', '--threshold', '0', '--no-deps',
+      ], {
+        cwd: path.resolve('.'),
+        encoding: 'utf8',
+        maxBuffer: 64 * 1024 * 1024,
+        env: { ...process.env, NO_COLOR: '1' },
+      });
+
+      assert.equal(result.error, undefined, result.error?.message);
+      assert.equal(result.status, 0, result.stderr);
+      assert.ok(result.stdout.length > 1024 * 1024,
+        `expected a large JSON payload, got ${result.stdout.length} bytes`);
+
+      const report = JSON.parse(result.stdout);
+      assert.equal(report.totalFindings, report.findings.length);
+      assert.ok(report.totalFindings >= 1800,
+        `expected all generated findings, got ${report.totalFindings}`);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/commands/ci.js
+++ b/cli/commands/ci.js
@@ -165,7 +165,10 @@ export async function ciCommand(targetPath = '.', options = {}) {
 
   // ── JSON Output ──────────────────────────────────────────────────────────
   if (options.json) {
-    console.log(JSON.stringify({
+    // A large report can be buffered by stdout. Wait for the write callback
+    // before the command's forced exit, otherwise CI consumers may receive a
+    // truncated JSON document.
+    await writeStdout(`${JSON.stringify({
       score: scoreResult.score,
       grade: scoreResult.grade.letter,
       totalFindings: allFindings.length,
@@ -178,7 +181,7 @@ export async function ciCommand(targetPath = '.', options = {}) {
       threshold,
       pass: determinePass(scoreResult, allFindings, threshold, failOn),
       duration: `${duration}s`,
-      }));
+      })}\n`);
   } else {
     // ── Compact CI Summary ───────────────────────────────────────────────
     const critical = allFindings.filter(f => f.severity === 'critical').length;
@@ -239,6 +242,12 @@ export async function ciCommand(targetPath = '.', options = {}) {
     }
     process.exit(0);
   }
+}
+
+function writeStdout(value) {
+  return new Promise((resolve, reject) => {
+    process.stdout.write(value, (error) => error ? reject(error) : resolve());
+  });
 }
 
 // =============================================================================

--- a/cli/commands/ci.js
+++ b/cli/commands/ci.js
@@ -52,6 +52,12 @@ import { isHighEntropyMatch, getConfidence } from '../utils/entropy.js';
 import { postPRComments } from './watch.js';
 import fg from 'fast-glob';
 
+const DEFAULT_STDOUT_WRITE_TIMEOUT_MS = 10_000;
+const configuredStdoutWriteTimeout = Number.parseInt(process.env.SHIP_SAFE_STDOUT_TIMEOUT_MS, 10);
+const STDOUT_WRITE_TIMEOUT_MS = Number.isInteger(configuredStdoutWriteTimeout) && configuredStdoutWriteTimeout > 0
+  ? configuredStdoutWriteTimeout
+  : DEFAULT_STDOUT_WRITE_TIMEOUT_MS;
+
 // =============================================================================
 // MAIN COMMAND
 // =============================================================================
@@ -168,20 +174,30 @@ export async function ciCommand(targetPath = '.', options = {}) {
     // A large report can be buffered by stdout. Wait for the write callback
     // before the command's forced exit, otherwise CI consumers may receive a
     // truncated JSON document.
-    await writeStdout(`${JSON.stringify({
-      score: scoreResult.score,
-      grade: scoreResult.grade.letter,
-      totalFindings: allFindings.length,
-      totalDepVulns: depVulns.length,
-      critical: allFindings.filter(f => f.severity === 'critical').length,
-      high: allFindings.filter(f => f.severity === 'high').length,
-      medium: allFindings.filter(f => f.severity === 'medium').length,
-      low: allFindings.filter(f => f.severity === 'low').length,
-      findings: projectFindings(allFindings),
-      threshold,
-      pass: determinePass(scoreResult, allFindings, threshold, failOn),
-      duration: `${duration}s`,
-      })}\n`);
+    try {
+      await writeStdout(`${JSON.stringify({
+        score: scoreResult.score,
+        grade: scoreResult.grade.letter,
+        totalFindings: allFindings.length,
+        totalDepVulns: depVulns.length,
+        critical: allFindings.filter(f => f.severity === 'critical').length,
+        high: allFindings.filter(f => f.severity === 'high').length,
+        medium: allFindings.filter(f => f.severity === 'medium').length,
+        low: allFindings.filter(f => f.severity === 'low').length,
+        findings: projectFindings(allFindings),
+        threshold,
+        pass: determinePass(scoreResult, allFindings, threshold, failOn),
+        duration: `${duration}s`,
+        })}\n`);
+    } catch (error) {
+      const message = error.code === 'SHIP_SAFE_STDOUT_TIMEOUT'
+        ? `Timed out writing JSON output to stdout after ${STDOUT_WRITE_TIMEOUT_MS}ms; the downstream consumer may not be reading.`
+        : `Could not write JSON output to stdout: ${error.message}`;
+      console.error(`[ship-safe] ${message}`);
+      // The report cannot be delivered once stdout is stalled or broken. Exit
+      // immediately so a blocked stream cannot keep the CI process alive.
+      process.exit(1);
+    }
   } else {
     // ── Compact CI Summary ───────────────────────────────────────────────
     const critical = allFindings.filter(f => f.severity === 'critical').length;
@@ -246,7 +262,28 @@ export async function ciCommand(targetPath = '.', options = {}) {
 
 function writeStdout(value) {
   return new Promise((resolve, reject) => {
-    process.stdout.write(value, (error) => error ? reject(error) : resolve());
+    let settled = false;
+    function finish(error) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      error ? reject(error) : resolve();
+    }
+
+    const timer = setTimeout(() => {
+      const error = new Error('stdout write timed out');
+      error.code = 'SHIP_SAFE_STDOUT_TIMEOUT';
+      finish(error);
+      // A live pipe that is no longer being read can keep the write callback
+      // pending forever. Close it after the bound so CI can fail cleanly.
+      process.stdout.destroy();
+    }, STDOUT_WRITE_TIMEOUT_MS);
+
+    try {
+      process.stdout.write(value, finish);
+    } catch (error) {
+      finish(error);
+    }
   });
 }
 


### PR DESCRIPTION
## Summary

Large CI reports can be truncated when the process exits before the JSON write has finished. Downstream consumers then receive invalid JSON and fail with `Unexpected end of JSON input`.

This change waits for the `stdout` write callback before completing JSON mode and adds a regression test that generates and parses a report larger than 1 MB.

## Why this matters

- Keeps `ship-safe ci --json` machine-readable for large repositories.
- Removes an intermittent failure in CI integrations and benchmark tooling.
- Preserves the existing report schema and exit behavior.

## Validation

- `node --test cli/__tests__/ci-json-output.test.js`
- `npm test`
- `npm run lint`
- `node benchmarks/false-positives/run.mjs`

Fixes #147.