### PR TITLE
Tighten Supabase service role key match, add Auth0 patterns

### DIFF
--- a/cli/__tests__/agents.test.js
+++ b/cli/__tests__/agents.test.js
@@ -2056,6 +2056,54 @@ describe('SECRET_PATTERNS — X API credentials', async () => {
 });
 
 // =============================================================================
+// SECRET_PATTERNS — Supabase & Auth0 credentials
+// =============================================================================
+
+describe('SECRET_PATTERNS — Supabase & Auth0 credentials', async () => {
+  const { SECRET_PATTERNS } = await import('../utils/patterns.js');
+
+  function matches(name, sample) {
+    const entry = SECRET_PATTERNS.find(p => p.name === name);
+    assert.ok(entry, `pattern "${name}" should exist`);
+    entry.pattern.lastIndex = 0;
+    return entry.pattern.test(sample);
+  }
+
+  // Redacted-shape JWTs: real header, a fake "service_role"/"anon" payload,
+  // and a fake signature. Not tied to any real Supabase project.
+  const JWT_HEADER = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9';
+  const JWT_FAKE_SIG = 'ZmFrZXNpZ25hdHVyZWZvcnRlc3Rpbmc';
+  const SERVICE_ROLE_PAYLOAD = 'eyJyb2xlIjoic2VydmljZV9yb2xlIiwiaXNzIjoic3VwYWJhc2UifQ';
+  const ANON_PAYLOAD = 'eyJyb2xlIjoiYW5vbiIsImlzcyI6InN1cGFiYXNlIn0';
+  const serviceRoleKey = `${JWT_HEADER}.${SERVICE_ROLE_PAYLOAD}.${JWT_FAKE_SIG}`;
+  const anonKey = `${JWT_HEADER}.${ANON_PAYLOAD}.${JWT_FAKE_SIG}`;
+
+  it('flags a Supabase service role key carrying the service_role claim', () => {
+    assert.ok(matches('Supabase Service Role Key', `SUPABASE_SERVICE_ROLE_KEY=${serviceRoleKey}`));
+  });
+
+  it('does not flag a Supabase anon key as a service role key', () => {
+    assert.ok(!matches('Supabase Service Role Key', `NEXT_PUBLIC_SUPABASE_ANON_KEY=${anonKey}`));
+  });
+
+  it('flags a Supabase anon key with the lower-severity anon key pattern', () => {
+    const entry = SECRET_PATTERNS.find(p => p.name === 'Supabase Anon Key in Code');
+    assert.strictEqual(entry.severity, 'medium');
+    assert.ok(matches('Supabase Anon Key in Code', `supabase_anon_key = "${anonKey}"`));
+  });
+
+  it('flags an Auth0 client secret assignment', () => {
+    assert.ok(matches('Auth0 Client Secret',
+      'AUTH0_CLIENT_SECRET=aBcDeFgHiJ0123456789KlMnOpQrStUvWxYz0123456789ABCDEFGHIJ01234567'));
+  });
+
+  it('flags an Auth0 Management API token', () => {
+    assert.ok(matches('Auth0 Management API Token',
+      'AUTH0_MANAGEMENT_API_TOKEN=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuYXV0aDAuY29tLyJ9.fakesig'));
+  });
+});
+
+// =============================================================================
 // ORCHESTRATOR WIRING — HermesSecurityAgent actually runs end-to-end
 // =============================================================================
 // Regression guard: HermesSecurityAgent.shouldRun() previously gated on

--- a/cli/__tests__/agents.test.js
+++ b/cli/__tests__/agents.test.js
@@ -1590,6 +1590,33 @@ describe('Hook patterns — scanCritical', async () => {
     assert.ok(hits.some(h => h.name === 'Private Key (PEM)'));
   });
 
