### PR TITLE
feat: detect fail-open Hermes adapter allowlists

### DIFF
--- a/cli/__tests__/hermes-adapter-allowlist.test.js
+++ b/cli/__tests__/hermes-adapter-allowlist.test.js
@@ -1,0 +1,119 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { HermesSecurityAgent } from '../agents/hermes-security-agent.js';
+
+function project(content, relativePath) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-hermes-adapter-'));
+  const file = path.join(dir, relativePath);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, content);
+  return { dir, file };
+}
+
+function cleanup(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+}
+
+async function scan(content, relativePath = 'plugins/platforms/telegram/adapter.py') {
+  const fixture = project(content, relativePath);
+  try {
+    return await new HermesSecurityAgent().analyze({
+      rootPath: fixture.dir,
+      files: [fixture.file],
+      recon: {},
+      options: {},
+    });
+  } finally {
+    cleanup(fixture.dir);
+  }
+}
+
+describe('Hermes network adapter allowlist boundary', () => {
+  it('detects an empty allowlist that falls through to agent dispatch', async () => {
+    const findings = await scan(`
+from hermes_agent.gateway import dispatch_agent
+
+class TelegramAdapter:
+    async def handle_message(self, message):
+        self.allowlist = self.config.get("allowlist", [])
+        if not self.allowlist:
+            return await dispatch_agent(message)
+        return await dispatch_agent(message)
+`);
+
+    const finding = findings.find((item) => item.rule === 'HERMES_ADAPTER_ALLOWLIST_FAIL_OPEN');
+    assert.ok(finding, 'expected a fail-open adapter finding');
+    assert.equal(finding.severity, 'critical');
+    assert.equal(finding.posture, 'boundary');
+  });
+
+  it('detects a session ID used as the only authorization gate', async () => {
+    const findings = await scan(`
+from hermes_agent.gateway import resolve_gateway_approval
+
+class WebhookAdapter:
+    async def resolve_approval(self, session_id, approval_id):
+        if session_id:
+            return await resolve_gateway_approval(session_id, approval_id)
+        return None
+`);
+
+    assert.ok(findings.some((item) => item.rule === 'HERMES_ADAPTER_ALLOWLIST_FAIL_OPEN'));
+  });
+
+  it('accepts an explicit non-empty allowlist with fail-closed rejection', async () => {
+    const findings = await scan(`
+from hermes_agent.gateway import dispatch_agent
+
+class TelegramAdapter:
+    async def handle_message(self, message, sender_id):
+        if not self.allowlist or sender_id not in self.allowlist:
+            raise PermissionError("sender is not allowed")
+        return await dispatch_agent(message)
+`);
+
+    assert.equal(
+      findings.filter((item) => item.rule === 'HERMES_ADAPTER_ALLOWLIST_FAIL_OPEN').length,
+      0,
+      'a fail-closed adapter should not be reported'
+    );
+  });
+
+  it('does not treat comments or docstrings as authorization evidence', async () => {
+    const findings = await scan(`
+from hermes_agent.gateway import dispatch_agent
+
+class TelegramAdapter:
+    async def handle_message(self, message):
+        """The allowlist must reject unauthorized senders with PermissionError."""
+        # allowlist and raise PermissionError are documented above, not enforced here.
+        return await dispatch_agent(message)
+`);
+
+    assert.ok(
+      findings.some((item) => item.rule === 'HERMES_ADAPTER_ALLOWLIST_FAIL_OPEN'),
+      'comments and docstrings must not suppress a missing authorization check'
+    );
+  });
+
+  it('does not treat ACP/local IPC as a network adapter boundary', async () => {
+    const findings = await scan(`
+from hermes_agent.acp_adapter import dispatch_agent
+
+class AcpAdapter:
+    async def handle_message(self, message, session_id):
+        if session_id:
+            return await dispatch_agent(message, session_id=session_id)
+        return None
+`, 'acp_adapter/permissions.py');
+
+    assert.equal(
+      findings.filter((item) => item.rule === 'HERMES_ADAPTER_ALLOWLIST_FAIL_OPEN').length,
+      0,
+      'ACP/local IPC is intentionally outside the network-adapter rule'
+    );
+  });
+});

--- a/cli/__tests__/hermes-posture.test.js
+++ b/cli/__tests__/hermes-posture.test.js
@@ -35,6 +35,7 @@ describe('postureFor', () => {
       'HERMES_XURL_TOKEN_STORE_EXPOSURE',
       'HERMES_MEMORY_EXFIL_PATTERN',
       'HERMES_BROWSER_CLOUD_METADATA_SSRF',
+      'HERMES_ADAPTER_ALLOWLIST_FAIL_OPEN',
     ]) {
       assert.equal(postureFor(rule), 'boundary', rule);
     }

