### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Ship Safe is MIT-licensed and free forever.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=asamassekou10/ship-safe&type=Date)](https://star-history.com/#asamassekou10/ship-safe&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=asamassekou10/ship-safe&type=Date)](https://star-history.dera.page/#asamassekou10/ship-safe&type=date)
 
 ---
 **Ship fast. Ship safe.** — [shipsafe.sh](https://shipsafe.sh)


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This switches it to the star-history.dera.page endpoint and updates the wrapping link to the hash-based URL format so the chart renders correctly again.