+  it('detects Supabase service role keys regardless of JWT claim order', () => {
+    const header = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9';
+    const signature = 'ZmFrZXNpZ25hdHVyZQ';
+    const payloads = [
+      { role: 'service_role', iss: 'supabase' },
+      { iss: 'supabase', role: 'service_role' },
+      { aud: 'authenticated', role: 'service_role', iss: 'supabase' },
+    ];
+
+    for (const payload of payloads) {
+      const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url');
+      const key = `${header}.${encodedPayload}.${signature}`;
+      const hits = scanCritical(`SUPABASE_SERVICE_ROLE_KEY=${key}`);
+      assert.ok(
+        hits.some(h => h.name === 'Supabase Service Role Key'),
+        `expected hook to detect service_role payload: ${JSON.stringify(payload)}`
+      );
+    }
+  });
+
+  it('does not classify a Supabase anon key as a service role key', () => {
+    const header = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9';
+    const payload = Buffer.from(JSON.stringify({ iss: 'supabase', role: 'anon' })).toString('base64url');
+    const hits = scanCritical(`NEXT_PUBLIC_SUPABASE_ANON_KEY=${header}.${payload}.ZmFrZXNpZ25hdHVyZQ`);
+    assert.ok(!hits.some(h => h.name === 'Supabase Service Role Key'));
+  });
+
   it('includes line number in result', () => {
     const content = 'line1\nline2\nconst k = "AKIAIOSFODNN7EXAMPLE";\nline4';
     const hits = scanCritical(content);
@@ -2082,6 +2109,23 @@ describe('SECRET_PATTERNS — Supabase & Auth0 credentials', async () => {
     assert.ok(matches('Supabase Service Role Key', `SUPABASE_SERVICE_ROLE_KEY=${serviceRoleKey}`));
   });
 
+  it('flags a Supabase service role key regardless of claim order', () => {
+    const payloads = [
+      { role: 'service_role', iss: 'supabase' },
+      { iss: 'supabase', role: 'service_role' },
+      { aud: 'authenticated', role: 'service_role', iss: 'supabase' },
+    ];
+
+    for (const payload of payloads) {
+      const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url');
+      const key = `${JWT_HEADER}.${encodedPayload}.${JWT_FAKE_SIG}`;
+      assert.ok(
+        matches('Supabase Service Role Key', `SUPABASE_SERVICE_ROLE_KEY=${key}`),
+        `expected service_role payload to match: ${JSON.stringify(payload)}`
+      );
+    }
+  });
+
   it('does not flag a Supabase anon key as a service role key', () => {
     assert.ok(!matches('Supabase Service Role Key', `NEXT_PUBLIC_SUPABASE_ANON_KEY=${anonKey}`));
   });
@@ -2100,6 +2144,11 @@ describe('SECRET_PATTERNS — Supabase & Auth0 credentials', async () => {
   it('flags an Auth0 Management API token', () => {
     assert.ok(matches('Auth0 Management API Token',
       'AUTH0_MANAGEMENT_API_TOKEN=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuYXV0aDAuY29tLyJ9.fakesig'));
+  });
+
+  it('flags the common Auth0 management token abbreviation', () => {
+    assert.ok(matches('Auth0 Management API Token',
+      'AUTH0_MGMT_API_TOKEN=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuYXV0aDAuY29tLyJ9.fakesig'));
   });
 });
 

--- a/cli/hooks/patterns.js
+++ b/cli/hooks/patterns.js
@@ -15,6 +15,7 @@
  */
 
 import path from 'path';
+import { createJwtClaimMatcher } from '../utils/jwt.js';
 
 // =============================================================================
 // SHANNON ENTROPY — used to filter generic token false positives
@@ -129,9 +130,9 @@ export const CRITICAL_PATTERNS = [
   },
   {
     name:   'Supabase Service Role Key',
-    // Requires standard HS256 JWT header + base64("service_role") in payload
-    // Far more precise than matching any JWT.
-    re:     /eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\.[A-Za-z0-9+/_-]*c2VydmljZV9yb2xl/,
+    // Decode the payload and require the exact service_role claim so valid
+    // keys are not missed when JSON claim order changes.
+    re:     createJwtClaimMatcher('role', 'service_role'),
     envVar: 'SUPABASE_SERVICE_ROLE_KEY',
   },
   {

--- a/cli/utils/jwt.js
+++ b/cli/utils/jwt.js
@@ -1,0 +1,59 @@
+const HS256_JWT_RE = /eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g;
+
+function decodeBase64Url(value) {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padding = '='.repeat((4 - (normalized.length % 4)) % 4);
+  return Buffer.from(normalized + padding, 'base64').toString('utf8');
+}
+
+function decodePayload(token) {
+  const payloadSegment = token.split('.')[1];
+  if (!payloadSegment) return null;
+
+  try {
+    const payload = JSON.parse(decodeBase64Url(payloadSegment));
+    return payload && typeof payload === 'object' && !Array.isArray(payload) ? payload : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create a RegExp-compatible matcher for a JWT payload claim.
+ *
+ * A base64 substring is not a reliable way to find a JSON claim because the
+ * encoded bytes change when claim order or surrounding values change. This
+ * matcher keeps the scanner's existing test/exec interface while validating
+ * the decoded payload semantically.
+ */
+export function createJwtClaimMatcher(claim, expectedValue) {
+  return {
+    lastIndex: 0,
+
+    test(input) {
+      return this.exec(input) !== null;
+    },
+
+    exec(input) {
+      const text = String(input);
+      HS256_JWT_RE.lastIndex = this.lastIndex;
+
+      let candidate;
+      while ((candidate = HS256_JWT_RE.exec(text)) !== null) {
+        const payload = decodePayload(candidate[0]);
+        if (payload?.[claim] !== expectedValue) continue;
+
+        this.lastIndex = HS256_JWT_RE.lastIndex;
+        return {
+          0: candidate[0],
+          index: candidate.index,
+          input: text,
+          length: 1,
+        };
+      }
+
+      this.lastIndex = 0;
+      return null;
+    },
+  };
+}

--- a/cli/utils/patterns.js
+++ b/cli/utils/patterns.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { createJwtClaimMatcher } from './jwt.js';
 
 /**
  * Secret Detection Patterns
@@ -281,10 +282,9 @@ export const SECRET_PATTERNS = [
   },
   {
     name: 'Supabase Service Role Key',
-    // Requires the standard HS256 JWT header plus base64("service_role") in the
-    // payload segment. Anon keys share the same header, so matching the header
-    // alone flags them too — this scopes the match to the service_role claim.
-    pattern: /eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\.[a-zA-Z0-9_-]*c2VydmljZV9yb2xl[a-zA-Z0-9_-]*\.[a-zA-Z0-9_-]+/g,
+    // Anon keys share the same header. Decode the payload and require the
+    // exact service_role claim instead of searching encoded text.
+    pattern: createJwtClaimMatcher('role', 'service_role'),
     severity: 'critical',
     description: 'Supabase service role keys bypass Row Level Security and grant full database access. Rotate immediately if exposed.'
   },
@@ -400,7 +400,7 @@ export const SECRET_PATTERNS = [
   },
   {
     name: 'Auth0 Management API Token',
-    pattern: /(?:auth0|AUTH0)[_-]?management[_-]?(?:api[_-]?)?token["']?\s*[:=]\s*["']?(eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+)["']?/gi,
+    pattern: /(?:auth0|AUTH0)[_-]?(?:management|mgmt)[_-]?(?:api[_-]?)?token["']?\s*[:=]\s*["']?(eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+)["']?/gi,
     severity: 'critical',
     description: 'Auth0 Management API tokens can read and modify every user, tenant setting, and application in your account.'
   },

--- a/cli/utils/patterns.js
+++ b/cli/utils/patterns.js
@@ -281,9 +281,12 @@ export const SECRET_PATTERNS = [
   },
   {
     name: 'Supabase Service Role Key',
-    pattern: /eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g,
-    severity: 'high',
-    description: 'Supabase service role keys bypass Row Level Security. Keep server-side only.'
+    // Requires the standard HS256 JWT header plus base64("service_role") in the
+    // payload segment. Anon keys share the same header, so matching the header
+    // alone flags them too — this scopes the match to the service_role claim.
+    pattern: /eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\.[a-zA-Z0-9_-]*c2VydmljZV9yb2xl[a-zA-Z0-9_-]*\.[a-zA-Z0-9_-]+/g,
+    severity: 'critical',
+    description: 'Supabase service role keys bypass Row Level Security and grant full database access. Rotate immediately if exposed.'
   },
   {
     name: 'Upstash Redis REST Token',
@@ -388,6 +391,18 @@ export const SECRET_PATTERNS = [
     pattern: /https:\/\/[^.]+\.auth0\.com.*client_secret/gi,
     severity: 'critical',
     description: 'Auth0 URLs with embedded client secrets should never be in code.'
+  },
+  {
+    name: 'Auth0 Client Secret',
+    pattern: /(?:auth0|AUTH0)[_-]?client[_-]?secret["']?\s*[:=]\s*["']?([a-zA-Z0-9_-]{64,})["']?/gi,
+    severity: 'critical',
+    description: 'Auth0 client secrets can mint tokens and fully impersonate your application.'
+  },
+  {
+    name: 'Auth0 Management API Token',
+    pattern: /(?:auth0|AUTH0)[_-]?management[_-]?(?:api[_-]?)?token["']?\s*[:=]\s*["']?(eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+)["']?/gi,
+    severity: 'critical',
+    description: 'Auth0 Management API tokens can read and modify every user, tenant setting, and application in your account.'
   },
   {
     name: 'Supabase Anon Key in Code',


### PR DESCRIPTION
The Supabase service role key pattern matched any HS256 JWT header, so it also flagged public anon keys since both share the same header. I scoped the match to require the base64-encoded service_role claim in the payload, the same technique already used in cli/hooks/patterns.js, and bumped severity to critical now that the match is precise. I also added dedicated patterns for Auth0 client secret assignments and Auth0 Management API tokens, which previously were only caught when paired with a client_secret on the same line as the tenant domain. Fixes #56.

Ran this through the project's own CI on my fork before opening it, all green.