--- a/cli/agents/hermes-security-agent.js
+++ b/cli/agents/hermes-security-agent.js
@@ -102,6 +102,9 @@ const BOUNDARY_RULES = new Set([
   // Escapes the agent process into the host through a path the shell-level
   // posture never covered (§2.2, "does not confine ... code-execution").
   'HERMES_XURL_SUBPROCESS_INJECTION',
+  // A network adapter that falls through to agent work without proving the
+  // caller is allowlisted crosses the adapter trust boundary (§2.6).
+  'HERMES_ADAPTER_ALLOWLIST_FAIL_OPEN',
 ]);
 
 /** Which half of Hermes's policy a rule falls under. */
@@ -453,6 +456,106 @@ function checkToolContextForwarding(content, filePath, agent) {
   return findings;
 }
 
+function pythonCodeOnly(content) {
+  return String(content || '')
+    .replace(/^[ \t]*#.*$/gm, '')
+    .replace(/'''[\s\S]*?'''|"""[\s\S]*?"""/g, '');
+}
+
+/**
+ * Detect network-facing Hermes adapter paths that dispatch without a
+ * fail-closed operator allowlist. This intentionally does not inspect ACP
+ * or shared gateway plumbing: ACP is local IPC, and the gateway's authz mixin
+ * is the central policy implementation rather than an adapter boundary.
+ */
+function checkAdapterAllowlistFailOpen(content, filePath, agent) {
+  const findings = [];
+  const normalizedPath = String(filePath || '').replace(/\\/g, '/');
+
+  if (!/\.(?:py|pyi)$/i.test(normalizedPath)) return findings;
+  if (/\/acp_adapter\//i.test(normalizedPath)) return findings;
+  if (!/(?:^|\/)(?:gateway\/platforms|plugins\/platforms)\//i.test(normalizedPath)) {
+    return findings;
+  }
+  if (/(?:\/|^)(?:base|helpers|platform_registry|authz_mixin)\.py$/i.test(normalizedPath)) {
+    return findings;
+  }
+
+  const lines = content.split(/\r?\n/);
+  const functionRe = /^(\s*)(?:async\s+)?def\s+([A-Za-z_]\w*)\s*\([^)]*\)\s*:/;
+  const functions = [];
+
+  // Python's indentation gives us a useful conservative function boundary
+  // without pulling a parser into the CLI just for this rule.
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = lines[index].match(functionRe);
+    if (!match) continue;
+
+    const indent = match[1].length;
+    const body = [lines[index]];
+    let end = index + 1;
+    for (; end < lines.length; end += 1) {
+      const line = lines[end];
+      const trimmed = line.trim();
+      if (trimmed && line.length - line.trimStart().length <= indent) break;
+      body.push(line);
+    }
+    functions.push({ name: match[2], startLine: index + 1, text: body.join('\n') });
+    index = end - 1;
+  }
+
+  const boundaryNameRe = /(?:dispatch|relay|forward|approval|approve|handle_(?:message|event|request)|on_(?:message|event)|process_(?:message|event)|send)(?:_|$)/i;
+  const agentSinkRe = /(?:dispatch_(?:agent|work|message)|resolve_(?:gateway_)?approval|(?:run|execute|invoke)_[a-z_]*agent|relay_(?:output|message)|forward_(?:output|message)|message_handler|agent_(?:run|execute|output)|_process_message_background)/i;
+  const authzRe = /(?:allow[_-]?list|allow_from|allowed_(?:users|chats|agents|platforms)|dm_policy|group_policy|authz|authori[sz](?:e|ed|ation)|is_allowed|check_access|require_auth|enforce_own_access_policy|_is_(?:user|sender)_authori[sz]ed)/i;
+  const rejectRe = /(?:raise\s+(?:permissionerror|runtimeerror|valueerror)|return\s+(?:false|none)\b|return\s+[^\n]*(?:deny|reject|forbid)|not\s+in\s+[^\n]*(?:allow|authori[sz])|\b(?:drop|reject|deny|forbidden|403)\b)/i;
+  const explicitFailOpenRe = /(?:allow[_-]?all|accept[_-]?all|open[_-]?access|dm_policy\s*==\s*['"]open['"]|allow[_-]?list\s*=\s*[^\n]*(?:or\s+(?:\[\s*['"]\*['"]\s*\]|true\b))|(?:config|settings|options)\.get\(\s*['"](?:allow[_-]?list|allow_from|allowed_users)['"][^)]*\)\s*or\s+(?:true\b|\[\s*['"]\*['"]\s*\]))/i;
+  const sessionGateRe = /(?:if\s+[^\n]*session[_-]?id|session[_-]?id\s+and|session[_-]?id\s*:\s*)/i;
+
+  for (const fn of functions) {
+    const code = pythonCodeOnly(fn.text);
+    if (!boundaryNameRe.test(fn.name) || !agentSinkRe.test(code)) continue;
+
+    const hasAuthz = authzRe.test(code);
+    const hasReject = rejectRe.test(code);
+    const hasExplicitFailOpen = explicitFailOpenRe.test(code);
+    const usesSessionAsGate = sessionGateRe.test(code) && !hasAuthz;
+    const hasExplicitDispatchWithoutAuthz = /(?:dispatch_agent|dispatch_work|resolve_(?:gateway_)?approval|relay_output)/i.test(code) && !hasAuthz;
+
+    let reason;
+    let confidence = 'medium';
+    if (hasExplicitFailOpen) {
+      reason = 'empty or missing allowlist falls through to an allow-all path';
+      confidence = 'high';
+    } else if (usesSessionAsGate) {
+      reason = 'session ID is used as the authorization gate';
+      confidence = 'high';
+    } else if (hasAuthz && !hasReject) {
+      reason = 'allowlist/authorization data is read without a fail-closed rejection before dispatch';
+    } else if (hasExplicitDispatchWithoutAuthz) {
+      reason = 'agent work or approval is dispatched without an allowlist/authz check';
+    } else {
+      continue;
+    }
+
+    findings.push(createFinding({
+      file: filePath,
+      line: fn.startLine,
+      severity: 'critical',
+      category: agent.category,
+      rule: 'HERMES_ADAPTER_ALLOWLIST_FAIL_OPEN',
+      title: 'Hermes: Network Adapter Dispatches Without a Fail-Closed Allowlist',
+      description: 'This network-exposed Hermes adapter can dispatch agent work, resolve an approval, or relay output without proving that the caller is in an operator-configured allowlist. Hermes SECURITY.md §2.6 requires adapters to refuse when the allowlist is missing or empty; session IDs are routing handles, not authorization boundaries.',
+      matched: `${fn.name}(): ${reason}`,
+      confidence,
+      cwe: 'CWE-862',
+      owasp: 'ASI03',
+      fix: 'Require an explicit, non-empty operator allowlist before dispatch, approval, or output relay. Reject missing/empty configuration by default and never treat a session ID as authorization.',
+    }));
+  }
+
+  return findings;
+}
+
 /**
  * Check skill frontmatter for permissions field.
  * Skill files are Markdown; frontmatter is YAML between --- delimiters.
@@ -796,6 +899,7 @@ export class HermesSecurityAgent extends BaseAgent {
       // Structural checks
       findings.push(...checkToolNameCollisions(content, filePath, this));
       findings.push(...checkToolContextForwarding(content, filePath, this));
+      findings.push(...checkAdapterAllowlistFailOpen(content, filePath, this));
       findings.push(...checkSkillFrontmatter(content, filePath, this));
       findings.push(...checkMemoryFileDeserialization(content, filePath, this));
       // Hermes v0.13.0 "Tenacity Release" coverage

--- a/docs/hermes-security-model.md
+++ b/docs/hermes-security-model.md
@@ -59,7 +59,9 @@ layer treats agent output as inert and some path breaks that, it is in scope.
 **Adapters that fail open are explicitly named.** Their §2.6 says every enabled
 network-exposed adapter requires an allowlist, and that code paths failing open
 when none is configured are bugs in scope. A static rule that finds those is
-our highest-value Hermes rule.
+our highest-value Hermes rule. Ship Safe reports this as
+`HERMES_ADAPTER_ALLOWLIST_FAIL_OPEN` with `critical` severity and `boundary`
+posture.
 
 ## What their policy treats as out of scope
 


### PR DESCRIPTION
## Summary
- add `HERMES_ADAPTER_ALLOWLIST_FAIL_OPEN` for network-facing Hermes platform adapters
- flag missing or empty allowlists that fall through to dispatch, session IDs used as authorization, and authorization reads without fail-closed rejection
- keep ACP/local IPC and shared gateway plumbing out of scope
- add safe, vulnerable, and comment/docstring regression coverage
- document the rule as a critical boundary finding

Closes #126.

## Validation
- `npm test` (476 passing)
- `npm run lint -- --no-warn-ignored` (0 errors; existing warnings only)
- `node benchmarks/false-positives/run.mjs --clone`
- audited the pinned Hermes source with zero findings from the new rule