### PR TITLE
feat(mcp): detect OAuth token boundary risks

### DIFF
--- a/cli/__tests__/mcp-oauth.test.js
+++ b/cli/__tests__/mcp-oauth.test.js
@@ -449,6 +449,114 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     assert.equal(findings.filter((finding) => finding.rule === 'MCP_UPSTREAM_TOKEN_PASSTHROUGH').length, 0);
   });
 
+  it('does not report unrelated OAuth helpers in an MCP-containing source file', async () => {
+    const cases = [
+      {
+        name: 'JavaScript',
+        ext: '.js',
+        code: `
+          import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+          const server = new McpServer({ name: 'demo', version: '1.0.0' });
+
+          function unrelatedOAuth(request) {
+            const token = request.headers.authorization;
+            jwt.verify(token, key);
+            const oauth = {
+              response_type: 'code',
+              authorization_endpoint: 'https://idp.example.com/authorize',
+              token_endpoint: 'https://idp.example.com/token',
+            };
+            return fetch('https://api.example.com', {
+              headers: { Authorization: token },
+            });
+          }
+        `,
+      },
+      {
+        name: 'Python',
+        ext: '.py',
+        code: `
+          from mcp.server.fastmcp import FastMCP
+          import jwt
+          import requests
+
+          mcp = FastMCP('demo')
+
+          def unrelated_oauth(request):
+              token = request.headers.get('Authorization')
+              jwt.decode(token, key)
+              oauth = {'response_type': 'code', 'authorization_endpoint': 'https://idp.example.com/authorize', 'token_endpoint': 'https://idp.example.com/token'}
+              return requests.get('https://api.example.com', headers={'Authorization': token})
+        `,
+      },
+      {
+        name: 'Ruby',
+        ext: '.rb',
+        code: `
+          require 'mcp'
+          require 'net/http'
+          MCPServer.new
+
+          def unrelated_oauth(request)
+            token = request['authorization']
+            JWT.decode(token, key)
+            oauth = { response_type: 'code', authorization_endpoint: 'https://idp.example.com/authorize', token_endpoint: 'https://idp.example.com/token' }
+            Net::HTTP.get(URI('https://api.example.com'))
+          end
+        `,
+      },
+      {
+        name: 'Go',
+        ext: '.go',
+        code: `
+          package main
+
+          import (
+            "net/http"
+            mcp "github.com/modelcontextprotocol/go-sdk/mcp"
+          )
+
+          var server = mcp.NewServer()
+
+          func unrelatedOAuth(w http.ResponseWriter, r *http.Request) {
+            token := r.Header.Get("Authorization")
+            jwt.Verify(token, key)
+            oauth := map[string]string{"response_type": "code", "authorization_endpoint": "https://idp.example.com/authorize", "token_endpoint": "https://idp.example.com/token"}
+            http.Get("https://api.example.com")
+          }
+        `,
+      },
+    ];
+
+    for (const testCase of cases) {
+      const findings = await scan(testCase.code, testCase.ext);
+      const oauthRules = new Set([
+        'MCP_TOKEN_AUDIENCE_UNVALIDATED',
+        'MCP_OAUTH_NO_PKCE',
+      ]);
+      assert.equal(
+        findings.filter((finding) => oauthRules.has(finding.rule)).length,
+        0,
+        testCase.name,
+      );
+    }
+  });
+
+  it('does not report an unrelated top-level JavaScript OAuth object', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+
+      const unrelatedOAuth = {
+        response_type: 'code',
+        authorization_endpoint: 'https://idp.example.com/authorize',
+        token_endpoint: 'https://idp.example.com/token',
+      };
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 0);
+  });
+
   it('flags a static OAuth client id combined with dynamic registration', async () => {
     const findings = await scan(`
       import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -520,6 +628,7 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
       "  authorization_endpoint: 'https://idp.example.com/authorize',",
       "  token_endpoint: 'https://idp.example.com/token',",
       '};',
+      "server.tool('oauth', () => oauth);",
     ].join('\n'));
 
     assert.equal(findings.filter((finding) => finding.rule === 'MCP_STATIC_CLIENT_ID_DYNAMIC_REG').length, 0);
@@ -537,6 +646,7 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
         authorization_endpoint: 'https://idp.example.com/authorize',
         token_endpoint: 'https://idp.example.com/token',
       };
+      server.tool('oauth', () => oauth);
     `);
 
     const hits = findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE');
@@ -556,6 +666,7 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
         authorization_endpoint: 'https://idp.example.com/authorize',
         token_endpoint: 'https://idp.example.com/token',
       };
+      server.tool('oauth', () => oauth);
     `);
 
     assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 1);
@@ -572,6 +683,8 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
         authorization_endpoint: 'https://idp.example.com/authorize',
         token_endpoint: 'https://idp.example.com/token',
       };
+      server.tool('safe', () => safeFlow);
+      server.tool('unsafe', () => unsafeFlow);
     `);
 
     assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 1);
@@ -583,6 +696,7 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
 
       const server = new McpServer({ name: 'oauth-proxy', version: '1.0.0' });
       const oauth = { response_type: 'code' }; // PKCE will be added later
+      server.tool('oauth', () => oauth);
     `);
 
     assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 1);
@@ -599,6 +713,7 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
         token_endpoint: 'https://idp.example.com/token',
         note: 'code_challenge will be added',
       };
+      server.tool('oauth', () => oauth);
     `);
 
     assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 1);
@@ -615,6 +730,7 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
         token_endpoint: 'https://idp.example.com/token',
         note: 'pkce: true',
       };
+      server.tool('oauth', () => oauth);
     `);
 
     assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 1);
@@ -631,6 +747,7 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
         token_endpoint: 'https://idp.example.com/token',
         note: 'pkce: false',
       };
+      server.tool('oauth', () => oauth);
     `);
 
     assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 1);
@@ -642,6 +759,7 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
 
       const server = new McpServer({ name: 'oauth-proxy', version: '1.0.0' });
       const oauth = { response_type: 'code', use_pkce: false };
+      server.tool('oauth', () => oauth);
     `);
 
     assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 1);
@@ -654,6 +772,7 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
 
         const server = new McpServer({ name: 'oauth-proxy', version: '1.0.0' });
         const oauth = { response_type: 'code', ${setting} };
+        server.tool('oauth', () => oauth);
       `);
 
       assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 1, setting);
@@ -998,6 +1117,7 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
           import jwt
 
           mcp = FastMCP('demo')
+          @mcp.tool()
           def profile(request):
               token = request.headers.get('Authorization')
               claims = jwt.decode(token, key)

--- a/cli/__tests__/mcp-oauth.test.js
+++ b/cli/__tests__/mcp-oauth.test.js
@@ -234,6 +234,49 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 1);
   });
 
+  it('does not let unrelated audience validation hide a direct inbound authorization finding', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+      import jwt from 'jsonwebtoken';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+      server.tool('profile', async (request) => {
+        validate(serviceCredential, { audience: 'internal-api' });
+        return jwt.verify(request.headers.authorization, key);
+      });
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 1);
+  });
+
+  it('accepts audience validation applied to a direct inbound authorization value', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+      import jwt from 'jsonwebtoken';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+      server.tool('profile', async (request) => (
+        jwt.verify(request.headers.authorization, key, { audience: 'https://mcp.example.com' })
+      ));
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 0);
+  });
+
+  it('accepts audience validation applied to a direct authorization header getter', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+      import jwt from 'jsonwebtoken';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+      server.tool('profile', async (request) => (
+        jwt.verify(request.headers.get('Authorization'), key, { audience: 'https://mcp.example.com' })
+      ));
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 0);
+  });
+
   it('does not let unrelated credential exchange hide the inbound token finding', async () => {
     const findings = await scan(`
       import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -248,6 +291,34 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     `);
 
     assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 1);
+  });
+
+  it('does not let unrelated token exchange hide a direct inbound authorization finding', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+      import jwt from 'jsonwebtoken';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+      server.tool('profile', async (request) => {
+        const exchanged = await exchangeToken(serviceCredential);
+        return jwt.verify(request.headers.authorization, key);
+      });
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 1);
+  });
+
+  it('accepts token exchange applied to a direct inbound authorization value', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+      server.tool('profile', async (request) => (
+        exchangeToken(request.headers.authorization)
+      ));
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 0);
   });
 
   it('does not pair an unused helper token with another helper request', async () => {
@@ -302,6 +373,21 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     assert.match(hits[0].description, /confused deputy/i);
   });
 
+  it('keeps static client and dynamic registration in scope despite a brace in a string', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+      const server = new McpServer({ name: 'oauth-proxy', version: '1.0.0' });
+      const oauth = {
+        note: '{',
+        client_id: 'mcp-proxy-production',
+        dynamic_client_registration: true,
+      };
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_STATIC_CLIENT_ID_DYNAMIC_REG').length, 1);
+  });
+
   it('does not pair static client id and dynamic registration from separate objects', async () => {
     const findings = await scan(`
       import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -331,6 +417,22 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     assert.equal(hits.length, 1);
     assert.equal(hits[0].severity, 'high');
     assert.match(hits[0].description, /PKCE/i);
+  });
+
+  it('keeps a missing-PKCE flow in scope despite a brace in a string', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+      const server = new McpServer({ name: 'oauth-proxy', version: '1.0.0' });
+      const oauth = {
+        note: '}',
+        response_type: 'code',
+        authorization_endpoint: 'https://idp.example.com/authorize',
+        token_endpoint: 'https://idp.example.com/token',
+      };
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 1);
   });
 
   it('reports a missing PKCE flow when another flow is PKCE-safe', async () => {

--- a/cli/__tests__/mcp-oauth.test.js
+++ b/cli/__tests__/mcp-oauth.test.js
@@ -73,6 +73,46 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 1);
   });
 
+  it('does not treat a custom request id header as an OAuth token', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+      server.tool('search', async (request) => {
+        const requestId = request.headers['X-Request-ID'];
+        return fetch('https://api.example.com/search', {
+          headers: { 'X-Request-ID': requestId },
+        });
+      });
+    `);
+
+    const oauthRules = new Set([
+      'MCP_UPSTREAM_TOKEN_PASSTHROUGH',
+      'MCP_TOKEN_AUDIENCE_UNVALIDATED',
+    ]);
+    assert.equal(findings.filter((finding) => oauthRules.has(finding.rule)).length, 0);
+  });
+
+  it('does not treat an API-key variable as a bearer token', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+      server.tool('search', async (request) => {
+        const apiKey = request.headers.authorization;
+        return fetch('https://api.example.com/search', {
+          headers: { Authorization: apiKey },
+        });
+      });
+    `);
+
+    const oauthRules = new Set([
+      'MCP_UPSTREAM_TOKEN_PASSTHROUGH',
+      'MCP_TOKEN_AUDIENCE_UNVALIDATED',
+    ]);
+    assert.equal(findings.filter((finding) => oauthRules.has(finding.rule)).length, 0);
+  });
+
   it('flags an inbound MCP token that is accepted without audience validation', async () => {
     const findings = await scan(`
       import jwt from 'jsonwebtoken';
@@ -92,6 +132,79 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     assert.match(hits[0].description, /audience/i);
   });
 
+  it('does not let a safe handler hide an unsafe handler audience check', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+      import jwt from 'jsonwebtoken';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+      server.tool('safe', async (request) => {
+        const safeToken = request.headers.authorization;
+        return jwt.verify(safeToken, key, { audience: 'https://mcp.example.com' });
+      });
+
+      server.tool('unsafe', async (request) => {
+        const unsafeToken = request.headers.authorization;
+        return jwt.verify(unsafeToken, key);
+      });
+    `);
+
+    const hits = findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED');
+    assert.equal(hits.length, 1);
+    assert.match(hits[0].matched, /unsafeToken|authorization/i);
+  });
+
+  it('does not treat an audience comment as validation', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+      import jwt from 'jsonwebtoken';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+      server.tool('profile', async (request) => {
+        const token = request.headers.authorization;
+        // audience: this is UI metadata, not token validation
+        return jwt.verify(token, key);
+      });
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 1);
+  });
+
+  it('does not treat an unrelated audience property as validation', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+      import jwt from 'jsonwebtoken';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+      server.tool('profile', async (request) => {
+        const token = request.headers.authorization;
+        const ui = { audience: 'admin-dashboard' };
+        return jwt.verify(token, key);
+      });
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 1);
+  });
+
+  it('does not pair an unused helper token with another helper request', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+      function readToken(request) {
+        const token = request.headers.authorization;
+        return token;
+      }
+      function unrelated(token) {
+        return fetch('https://api.example.com/search', {
+          headers: { Authorization: token },
+        });
+      }
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_UPSTREAM_TOKEN_PASSTHROUGH').length, 0);
+  });
+
   it('flags a static OAuth client id combined with dynamic registration', async () => {
     const findings = await scan(`
       import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -107,6 +220,18 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     assert.equal(hits.length, 1);
     assert.equal(hits[0].severity, 'high');
     assert.match(hits[0].description, /confused deputy/i);
+  });
+
+  it('does not pair static client id and dynamic registration from separate objects', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+      const server = new McpServer({ name: 'oauth-proxy', version: '1.0.0' });
+      const clientConfig = { client_id: 'mcp-proxy-production' };
+      const registrationConfig = { dynamic_client_registration: true };
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_STATIC_CLIENT_ID_DYNAMIC_REG').length, 0);
   });
 
   it('flags an MCP authorization-code flow without PKCE', async () => {
@@ -126,6 +251,57 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     assert.equal(hits.length, 1);
     assert.equal(hits[0].severity, 'high');
     assert.match(hits[0].description, /PKCE/i);
+  });
+
+  it('reports a missing PKCE flow when another flow is PKCE-safe', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+      const server = new McpServer({ name: 'oauth-proxy', version: '1.0.0' });
+      const safeFlow = { response_type: 'code', code_challenge: challenge };
+      const unsafeFlow = {
+        response_type: 'code',
+        authorization_endpoint: 'https://idp.example.com/authorize',
+        token_endpoint: 'https://idp.example.com/token',
+      };
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 1);
+  });
+
+  it('does not treat a PKCE comment as a mitigation', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+      const server = new McpServer({ name: 'oauth-proxy', version: '1.0.0' });
+      const oauth = { response_type: 'code' }; // PKCE will be added later
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 1);
+  });
+
+  it('flags an authorization-code flow with PKCE explicitly disabled', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+      const server = new McpServer({ name: 'oauth-proxy', version: '1.0.0' });
+      const oauth = { response_type: 'code', use_pkce: false };
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 1);
+  });
+
+  it('flags null and disabled PKCE settings', async () => {
+    for (const setting of ['pkce: null', "pkce: 'disabled'"]) {
+      const findings = await scan(`
+        import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+        const server = new McpServer({ name: 'oauth-proxy', version: '1.0.0' });
+        const oauth = { response_type: 'code', ${setting} };
+      `);
+
+      assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 1, setting);
+    }
   });
 
   it('uses language-specific token and outbound request shapes', async () => {
@@ -270,6 +446,18 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     assert.equal(hits.length, 1);
   });
 
+  it('does not pair static client id and registration from separate config objects', async () => {
+    const findings = await scan(JSON.stringify({
+      client: { client_id: 'mcp-proxy-production' },
+      registration: { dynamic_client_registration: true },
+      mcpServers: {
+        proxy: { command: 'node', args: ['server.js'] },
+      },
+    }), '.mcp.json');
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_STATIC_CLIENT_ID_DYNAMIC_REG').length, 0);
+  });
+
   it('flags an authorization-code flow without PKCE in a project MCP config', async () => {
     const findings = await scan(JSON.stringify({
       oauth: {
@@ -285,6 +473,25 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
 
     const hits = findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE');
     assert.equal(hits.length, 1);
+  });
+
+  it('reports confused deputy and missing PKCE independently in one config', async () => {
+    const findings = await scan(JSON.stringify({
+      oauth: {
+        client_id: 'mcp-proxy-production',
+        dynamic_client_registration: true,
+        response_type: 'code',
+        authorization_endpoint: 'https://idp.example.com/authorize',
+        token_endpoint: 'https://idp.example.com/token',
+      },
+      mcpServers: {
+        proxy: { command: 'node', args: ['server.js'] },
+      },
+    }), '.mcp.json');
+
+    const rules = new Set(findings.map((finding) => finding.rule));
+    assert.equal(rules.has('MCP_STATIC_CLIENT_ID_DYNAMIC_REG'), true);
+    assert.equal(rules.has('MCP_OAUTH_NO_PKCE'), true);
   });
 
   it('stays quiet when audience validation, token exchange, and PKCE are present', async () => {

--- a/cli/__tests__/mcp-oauth.test.js
+++ b/cli/__tests__/mcp-oauth.test.js
@@ -1,0 +1,339 @@
+/**
+ * Ship Safe — MCPSecurityAgent OAuth and token-boundary fixtures
+ * ===============================================================
+ *
+ * Regression coverage for issue #104.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { MCPSecurityAgent } from '../agents/mcp-security-agent.js';
+
+function fixture(content, ext = '.js') {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-mcp-oauth-'));
+  const file = path.join(dir, `server${ext}`);
+  fs.writeFileSync(file, content);
+  return { dir, file };
+}
+
+function cleanup(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+}
+
+async function scan(content, ext = '.js') {
+  const { dir, file } = fixture(content, ext);
+  try {
+    return await new MCPSecurityAgent().analyze({
+      rootPath: dir,
+      files: [file],
+      recon: {},
+      options: {},
+    });
+  } finally {
+    cleanup(dir);
+  }
+}
+
+describe('MCPSecurityAgent — OAuth security rules', () => {
+  it('flags an MCP tool that forwards an inbound bearer token downstream', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+      server.tool('search', async (request) => {
+        const authorization = request.headers.authorization;
+        return fetch('https://api.example.com/search', {
+          headers: { Authorization: authorization },
+        });
+      });
+    `);
+
+    const hits = findings.filter((finding) => finding.rule === 'MCP_UPSTREAM_TOKEN_PASSTHROUGH');
+    assert.equal(hits.length, 1);
+    assert.equal(hits[0].severity, 'high');
+    assert.match(hits[0].matched, /fetch/i);
+    assert.match(hits[0].description, /audience/i);
+  });
+
+  it('flags a direct inbound authorization header passed to fetch', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+      server.tool('search', async (request) => fetch('https://api.example.com/search', {
+        headers: { Authorization: request.headers.authorization },
+      }));
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_UPSTREAM_TOKEN_PASSTHROUGH').length, 1);
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 1);
+  });
+
+  it('flags an inbound MCP token that is accepted without audience validation', async () => {
+    const findings = await scan(`
+      import jwt from 'jsonwebtoken';
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+      server.tool('profile', async (request) => {
+        const token = request.headers.authorization?.replace(/^Bearer\\s+/i, '');
+        const claims = jwt.verify(token, process.env.MCP_PUBLIC_KEY);
+        return claims.sub;
+      });
+    `);
+
+    const hits = findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED');
+    assert.equal(hits.length, 1);
+    assert.equal(hits[0].severity, 'high');
+    assert.match(hits[0].description, /audience/i);
+  });
+
+  it('flags a static OAuth client id combined with dynamic registration', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+      const server = new McpServer({ name: 'oauth-proxy', version: '1.0.0' });
+      const oauth = {
+        client_id: 'mcp-proxy-production',
+        dynamic_client_registration: true,
+      };
+    `);
+
+    const hits = findings.filter((finding) => finding.rule === 'MCP_STATIC_CLIENT_ID_DYNAMIC_REG');
+    assert.equal(hits.length, 1);
+    assert.equal(hits[0].severity, 'high');
+    assert.match(hits[0].description, /confused deputy/i);
+  });
+
+  it('flags an MCP authorization-code flow without PKCE', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+      const server = new McpServer({ name: 'oauth-proxy', version: '1.0.0' });
+      const oauth = {
+        client_id: process.env.MCP_CLIENT_ID,
+        response_type: 'code',
+        authorization_endpoint: 'https://idp.example.com/authorize',
+        token_endpoint: 'https://idp.example.com/token',
+      };
+    `);
+
+    const hits = findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE');
+    assert.equal(hits.length, 1);
+    assert.equal(hits[0].severity, 'high');
+    assert.match(hits[0].description, /PKCE/i);
+  });
+
+  it('uses language-specific token and outbound request shapes', async () => {
+    const cases = [
+      {
+        name: 'Python',
+        ext: '.py',
+        code: `
+          from mcp.server.fastmcp import FastMCP
+          import requests
+
+          mcp = FastMCP('demo')
+          def lookup(request):
+              token = request.headers.get('Authorization')
+              return requests.get('https://api.example.com/search', headers={'Authorization': token})
+        `,
+      },
+      {
+        name: 'Ruby',
+        ext: '.rb',
+        code: `
+          require 'net/http'
+          class MCP::Server
+            def lookup(request)
+              token = request.headers['Authorization']
+              Net::HTTP.get(URI('https://api.example.com/search'), { 'Authorization' => token })
+            end
+          end
+        `,
+      },
+      {
+        name: 'Go',
+        ext: '.go',
+        code: `
+          package main
+          import (
+            "net/http"
+            mcp "github.com/modelcontextprotocol/go-sdk/mcp"
+          )
+
+          var server = mcp.NewServer()
+          func lookup(r *http.Request) {
+            token := r.Header.Get("Authorization")
+            req, _ := http.NewRequest("GET", "https://api.example.com/search", nil)
+            req.Header.Set("Authorization", token)
+            client.Do(req)
+          }
+        `,
+      },
+    ];
+
+    for (const testCase of cases) {
+      const findings = await scan(testCase.code, testCase.ext);
+      const hits = findings.filter((finding) => finding.rule === 'MCP_UPSTREAM_TOKEN_PASSTHROUGH');
+      assert.equal(hits.length, 1, `${testCase.name} token passthrough shape was not detected`);
+    }
+  });
+
+  it('does not apply the JavaScript outbound shape to Python', async () => {
+    const findings = await scan(`
+      from mcp.server.fastmcp import FastMCP
+
+      mcp = FastMCP('demo')
+      def lookup(request):
+          const token = request.headers.authorization
+          return fetch('https://api.example.com/search', { headers: { Authorization: token } })
+    `, '.py');
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_UPSTREAM_TOKEN_PASSTHROUGH').length, 0);
+  });
+
+  it('keeps audience, confused-deputy, and PKCE rules available in other languages', async () => {
+    const cases = [
+      {
+        name: 'Python audience',
+        ext: '.py',
+        rule: 'MCP_TOKEN_AUDIENCE_UNVALIDATED',
+        code: `
+          from mcp.server.fastmcp import FastMCP
+          import jwt
+
+          mcp = FastMCP('demo')
+          def profile(request):
+              token = request.headers.get('Authorization')
+              claims = jwt.decode(token, key)
+              return claims['sub']
+        `,
+      },
+      {
+        name: 'Ruby confused deputy',
+        ext: '.rb',
+        rule: 'MCP_STATIC_CLIENT_ID_DYNAMIC_REG',
+        code: `
+          class MCP::Proxy
+            OAUTH = {
+              client_id: 'mcp-proxy-production',
+              dynamic_client_registration: true,
+            }
+          end
+        `,
+      },
+      {
+        name: 'Go PKCE',
+        ext: '.go',
+        rule: 'MCP_OAUTH_NO_PKCE',
+        code: `
+          package main
+          import mcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+          var server = mcp.NewServer()
+          var oauth = map[string]string{
+            "response_type": "code",
+            "authorization_endpoint": "https://idp.example.com/authorize",
+            "token_endpoint": "https://idp.example.com/token",
+          }
+        `,
+      },
+    ];
+
+    for (const testCase of cases) {
+      const findings = await scan(testCase.code, testCase.ext);
+      assert.equal(
+        findings.filter((finding) => finding.rule === testCase.rule).length,
+        1,
+        `${testCase.name} rule was not detected`,
+      );
+    }
+  });
+
+  it('flags confused-deputy OAuth settings in a project MCP config', async () => {
+    const findings = await scan(JSON.stringify({
+      oauth: {
+        client_id: 'mcp-proxy-production',
+        dynamic_client_registration: true,
+      },
+      mcpServers: {
+        proxy: { command: 'node', args: ['server.js'] },
+      },
+    }), '.mcp.json');
+
+    const hits = findings.filter((finding) => finding.rule === 'MCP_STATIC_CLIENT_ID_DYNAMIC_REG');
+    assert.equal(hits.length, 1);
+  });
+
+  it('flags an authorization-code flow without PKCE in a project MCP config', async () => {
+    const findings = await scan(JSON.stringify({
+      oauth: {
+        client_id: '${MCP_CLIENT_ID}',
+        response_type: 'code',
+        authorization_endpoint: 'https://idp.example.com/authorize',
+        token_endpoint: 'https://idp.example.com/token',
+      },
+      mcpServers: {
+        proxy: { command: 'node', args: ['server.js'] },
+      },
+    }), '.mcp.json');
+
+    const hits = findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE');
+    assert.equal(hits.length, 1);
+  });
+
+  it('stays quiet when audience validation, token exchange, and PKCE are present', async () => {
+    const findings = await scan(`
+      import jwt from 'jsonwebtoken';
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+      const server = new McpServer({ name: 'safe-proxy', version: '1.0.0' });
+      server.tool('search', async (request) => {
+        const subjectToken = request.headers.authorization;
+        const claims = jwt.verify(subjectToken, process.env.MCP_PUBLIC_KEY, {
+          audience: 'https://mcp.example.com',
+        });
+        const downstreamToken = await exchangeToken(subjectToken, {
+          audience: 'https://api.example.com',
+        });
+        return fetch('https://api.example.com/search', {
+          headers: { Authorization: \`Bearer \${downstreamToken}\` },
+        });
+      });
+
+      const oauth = {
+        client_id: process.env.MCP_CLIENT_ID,
+        response_type: 'code',
+        code_challenge: challenge,
+        code_challenge_method: 'S256',
+      };
+    `);
+
+    const oauthRules = new Set([
+      'MCP_UPSTREAM_TOKEN_PASSTHROUGH',
+      'MCP_TOKEN_AUDIENCE_UNVALIDATED',
+      'MCP_STATIC_CLIENT_ID_DYNAMIC_REG',
+      'MCP_OAUTH_NO_PKCE',
+    ]);
+    assert.equal(findings.filter((finding) => oauthRules.has(finding.rule)).length, 0);
+  });
+
+  it('does not treat an environment-backed client id as static', async () => {
+    const findings = await scan(JSON.stringify({
+      oauth: {
+        client_id: '${MCP_CLIENT_ID}',
+        dynamic_client_registration: true,
+      },
+      mcpServers: {
+        proxy: { command: 'node', args: ['server.js'] },
+      },
+    }), '.mcp.json');
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_STATIC_CLIENT_ID_DYNAMIC_REG').length, 0);
+  });
+});

--- a/cli/__tests__/mcp-oauth.test.js
+++ b/cli/__tests__/mcp-oauth.test.js
@@ -59,6 +59,46 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     assert.match(hits[0].description, /audience/i);
   });
 
+  it('flags bearer-token passthrough in a registered Ruby MCP tool block', async () => {
+    const findings = await scan(`
+      require 'mcp'
+      require 'net/http'
+
+      server = MCP::Server.new(name: 'demo')
+      server.define_tool(name: 'search') do |request|
+        token = request['authorization']
+        Net::HTTP.post(uri, body, { 'Authorization' => token })
+      end
+    `, '.rb');
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_UPSTREAM_TOKEN_PASSTHROUGH').length, 1);
+  });
+
+  it('flags bearer-token passthrough in a registered Go MCP tool handler', async () => {
+    const findings = await scan(`
+      package main
+
+      import (
+        "net/http"
+        mcp "github.com/modelcontextprotocol/go-sdk/mcp"
+      )
+
+      var server = mcp.NewServer()
+
+      func search(w http.ResponseWriter, r *http.Request) {
+        token := r.Header.Get("Authorization")
+        downstream, _ := http.NewRequest("GET", apiURL, nil)
+        downstream.Header.Set("Authorization", token)
+      }
+
+      func registerTools() {
+        mcp.AddTool(server, &mcp.Tool{Name: "search"}, search)
+      }
+    `, '.go');
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_UPSTREAM_TOKEN_PASSTHROUGH').length, 1);
+  });
+
   it('flags a direct inbound authorization header passed to fetch', async () => {
     const findings = await scan(`
       import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -250,6 +290,106 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     assert.equal(hits.length, 1);
     assert.equal(hits[0].severity, 'high');
     assert.match(hits[0].description, /audience/i);
+  });
+
+  it('flags an inbound token in a registered Ruby MCP tool block', async () => {
+    const findings = await scan(`
+      require 'mcp'
+      require 'jwt'
+
+      server = MCP::Server.new(name: 'demo')
+      server.define_tool(name: 'profile') do |request|
+        token = request['authorization']
+        JWT.decode(token, key)
+      end
+    `, '.rb');
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 1);
+  });
+
+  it('accepts audience validation in a registered Ruby MCP tool block', async () => {
+    const findings = await scan(`
+      require 'mcp'
+      require 'jwt'
+
+      server = MCP::Server.new(name: 'demo')
+      server.define_tool(name: 'profile') do |request|
+        token = request['authorization']
+        JWT.decode(token, key, audience: 'mcp-server')
+      end
+    `, '.rb');
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 0);
+  });
+
+  it('flags an inbound token in a named Go MCP tool handler', async () => {
+    const findings = await scan(`
+      package main
+
+      import (
+        "net/http"
+        mcp "github.com/modelcontextprotocol/go-sdk/mcp"
+      )
+
+      var server = mcp.NewServer()
+
+      func profile(w http.ResponseWriter, r *http.Request) {
+        token := r.Header.Get("Authorization")
+        jwt.Parse(token, key)
+      }
+
+      func registerTools() {
+        mcp.AddTool(server, &mcp.Tool{Name: "profile"}, profile)
+      }
+    `, '.go');
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 1);
+  });
+
+  it('accepts audience validation in a named Go MCP tool handler', async () => {
+    const findings = await scan(`
+      package main
+
+      import (
+        "net/http"
+        mcp "github.com/modelcontextprotocol/go-sdk/mcp"
+      )
+
+      var server = mcp.NewServer()
+
+      func profile(w http.ResponseWriter, r *http.Request) {
+        token := r.Header.Get("Authorization")
+        jwt.ParseWithClaims(token, &claims, key)
+      }
+
+      func registerTools() {
+        mcp.AddTool(server, &mcp.Tool{Name: "profile"}, profile)
+      }
+    `, '.go');
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 0);
+  });
+
+  it('flags an inbound token in an inline Go MCP tool handler', async () => {
+    const findings = await scan(`
+      package main
+
+      import (
+        "net/http"
+        mcp "github.com/modelcontextprotocol/go-sdk/mcp"
+      )
+
+      var server = mcp.NewServer()
+
+      func registerTools() {
+        mcp.AddTool(server, &mcp.Tool{}, func(w http.ResponseWriter, r *http.Request) {
+          token := r.Header.Get("Authorization")
+          jwt.Parse(token, key)
+        })
+      }
+    `, '.go');
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 1);
   });
 
   it('does not let a safe handler hide an unsafe handler audience check', async () => {

--- a/cli/__tests__/mcp-oauth.test.js
+++ b/cli/__tests__/mcp-oauth.test.js
@@ -73,6 +73,30 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 1);
   });
 
+  it('recognizes direct MCP callbacks after an object configuration argument', async () => {
+    const cases = [
+      `server.tool('search', { description: 'Search', inputSchema: { query: z.string() } }, async (request) => {`,
+      `server.registerTool('search', { description: 'Search', inputSchema: { query: z.string() } }, async (request) => {`,
+    ];
+
+    for (const registration of cases) {
+      const findings = await scan(`
+        import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+        const server = new McpServer({ name: 'demo', version: '1.0.0' });
+        ${registration}
+          const token = request.headers.authorization;
+          return fetch('https://api.example.com/search', {
+            headers: { Authorization: token },
+          });
+        });
+      `);
+
+      assert.equal(findings.filter((finding) => finding.rule === 'MCP_UPSTREAM_TOKEN_PASSTHROUGH').length, 1, registration);
+      assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 1, registration);
+    }
+  });
+
   it('ignores downstream request examples inside strings', async () => {
     const findings = await scan(`
       import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -196,6 +220,21 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     const hits = findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED');
     assert.equal(hits.length, 1);
     assert.match(hits[0].matched, /unsafeToken|authorization/i);
+  });
+
+  it('does not treat an OAuth header expression stored in a string as an inbound token', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+      import jwt from 'jsonwebtoken';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+      server.tool('profile', async () => {
+        const token = 'request.headers.authorization';
+        return jwt.verify(token, key);
+      });
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 0);
   });
 
   it('does not treat an audience comment as validation', async () => {
@@ -891,6 +930,26 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     `, '.py');
 
     assert.equal(findings.filter((finding) => finding.rule === 'MCP_UPSTREAM_TOKEN_PASSTHROUGH').length, 1);
+  });
+
+  it('recognizes a multiline FastMCP tool decorator', async () => {
+    const findings = await scan(`
+      from mcp.server.fastmcp import FastMCP
+      import requests
+
+      mcp = FastMCP('demo')
+
+      @mcp.tool(
+          name='lookup',
+          description='Search the catalog',
+      )
+      async def lookup(request):
+          token = request.headers.get('Authorization')
+          return await requests.get('https://api.example.com/search', headers={'Authorization': token})
+    `, '.py');
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_UPSTREAM_TOKEN_PASSTHROUGH').length, 1);
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 1);
   });
 
   it('does not treat a generic Python tool decorator as an MCP handler', async () => {

--- a/cli/__tests__/mcp-oauth.test.js
+++ b/cli/__tests__/mcp-oauth.test.js
@@ -170,6 +170,38 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 1);
   });
 
+  it('does not treat an unrelated audience string as validation', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+      import jwt from 'jsonwebtoken';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+      server.tool('profile', async (request) => {
+        const note = 'verify audience';
+        const token = request.headers.authorization;
+        return jwt.verify(token, key);
+      });
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 1);
+  });
+
+  it('does not treat an unrelated token-exchange string as mitigation', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+      import jwt from 'jsonwebtoken';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+      server.tool('profile', async (request) => {
+        const note = 'token_exchange RFC 8693';
+        const token = request.headers.authorization;
+        return jwt.verify(token, key);
+      });
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 1);
+  });
+
   it('does not treat an unrelated audience property as validation', async () => {
     const findings = await scan(`
       import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -179,6 +211,38 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
       server.tool('profile', async (request) => {
         const token = request.headers.authorization;
         const ui = { audience: 'admin-dashboard' };
+        return jwt.verify(token, key);
+      });
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 1);
+  });
+
+  it('does not let unrelated credential audience validation hide the inbound token finding', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+      import jwt from 'jsonwebtoken';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+      server.tool('profile', async (request) => {
+        const token = request.headers.authorization;
+        validate(serviceCredential, { audience: 'internal-api' });
+        return jwt.verify(token, key);
+      });
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 1);
+  });
+
+  it('does not let unrelated credential exchange hide the inbound token finding', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+      import jwt from 'jsonwebtoken';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+      server.tool('profile', async (request) => {
+        const token = request.headers.authorization;
+        const exchanged = await exchangeToken(serviceCredential);
         return jwt.verify(token, key);
       });
     `);
@@ -197,6 +261,22 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
       }
       function unrelated(token) {
         return fetch('https://api.example.com/search', {
+          headers: { Authorization: token },
+        });
+      }
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_UPSTREAM_TOKEN_PASSTHROUGH').length, 0);
+  });
+
+  it('does not flag an unrelated helper that forwards a token outside an MCP tool handler', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+      function unrelatedHttpProxy(request) {
+        const token = request.headers.authorization;
+        return fetch('https://api.example.com', {
           headers: { Authorization: token },
         });
       }
@@ -275,6 +355,54 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
 
       const server = new McpServer({ name: 'oauth-proxy', version: '1.0.0' });
       const oauth = { response_type: 'code' }; // PKCE will be added later
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 1);
+  });
+
+  it('does not treat an unrelated PKCE string as a mitigation', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+      const server = new McpServer({ name: 'oauth-proxy', version: '1.0.0' });
+      const oauth = {
+        response_type: 'code',
+        authorization_endpoint: 'https://idp.example.com/authorize',
+        token_endpoint: 'https://idp.example.com/token',
+        note: 'code_challenge will be added',
+      };
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 1);
+  });
+
+  it('does not treat a PKCE marker inside a note string as a mitigation', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+      const server = new McpServer({ name: 'oauth-proxy', version: '1.0.0' });
+      const oauth = {
+        response_type: 'code',
+        authorization_endpoint: 'https://idp.example.com/authorize',
+        token_endpoint: 'https://idp.example.com/token',
+        note: 'pkce: true',
+      };
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 1);
+  });
+
+  it('does not treat a PKCE marker inside a note string as an explicit disable', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+      const server = new McpServer({ name: 'oauth-proxy', version: '1.0.0' });
+      const oauth = {
+        response_type: 'code',
+        authorization_endpoint: 'https://idp.example.com/authorize',
+        token_endpoint: 'https://idp.example.com/token',
+        note: 'pkce: false',
+      };
     `);
 
     assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 1);
@@ -473,6 +601,24 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
 
     const hits = findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE');
     assert.equal(hits.length, 1);
+  });
+
+  it('keeps quoted PKCE config keys visible to mitigation detection', async () => {
+    const findings = await scan(JSON.stringify({
+      oauth: {
+        client_id: '${MCP_CLIENT_ID}',
+        response_type: 'code',
+        authorization_endpoint: 'https://idp.example.com/authorize',
+        token_endpoint: 'https://idp.example.com/token',
+        code_challenge: 'challenge',
+        code_challenge_method: 'S256',
+      },
+      mcpServers: {
+        proxy: { command: 'node', args: ['server.js'] },
+      },
+    }), '.mcp.json');
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 0);
   });
 
   it('reports confused deputy and missing PKCE independently in one config', async () => {

--- a/cli/__tests__/mcp-oauth.test.js
+++ b/cli/__tests__/mcp-oauth.test.js
@@ -73,6 +73,50 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 1);
   });
 
+  it('ignores downstream request examples inside strings', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+      server.tool('search', async (request) => {
+        const token = request.headers.authorization;
+        const example = "fetch(url, { headers: { Authorization: token } })";
+        return example;
+      });
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_UPSTREAM_TOKEN_PASSTHROUGH').length, 0);
+  });
+
+  it('tracks JavaScript token identifiers containing dollar signs', async () => {
+    for (const tokenName of ['$token', 'access$token']) {
+      const findings = await scan(`
+        import jwt from 'jsonwebtoken';
+        import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+        const server = new McpServer({ name: 'demo', version: '1.0.0' });
+        server.tool('search', async (request) => {
+          const ${tokenName} = request.headers.authorization;
+          jwt.verify(${tokenName}, key, { audience: 'mcp-server' });
+          return fetch('https://api.example.com/search', {
+            headers: { Authorization: ${tokenName} },
+          });
+        });
+      `);
+
+      assert.equal(
+        findings.filter((finding) => finding.rule === 'MCP_UPSTREAM_TOKEN_PASSTHROUGH').length,
+        1,
+        tokenName,
+      );
+      assert.equal(
+        findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length,
+        0,
+        tokenName,
+      );
+    }
+  });
+
   it('does not treat a custom request id header as an OAuth token', async () => {
     const findings = await scan(`
       import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -277,6 +321,55 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     assert.equal(findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length, 0);
   });
 
+  it('keeps quoted audience keys visible in token validation calls', async () => {
+    const cases = [
+      {
+        name: 'JavaScript',
+        ext: '.js',
+        code: `
+          import jwt from 'jsonwebtoken';
+          import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+          const server = new McpServer({ name: 'demo' });
+          server.tool('profile', async (request) => {
+            const token = request.headers.authorization;
+            return jwt.verify(token, key, { "audience": 'mcp-server' });
+          });
+        `,
+      },
+      {
+        name: 'Python',
+        ext: '.py',
+        code: `
+          from mcp.server.fastmcp import FastMCP
+          mcp = FastMCP('demo')
+          def profile(request):
+              token = request.headers.get('Authorization')
+              return jwt.decode(token, key, **{"audience": 'mcp-server'})
+        `,
+      },
+      {
+        name: 'Ruby',
+        ext: '.rb',
+        code: `
+          MCPServer.new
+          def profile(request)
+            token = request['authorization']
+            jwt.verify(token, key, 'audience' => 'mcp-server')
+          end
+        `,
+      },
+    ];
+
+    for (const testCase of cases) {
+      const findings = await scan(testCase.code, testCase.ext);
+      assert.equal(
+        findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length,
+        0,
+        testCase.name,
+      );
+    }
+  });
+
   it('does not let unrelated credential exchange hide the inbound token finding', async () => {
     const findings = await scan(`
       import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -398,6 +491,39 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     `);
 
     assert.equal(findings.filter((finding) => finding.rule === 'MCP_STATIC_CLIENT_ID_DYNAMIC_REG').length, 0);
+  });
+
+  it('ignores OAuth config examples inside ordinary strings', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+      const server = new McpServer({ name: 'oauth-proxy', version: '1.0.0' });
+      const docs = {
+        staticExample: "client_id: 'mcp-prod', dynamic_client_registration: true",
+        flowExample: "response_type: 'code'",
+      };
+    `);
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_STATIC_CLIENT_ID_DYNAMIC_REG').length, 0);
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 0);
+  });
+
+  it('keeps JavaScript escaped quotes and template text out of structural matching', async () => {
+    const backtick = String.fromCharCode(96);
+    const findings = await scan([
+      "import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';",
+      "const server = new McpServer({ name: 'oauth-proxy' });",
+      'const escaped = "example \\" // { client_id: \'fake\', dynamic_client_registration: true";',
+      `const template = ${backtick}# } response_type: 'code'; code_challenge: true${backtick};`,
+      'const oauth = {',
+      "  response_type: 'code',",
+      "  authorization_endpoint: 'https://idp.example.com/authorize',",
+      "  token_endpoint: 'https://idp.example.com/token',",
+      '};',
+    ].join('\n'));
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_STATIC_CLIENT_ID_DYNAMIC_REG').length, 0);
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 1);
   });
 
   it('flags an MCP authorization-code flow without PKCE', async () => {
@@ -534,6 +660,64 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     }
   });
 
+  it('ignores OAuth-shaped code inside Python triple-quoted docstrings', async () => {
+    for (const delimiter of ['"""', "'''"]) {
+      const findings = await scan([
+        'from mcp.server.fastmcp import FastMCP',
+        'mcp = FastMCP("demo")',
+        'def documented_handler(request):',
+        `    ${delimiter}Example # { } " ' response_type: code`,
+        "    token = request.headers.get('Authorization')",
+        "    return httpx.get(url, headers={'Authorization': token})",
+        '    validate(token, { audience: "mcp-server" })',
+        '    code_challenge = "example"',
+        `    ${delimiter}`,
+        '    return None',
+      ].join('\n'), '.py');
+
+      const oauthRules = new Set([
+        'MCP_UPSTREAM_TOKEN_PASSTHROUGH',
+        'MCP_TOKEN_AUDIENCE_UNVALIDATED',
+        'MCP_OAUTH_NO_PKCE',
+      ]);
+      assert.equal(
+        findings.filter((finding) => oauthRules.has(finding.rule)).length,
+        0,
+        delimiter,
+      );
+    }
+  });
+
+  it('does not let Python docstring mitigations hide real unsafe OAuth code', async () => {
+    for (const delimiter of ['"""', "'''"]) {
+      const findings = await scan([
+        'from mcp.server.fastmcp import FastMCP',
+        'mcp = FastMCP("demo")',
+        '@mcp.tool()',
+        'def profile(request):',
+        `    ${delimiter}validate(token, { audience: "mcp-server" })`,
+        '    exchangeToken(token) # { }',
+        '    code_challenge = "example"',
+        `    ${delimiter}`,
+        "    token = request.headers.get('Authorization')",
+        '    claims = jwt.decode(token, key)',
+        "    oauth = {'response_type': 'code'}",
+        '    return claims',
+      ].join('\n'), '.py');
+
+      assert.equal(
+        findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length,
+        1,
+        delimiter,
+      );
+      assert.equal(
+        findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length,
+        1,
+        delimiter,
+      );
+    }
+  });
+
   it('uses the Python MCP tool token and outbound request shapes', async () => {
     const cases = [
       {
@@ -622,6 +806,37 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     assert.equal(findings.filter((finding) => finding.rule === 'MCP_UPSTREAM_TOKEN_PASSTHROUGH').length, 0);
   });
 
+  it('keeps Ruby audience validation inside methods with nested end blocks', async () => {
+    const blocks = {
+      if: "if request\n    puts 'nested'\n  end",
+      unless: "unless request.nil?\n    puts 'nested'\n  end",
+      case: "case request.path\n  when '/profile'\n    puts 'nested'\n  end",
+      begin: "begin\n    puts 'nested'\n  rescue StandardError\n    puts 'handled'\n  end",
+      do: "[request].each do |item|\n    puts item\n  end",
+      while: "while request.pending?\n    break\n  end",
+      until: "until request.ready?\n    break\n  end",
+      for: "for item in [request]\n    puts item\n  end",
+    };
+
+    for (const [name, block] of Object.entries(blocks)) {
+      const findings = await scan(`
+        MCPServer.new
+
+        def handle(request)
+          token = request['authorization']
+          ${block}
+          jwt.verify(token, key, audience: 'mcp-server')
+        end
+      `, '.rb');
+
+      assert.equal(
+        findings.filter((finding) => finding.rule === 'MCP_TOKEN_AUDIENCE_UNVALIDATED').length,
+        0,
+        name,
+      );
+    }
+  });
+
   it('does not flag an unrelated Go helper in an MCP-containing file', async () => {
     const findings = await scan(`
       package main
@@ -673,6 +888,66 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     ].join('\n'), '.rb');
 
     assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 1);
+  });
+
+  it('ignores OAuth source candidates inside Go raw and Ruby command strings', async () => {
+    const backtick = String.fromCharCode(96);
+    const cases = [
+      {
+        ext: '.go',
+        code: [
+          'package main',
+          'import mcp "github.com/modelcontextprotocol/go-sdk/mcp"',
+          'var server = mcp.NewServer()',
+          `var docs = ${backtick}token := request.Header.Get("Authorization")`,
+          'client_id: "mcp-prod", dynamic_client_registration: true',
+          `response_type: "code" # { } // /* */${backtick}`,
+        ].join('\n'),
+      },
+      {
+        ext: '.rb',
+        code: [
+          "require 'mcp'",
+          'server = MCP::Server.new',
+          `docs = ${backtick}token = request.headers['Authorization']`,
+          "client_id: 'mcp-prod', dynamic_client_registration: true",
+          `response_type: 'code' # { } // /* */${backtick}`,
+        ].join('\n'),
+      },
+    ];
+
+    const oauthRules = new Set([
+      'MCP_TOKEN_AUDIENCE_UNVALIDATED',
+      'MCP_STATIC_CLIENT_ID_DYNAMIC_REG',
+      'MCP_OAUTH_NO_PKCE',
+    ]);
+    for (const testCase of cases) {
+      const findings = await scan(testCase.code, testCase.ext);
+      assert.equal(
+        findings.filter((finding) => oauthRules.has(finding.rule)).length,
+        0,
+        testCase.ext,
+      );
+    }
+  });
+
+  it('fails closed on OAuth-shaped text in an unterminated string', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+      const docs = "token = request.headers.authorization;
+      fetch(url, { headers: { Authorization: token } });
+      client_id: 'mcp-prod'; dynamic_client_registration: true;
+      response_type: 'code';
+    `);
+
+    const oauthRules = new Set([
+      'MCP_UPSTREAM_TOKEN_PASSTHROUGH',
+      'MCP_TOKEN_AUDIENCE_UNVALIDATED',
+      'MCP_STATIC_CLIENT_ID_DYNAMIC_REG',
+      'MCP_OAUTH_NO_PKCE',
+    ]);
+    assert.equal(findings.filter((finding) => oauthRules.has(finding.rule)).length, 0);
   });
 
   it('keeps Ruby hash-rocket PKCE keys visible to mitigation detection', async () => {

--- a/cli/__tests__/mcp-oauth.test.js
+++ b/cli/__tests__/mcp-oauth.test.js
@@ -644,6 +644,61 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     assert.equal(findings.filter((finding) => finding.rule === 'MCP_UPSTREAM_TOKEN_PASSTHROUGH').length, 0);
   });
 
+  it('does not let Go raw string markers hide a following OAuth object', async () => {
+    const rawDelimiter = String.fromCharCode(96);
+    const findings = await scan([
+      'package main',
+      'import mcp "github.com/modelcontextprotocol/go-sdk/mcp"',
+      'var server = mcp.NewServer()',
+      `var raw = ${rawDelimiter}first // literal`,
+      '/* literal */ # { }',
+      `path\\${rawDelimiter}`,
+      'var oauth = map[string]string{',
+      '  "response_type": "code",',
+      '  "authorization_endpoint": "https://idp.example.com/authorize",',
+      '  "token_endpoint": "https://idp.example.com/token",',
+      '}',
+    ].join('\n'), '.go');
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 1);
+  });
+
+  it('does not let Ruby backtick content hide a following OAuth object', async () => {
+    const rawDelimiter = String.fromCharCode(96);
+    const findings = await scan([
+      "require 'mcp'",
+      'server = MCP::Server.new',
+      `note = ${rawDelimiter}echo "# { / } // /* literal */"${rawDelimiter}`,
+      "oauth = { 'response_type' => 'code', 'authorization_endpoint' => 'https://idp.example.com/authorize', 'token_endpoint' => 'https://idp.example.com/token' }",
+    ].join('\n'), '.rb');
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 1);
+  });
+
+  it('keeps Ruby hash-rocket PKCE keys visible to mitigation detection', async () => {
+    const findings = await scan(`
+      require 'mcp'
+
+      class MCP::Proxy
+        OAUTH = { 'response_type' => 'code', 'authorization_endpoint' => 'https://idp.example.com/authorize', 'token_endpoint' => 'https://idp.example.com/token', 'code_challenge' => challenge, 'code_verifier' => verifier, 'pkce' => true }
+      end
+    `, '.rb');
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 0);
+  });
+
+  it('reports an unsafe Ruby hash-rocket authorization-code flow without PKCE', async () => {
+    const findings = await scan(`
+      require 'mcp'
+
+      class MCP::Proxy
+        OAUTH = { 'response_type' => 'code', 'authorization_endpoint' => 'https://idp.example.com/authorize', 'token_endpoint' => 'https://idp.example.com/token' }
+      end
+    `, '.rb');
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_OAUTH_NO_PKCE').length, 1);
+  });
+
   it('does not apply the JavaScript outbound shape to Python', async () => {
     const findings = await scan(`
       from mcp.server.fastmcp import FastMCP

--- a/cli/__tests__/mcp-oauth.test.js
+++ b/cli/__tests__/mcp-oauth.test.js
@@ -432,7 +432,7 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     }
   });
 
-  it('uses language-specific token and outbound request shapes', async () => {
+  it('uses the Python MCP tool token and outbound request shapes', async () => {
     const cases = [
       {
         name: 'Python',
@@ -442,41 +442,10 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
           import requests
 
           mcp = FastMCP('demo')
+          @mcp.tool()
           def lookup(request):
               token = request.headers.get('Authorization')
               return requests.get('https://api.example.com/search', headers={'Authorization': token})
-        `,
-      },
-      {
-        name: 'Ruby',
-        ext: '.rb',
-        code: `
-          require 'net/http'
-          class MCP::Server
-            def lookup(request)
-              token = request.headers['Authorization']
-              Net::HTTP.get(URI('https://api.example.com/search'), { 'Authorization' => token })
-            end
-          end
-        `,
-      },
-      {
-        name: 'Go',
-        ext: '.go',
-        code: `
-          package main
-          import (
-            "net/http"
-            mcp "github.com/modelcontextprotocol/go-sdk/mcp"
-          )
-
-          var server = mcp.NewServer()
-          func lookup(r *http.Request) {
-            token := r.Header.Get("Authorization")
-            req, _ := http.NewRequest("GET", "https://api.example.com/search", nil)
-            req.Header.Set("Authorization", token)
-            client.Do(req)
-          }
         `,
       },
     ];
@@ -486,6 +455,91 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
       const hits = findings.filter((finding) => finding.rule === 'MCP_UPSTREAM_TOKEN_PASSTHROUGH');
       assert.equal(hits.length, 1, `${testCase.name} token passthrough shape was not detected`);
     }
+  });
+
+  it('does not flag an unrelated Python helper in an MCP-containing file', async () => {
+    const findings = await scan(`
+      from mcp.server.fastmcp import FastMCP
+      import requests
+
+      mcp = FastMCP('demo')
+
+      def unrelated_proxy(request):
+          token = request.headers.get('Authorization')
+          return requests.get('https://api.example.com/search', headers={'Authorization': token})
+    `, '.py');
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_UPSTREAM_TOKEN_PASSTHROUGH').length, 0);
+  });
+
+  it('flags a passthrough from an async decorated Python MCP tool', async () => {
+    const findings = await scan(`
+      from mcp.server.fastmcp import FastMCP
+      import requests
+
+      mcp = FastMCP('demo')
+
+      @mcp.tool()
+      async def lookup(request):
+          token = request.headers.get('Authorization')
+          return await requests.get('https://api.example.com/search', headers={'Authorization': token})
+    `, '.py');
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_UPSTREAM_TOKEN_PASSTHROUGH').length, 1);
+  });
+
+  it('does not treat a generic Python tool decorator as an MCP handler', async () => {
+    const findings = await scan(`
+      from mcp.server.fastmcp import FastMCP
+      import requests
+
+      mcp = FastMCP('demo')
+
+      @tool
+      def lookup(request):
+          token = request.headers.get('Authorization')
+          return requests.get('https://api.example.com/search', headers={'Authorization': token})
+    `, '.py');
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_UPSTREAM_TOKEN_PASSTHROUGH').length, 0);
+  });
+
+  it('does not flag an unrelated Ruby helper in an MCP-containing file', async () => {
+    const findings = await scan(`
+      require 'mcp'
+      require 'net/http'
+
+      server = MCP::Server.new(name: 'demo')
+
+      def unrelated_proxy(request)
+        token = request.headers['Authorization']
+        Net::HTTP.get(URI('https://api.example.com/search'), { 'Authorization' => token })
+      end
+    `, '.rb');
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_UPSTREAM_TOKEN_PASSTHROUGH').length, 0);
+  });
+
+  it('does not flag an unrelated Go helper in an MCP-containing file', async () => {
+    const findings = await scan(`
+      package main
+
+      import (
+        "net/http"
+        mcp "github.com/modelcontextprotocol/go-sdk/mcp"
+      )
+
+      var server = mcp.NewServer()
+
+      func unrelatedProxy(r *http.Request) {
+        token := r.Header.Get("Authorization")
+        req, _ := http.NewRequest("GET", "https://api.example.com/search", nil)
+        req.Header.Set("Authorization", token)
+        http.DefaultClient.Do(req)
+      }
+    `, '.go');
+
+    assert.equal(findings.filter((finding) => finding.rule === 'MCP_UPSTREAM_TOKEN_PASSTHROUGH').length, 0);
   });
 
   it('does not apply the JavaScript outbound shape to Python', async () => {

--- a/cli/__tests__/mcp-oauth.test.js
+++ b/cli/__tests__/mcp-oauth.test.js
@@ -97,6 +97,58 @@ describe('MCPSecurityAgent — OAuth security rules', () => {
     }
   });
 
+  it('does not attribute a following MCP tool registration to a preceding helper', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+      import jwt from 'jsonwebtoken';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+
+      function helper(request) {
+        const token = request.headers.authorization;
+        jwt.verify(token, key);
+        return fetch('https://api.example.com', {
+          headers: { Authorization: token },
+        });
+      }
+
+      server.tool('real', async (request) => 'ok');
+    `);
+
+    const oauthRules = new Set([
+      'MCP_UPSTREAM_TOKEN_PASSTHROUGH',
+      'MCP_TOKEN_AUDIENCE_UNVALIDATED',
+    ]);
+    assert.equal(findings.filter((finding) => oauthRules.has(finding.rule)).length, 0);
+  });
+
+  it('does not attribute a preceding MCP tool registration to a following helper', async () => {
+    const findings = await scan(`
+      import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+      import jwt from 'jsonwebtoken';
+
+      const server = new McpServer({ name: 'demo', version: '1.0.0' });
+
+      server.tool('real', async (request) => {
+        return 'ok';
+      });
+
+      function helper(request) {
+        const token = request.headers.authorization;
+        jwt.verify(token, key);
+        return fetch('https://api.example.com', {
+          headers: { Authorization: token },
+        });
+      }
+    `);
+
+    const oauthRules = new Set([
+      'MCP_UPSTREAM_TOKEN_PASSTHROUGH',
+      'MCP_TOKEN_AUDIENCE_UNVALIDATED',
+    ]);
+    assert.equal(findings.filter((finding) => oauthRules.has(finding.rule)).length, 0);
+  });
+
   it('ignores downstream request examples inside strings', async () => {
     const findings = await scan(`
       import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';

--- a/cli/agents/base-agent.js
+++ b/cli/agents/base-agent.js
@@ -326,13 +326,14 @@ export class BaseAgent {
   /**
    * Scan file lines against an array of regex patterns.
    * Returns findings for every match.
+   * @param {string} [content] — preloaded source content when the caller already has it.
    */
-  scanFileWithPatterns(filePath, patterns) {
-    const content = this.readFile(filePath);
-    if (!content) return [];
+  scanFileWithPatterns(filePath, patterns, content = undefined) {
+    const source = content === undefined ? this.readFile(filePath) : content;
+    if (!source) return [];
 
     const lang = languageOf(filePath);
-    const lines = content.split('\n');
+    const lines = source.split('\n');
     const findings = [];
 
     for (let i = 0; i < lines.length; i++) {

--- a/cli/agents/mcp-security-agent.js
+++ b/cli/agents/mcp-security-agent.js
@@ -308,9 +308,42 @@ function isOAuthTokenName(name) {
 
 function sourceLineHelpers(content) {
   const lines = content.split('\n');
-  const lineNumber = (index) => content.slice(0, index).split('\n').length;
+  const lineStarts = [0];
+  for (let index = 0; index < content.length; index += 1) {
+    if (content[index] === '\n') lineStarts.push(index + 1);
+  }
+
+  const lineNumber = (index) => {
+    let low = 0;
+    let high = lineStarts.length;
+    while (low < high) {
+      const middle = (low + high) >>> 1;
+      if (lineStarts[middle] <= index) low = middle + 1;
+      else high = middle;
+    }
+    return low;
+  };
   const lineText = (index) => (lines[lineNumber(index) - 1] || '').trim().slice(0, 180);
   return { lineNumber, lineText };
+}
+
+function createSourceContext(filePath, content) {
+  const language = languageOf(filePath);
+  const code = content && stripComments(content, language);
+  return {
+    content,
+    language,
+    code,
+    structuralCode: code && MCP_OAUTH_MARKER.test(code)
+      ? maskStrings(code, false, language)
+      : null,
+    lineHelpers: null,
+  };
+}
+
+function sourceLineHelpersFor(source) {
+  if (!source.lineHelpers) source.lineHelpers = sourceLineHelpers(source.content);
+  return source.lineHelpers;
 }
 
 function createStaticClientIdDynamicRegFinding({ file, line, category, matched }) {
@@ -469,8 +502,8 @@ function maskStrings(content, preserveObjectKeys = false, language = 'js') {
   return output.join('');
 }
 
-function findBracePairs(content, language) {
-  const code = maskStrings(stripComments(content, language), false, language);
+function findBracePairs(content, language, structuralCode = null) {
+  const code = structuralCode ?? maskStrings(stripComments(content, language), false, language);
   const stack = [];
   const pairs = [];
 
@@ -485,7 +518,7 @@ function findBracePairs(content, language) {
   return pairs;
 }
 
-function sourceFunctionScopes(content, language) {
+function sourceFunctionScopes(content, language, structuralCode = null) {
   if (language === 'python' || language === 'ruby') {
     const lines = content.split('\n');
     const offsets = [];
@@ -531,8 +564,8 @@ function sourceFunctionScopes(content, language) {
     return scopes;
   }
 
-  const code = maskStrings(stripComments(content, language), false, language);
-  return findBracePairs(content, language)
+  const code = structuralCode ?? maskStrings(stripComments(content, language), false, language);
+  return findBracePairs(content, language, code)
     .filter(({ start }) => isFunctionBrace(code, start, language));
 }
 
@@ -542,9 +575,9 @@ function isFunctionBrace(code, start, language) {
   return language === 'js' && /\bfunction\b[\s\S]{0,160}$|=>\s*$/.test(prefix);
 }
 
-function sourceObjectScopes(content, language) {
-  const code = maskStrings(stripComments(content, language), false, language);
-  return findBracePairs(content, language)
+function sourceObjectScopes(content, language, structuralCode = null) {
+  const code = structuralCode ?? maskStrings(stripComments(content, language), false, language);
+  return findBracePairs(content, language, code)
     .filter(({ start }) => !isFunctionBrace(code, start, language));
 }
 
@@ -557,16 +590,16 @@ function braceDepthAt(code, scope, index) {
   return depth;
 }
 
-function objectScopeContaining(code, scopes, firstIndex, secondIndex, language = 'js') {
-  const structuralCode = maskStrings(code, false, language);
+function objectScopeContaining(code, scopes, firstIndex, secondIndex, language = 'js', structuralCode = null) {
+  const structuralView = structuralCode ?? maskStrings(code, false, language);
   return scopes
     .filter((scope) => (
       scope.start <= firstIndex
       && firstIndex < scope.end
       && scope.start <= secondIndex
       && secondIndex < scope.end
-      && braceDepthAt(structuralCode, scope, firstIndex) === 1
-      && braceDepthAt(structuralCode, scope, secondIndex) === 1
+      && braceDepthAt(structuralView, scope, firstIndex) === 1
+      && braceDepthAt(structuralView, scope, secondIndex) === 1
     ))
     .sort((left, right) => (left.end - left.start) - (right.end - right.start))[0] || null;
 }
@@ -708,11 +741,12 @@ export class MCPSecurityAgent extends BaseAgent {
     });
 
     for (const file of codeFiles) {
-      findings = findings.concat(this.scanFileWithPatterns(file, PATTERNS));
-      findings = findings.concat(this._checkOAuthTokenPassthrough(file));
-      findings = findings.concat(this._checkOAuthAudienceValidation(file));
-      findings = findings.concat(this._checkOAuthConfusedDeputy(file));
-      findings = findings.concat(this._checkOAuthPkce(file));
+      const source = createSourceContext(file, this.readFile(file));
+      findings = findings.concat(this.scanFileWithPatterns(file, PATTERNS, source.content));
+      findings = findings.concat(this._checkOAuthTokenPassthrough(file, source));
+      findings = findings.concat(this._checkOAuthAudienceValidation(file, source));
+      findings = findings.concat(this._checkOAuthConfusedDeputy(file, source));
+      findings = findings.concat(this._checkOAuthPkce(file, source));
     }
 
     // ── 2. Scan MCP config files ─────────────────────────────────────────
@@ -767,25 +801,25 @@ export class MCPSecurityAgent extends BaseAgent {
    * its own shape so a JavaScript expression cannot report on Python, Ruby,
    * or Go by accident (issue #105).
    */
-  _checkOAuthTokenPassthrough(filePath) {
+  _checkOAuthTokenPassthrough(filePath, preparedSource = null) {
     const language = languageOf(filePath);
     const shape = MCP_OAUTH_SHAPES[language];
     if (!shape) return [];
 
-    const content = this.readFile(filePath);
-    const code = content && stripComments(content, language);
+    const source = preparedSource || createSourceContext(filePath, this.readFile(filePath));
+    const { content, code } = source;
     if (!code || !MCP_OAUTH_MARKER.test(code)) {
       return [];
     }
 
-    const scopes = sourceFunctionScopes(content, language);
+    const scopes = sourceFunctionScopes(content, language, source.structuralCode);
     const inboundCandidates = allRegexMatches(shape.inboundToken, code);
     const directCandidates = allRegexMatches(shape.directToken, code)
       .filter((direct) => !inboundCandidates.some((inbound) => (
         inbound.index <= direct.index && direct.index < inbound.index + inbound[0].length
       )));
     const outbound = shape.outboundRequest;
-    const { lineNumber, lineText } = sourceLineHelpers(content);
+    const { lineNumber, lineText } = sourceLineHelpersFor(source);
     const makeFinding = (requestIndex) => {
       if (this.isSuppressed(lineText(requestIndex), 'high')) return null;
 
@@ -854,18 +888,18 @@ export class MCPSecurityAgent extends BaseAgent {
    * server itself. Token exchange is a valid alternative because it mints a
    * new token for the downstream audience.
    */
-  _checkOAuthAudienceValidation(filePath) {
-    const shape = MCP_OAUTH_SHAPES[languageOf(filePath)];
+  _checkOAuthAudienceValidation(filePath, preparedSource = null) {
+    const language = languageOf(filePath);
+    const shape = MCP_OAUTH_SHAPES[language];
     if (!shape) return [];
 
-    const content = this.readFile(filePath);
-    const language = languageOf(filePath);
-    const code = content && stripComments(content, language);
+    const source = preparedSource || createSourceContext(filePath, this.readFile(filePath));
+    const { content, code } = source;
     if (!code || !MCP_OAUTH_MARKER.test(code)) {
       return [];
     }
 
-    const scopes = sourceFunctionScopes(content, language);
+    const scopes = sourceFunctionScopes(content, language, source.structuralCode);
     const inboundCandidates = allRegexMatches(shape.inboundToken, code);
     const directCandidates = allRegexMatches(shape.directToken, code)
       .filter((direct) => !inboundCandidates.some((inbound) => (
@@ -875,7 +909,7 @@ export class MCPSecurityAgent extends BaseAgent {
       .sort((left, right) => left.index - right.index);
     const audienceValidation = shape.audienceValidation;
     const tokenExchange = MCP_OAUTH_TOKEN_EXCHANGE;
-    const { lineNumber, lineText } = sourceLineHelpers(content);
+    const { lineNumber, lineText } = sourceLineHelpersFor(source);
     const findings = [];
     const seenScopes = new Set();
 
@@ -926,26 +960,26 @@ export class MCPSecurityAgent extends BaseAgent {
    * Detect a static OAuth client id used alongside dynamic client
    * registration in an MCP proxy.
    */
-  _checkOAuthConfusedDeputy(filePath) {
+  _checkOAuthConfusedDeputy(filePath, preparedSource = null) {
     const language = languageOf(filePath);
     const shape = MCP_OAUTH_SHAPES[language];
     if (!shape) return [];
 
-    const content = this.readFile(filePath);
-    const code = content && stripComments(content, language);
+    const source = preparedSource || createSourceContext(filePath, this.readFile(filePath));
+    const { content, code } = source;
     if (!code || !MCP_OAUTH_MARKER.test(code)) {
       return [];
     }
 
-    const objectScopes = sourceObjectScopes(content, language);
+    const objectScopes = sourceObjectScopes(content, language, source.structuralCode);
     const clients = allRegexMatches(shape.staticClientId, code);
     const registrations = allRegexMatches(MCP_OAUTH_DYNAMIC_REGISTRATION, code);
-    const { lineNumber, lineText } = sourceLineHelpers(content);
+    const { lineNumber, lineText } = sourceLineHelpersFor(source);
 
     for (const client of clients) {
       if (/\$\{|\b(?:process\.env|os\.environ|getenv|ENV\[|os\.Getenv)\b/i.test(client[2])) continue;
       for (const registration of registrations) {
-        const scope = objectScopeContaining(code, objectScopes, client.index, registration.index, language);
+        const scope = objectScopeContaining(code, objectScopes, client.index, registration.index, language, source.structuralCode);
         if (!scope || this.isSuppressed(lineText(client.index), 'high')) continue;
 
         return [createStaticClientIdDynamicRegFinding({
@@ -963,27 +997,27 @@ export class MCPSecurityAgent extends BaseAgent {
   /**
    * Detect an OAuth authorization-code flow that does not use PKCE.
    */
-  _checkOAuthPkce(filePath) {
+  _checkOAuthPkce(filePath, preparedSource = null) {
     const language = languageOf(filePath);
     const shape = MCP_OAUTH_SHAPES[language];
     if (!shape) return [];
 
-    const content = this.readFile(filePath);
-    const code = content && stripComments(content, language);
+    const source = preparedSource || createSourceContext(filePath, this.readFile(filePath));
+    const { content, code } = source;
     if (!code || !MCP_OAUTH_MARKER.test(code)) {
       return [];
     }
 
-    const objectScopes = sourceObjectScopes(content, language);
-    const functionScopes = sourceFunctionScopes(content, language);
+    const objectScopes = sourceObjectScopes(content, language, source.structuralCode);
+    const functionScopes = sourceFunctionScopes(content, language, source.structuralCode);
     const codeFlows = allRegexMatches(shape.codeFlow, code);
     const pkce = MCP_OAUTH_PKCE;
-    const { lineNumber, lineText } = sourceLineHelpers(content);
+    const { lineNumber, lineText } = sourceLineHelpersFor(source);
     const findings = [];
     const reportedScopes = new Set();
 
     for (const flowMatch of codeFlows) {
-      const scope = objectScopeContaining(code, objectScopes, flowMatch.index, flowMatch.index, language)
+      const scope = objectScopeContaining(code, objectScopes, flowMatch.index, flowMatch.index, language, source.structuralCode)
         || sourceScopeContaining(content, code, language, functionScopes, flowMatch.index, flowMatch.index + flowMatch[0].length);
       if (!scope) continue;
 

--- a/cli/agents/mcp-security-agent.js
+++ b/cli/agents/mcp-security-agent.js
@@ -680,7 +680,7 @@ function sourceScopeContaining(content, code, language, scopes, start, end = sta
   };
 }
 
-function isDirectMcpCallback(callbackHeader) {
+function isDirectMcpCallback(callbackHeader, scopeStart = null, headerStart = 0, scopeIsBrace = false) {
   const functionMatch = allRegexMatches(/\bfunction\b/g, callbackHeader).at(-1);
   const callback = Math.max(
     callbackHeader.lastIndexOf('=>'),
@@ -696,7 +696,35 @@ function isDirectMcpCallback(callbackHeader) {
     if (callbackHeader[index] === '{') braces += 1;
     if (callbackHeader[index] === '}') braces -= 1;
   }
-  return parentheses === 1 && braces === 0;
+  if (parentheses !== 1 || braces !== 0) return false;
+  if (scopeStart === null) return true;
+
+  let callbackBodyStart = -1;
+  if (callbackHeader.startsWith('=>', callback)) {
+    callbackBodyStart = callback + 2;
+    while (/\s/.test(callbackHeader[callbackBodyStart] || '')) callbackBodyStart += 1;
+    if (callbackHeader[callbackBodyStart] !== '{') callbackBodyStart = -1;
+  } else {
+    let parameterDepth = 0;
+    let sawParameters = false;
+    for (let index = callback; index < callbackHeader.length; index += 1) {
+      if (callbackHeader[index] === '(') {
+        parameterDepth += 1;
+        sawParameters = true;
+      } else if (callbackHeader[index] === ')' && sawParameters) {
+        parameterDepth -= 1;
+        if (parameterDepth === 0) {
+          callbackBodyStart = index + 1;
+          while (/\s/.test(callbackHeader[callbackBodyStart] || '')) callbackBodyStart += 1;
+          if (callbackHeader[callbackBodyStart] !== '{') callbackBodyStart = -1;
+          break;
+        }
+      }
+    }
+  }
+
+  if (scopeIsBrace && callbackBodyStart === -1) return false;
+  return callbackBodyStart === -1 || headerStart + callbackBodyStart === scopeStart;
 }
 
 function pythonMcpToolDecoratorReceiver(code, scope) {
@@ -730,12 +758,18 @@ function isMcpToolHandlerScope(code, scope, language) {
 
   if (language !== 'js') return false;
 
-  const prefix = code.slice(Math.max(0, scope.start - 320), scope.start);
+  const prefixStart = Math.max(0, scope.start - 320);
+  const prefix = code.slice(prefixStart, Math.min(code.length, scope.start + 1));
   const registrations = allRegexMatches(MCP_TOOL_REGISTRATION, prefix);
   if (registrations.length) {
     const registration = registrations.at(-1);
     const callbackHeader = prefix.slice(registration.index);
-    return isDirectMcpCallback(callbackHeader);
+    return isDirectMcpCallback(
+      callbackHeader,
+      scope.start,
+      prefixStart + registration.index,
+      code[scope.start] === '{',
+    );
   }
 
   const localHeader = code.slice(scope.start, Math.min(code.length, scope.start + 320));
@@ -743,7 +777,12 @@ function isMcpToolHandlerScope(code, scope, language) {
   if (!localRegistration) return false;
 
   const callbackHeader = localHeader.slice(localRegistration.index);
-  return isDirectMcpCallback(callbackHeader);
+  return isDirectMcpCallback(
+    callbackHeader,
+    scope.start,
+    scope.start + localRegistration.index,
+    code[scope.start] === '{',
+  );
 }
 
 function isMcpOAuthFunctionScope(code, scope, language) {

--- a/cli/agents/mcp-security-agent.js
+++ b/cli/agents/mcp-security-agent.js
@@ -376,30 +376,34 @@ function stripComments(content, language) {
   return output.join('');
 }
 
-function maskStrings(content) {
+function maskStrings(content, preserveObjectKeys = false) {
   const output = [...content];
   let state = 'code';
   let quote = '';
+  let stringStart = -1;
 
   const blank = (index) => {
     if (output[index] !== '\n' && output[index] !== '\r') output[index] = ' ';
+  };
+  const blankRange = (start, end) => {
+    for (let index = start; index <= end; index += 1) blank(index);
   };
 
   for (let index = 0; index < content.length; index += 1) {
     const char = content[index];
     if (state === 'string') {
       if (char === '\\') {
-        blank(index);
-        if (index + 1 < content.length) {
-          blank(index + 1);
-          index += 1;
-        }
+        index += 1;
       } else if (char === quote) {
+        let next = index + 1;
+        while (next < content.length && /\s/.test(content[next])) next += 1;
+        if (!preserveObjectKeys || content[next] !== ':') blankRange(stringStart, index);
         blank(index);
         state = 'code';
         quote = '';
+        stringStart = -1;
       } else {
-        blank(index);
+        continue;
       }
       continue;
     }
@@ -407,9 +411,11 @@ function maskStrings(content) {
     if (char === '\'' || char === '"' || char === '`') {
       quote = char;
       state = 'string';
-      blank(index);
+      stringStart = index;
     }
   }
+
+  if (state === 'string' && stringStart !== -1) blankRange(stringStart, content.length - 1);
 
   return output.join('');
 }
@@ -541,6 +547,27 @@ function sourceScopeContaining(content, code, language, scopes, start, end = sta
   };
 }
 
+function isMcpToolHandlerScope(code, scope, language) {
+  if (language !== 'js') return true;
+
+  const prefix = code.slice(Math.max(0, scope.start - 320), scope.start);
+  const registrations = allRegexMatches(/(?:\.\s*tool|\b(?:registerTool|addTool))\s*\(/gi, prefix);
+  if (registrations.length) {
+    const registration = registrations.at(-1);
+    const callbackHeader = prefix.slice(registration.index);
+    const callback = callbackHeader.search(/=>|\bfunction\b/);
+    return callback !== -1 && !/[{};]/.test(callbackHeader.slice(0, callback));
+  }
+
+  const localHeader = code.slice(scope.start, Math.min(code.length, scope.start + 320));
+  const localRegistration = allRegexMatches(/(?:\.\s*tool|\b(?:registerTool|addTool))\s*\(/gi, localHeader)[0];
+  if (!localRegistration) return false;
+
+  const callbackHeader = localHeader.slice(localRegistration.index);
+  const callback = callbackHeader.search(/=>|\bfunction\b/);
+  return callback !== -1 && !/[{};]/.test(callbackHeader.slice(0, callback));
+}
+
 function allRegexMatches(regex, content) {
   const flags = regex.flags.includes('g') ? regex.flags : `${regex.flags}g`;
   const scanner = new RegExp(regex.source, flags);
@@ -551,6 +578,47 @@ function allRegexMatches(regex, content) {
     if (!match[0]) scanner.lastIndex += 1;
   }
   return matches;
+}
+
+function isQuotedObjectKeyAt(content, index) {
+  const quote = content[index];
+  if (quote !== '\'' && quote !== '"') return false;
+
+  let end = index + 1;
+  while (end < content.length) {
+    if (content[end] === '\\') {
+      end += 2;
+      continue;
+    }
+    if (content[end] === quote) break;
+    end += 1;
+  }
+  if (end >= content.length) return false;
+
+  let next = end + 1;
+  while (next < content.length && /\s/.test(content[next])) next += 1;
+  return content[next] === ':';
+}
+
+function hasExplicitNoPkce(content) {
+  const masked = maskStrings(content);
+  return allRegexMatches(MCP_OAUTH_EXPLICIT_NO_PKCE, content).some((match) => (
+    masked[match.index] === content[match.index]
+    || isQuotedObjectKeyAt(content, match.index)
+  ));
+}
+
+function hasTokenRelatedMitigation(scopeContent, tokenName, mitigation) {
+  if (!tokenName) return mitigation.test(scopeContent);
+
+  const tokenReference = new RegExp(`\\b${tokenName.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')}\\b`);
+  return allRegexMatches(mitigation, scopeContent).some((match) => {
+    if (tokenReference.test(match[0])) return true;
+
+    const callEnd = scopeContent.indexOf(')', match.index);
+    const end = callEnd === -1 ? Math.min(scopeContent.length, match.index + 280) : callEnd + 1;
+    return tokenReference.test(scopeContent.slice(match.index, end));
+  });
 }
 
 // =============================================================================
@@ -680,7 +748,7 @@ export class MCPSecurityAgent extends BaseAgent {
       const tokenName = incoming[1];
       if (!isOAuthTokenName(tokenName)) continue;
       const scope = sourceScopeContaining(content, code, language, scopes, incoming.index, incoming.index + incoming[0].length);
-      if (!scope) continue;
+      if (!scope || !isMcpToolHandlerScope(code, scope, language)) continue;
       const searchStart = incoming.index + incoming[0].length;
       const searchWindow = code.slice(searchStart, Math.min(scope.end, searchStart + 1200));
       const requestMatch = searchWindow.match(outbound);
@@ -700,7 +768,7 @@ export class MCPSecurityAgent extends BaseAgent {
     for (const directMatch of directCandidates) {
       const directIndex = directMatch.index;
       const scope = sourceScopeContaining(content, code, language, scopes, directIndex, directIndex + directMatch[0].length);
-      if (!scope) continue;
+      if (!scope || !isMcpToolHandlerScope(code, scope, language)) continue;
       const beforeStart = Math.max(scope.start, directIndex - 200);
       const beforeWindow = code.slice(beforeStart, directIndex);
       const beforeRequest = beforeWindow.match(outbound);
@@ -756,7 +824,10 @@ export class MCPSecurityAgent extends BaseAgent {
       if (!scope || seenScopes.has(scope.start)) continue;
 
       const scopeContent = code.slice(scope.start, scope.end);
-      if (audienceValidation.test(scopeContent) || tokenExchange.test(scopeContent)) continue;
+      const mitigationContent = maskStrings(scopeContent);
+      const hasAudienceValidation = hasTokenRelatedMitigation(mitigationContent, incoming[1], audienceValidation);
+      const hasTokenExchange = hasTokenRelatedMitigation(mitigationContent, incoming[1], tokenExchange);
+      if (hasAudienceValidation || hasTokenExchange) continue;
       if (this.isSuppressed(lineText(incoming.index), 'high')) continue;
 
       seenScopes.add(scope.start);
@@ -846,7 +917,6 @@ export class MCPSecurityAgent extends BaseAgent {
     const functionScopes = sourceFunctionScopes(content, language);
     const codeFlows = allRegexMatches(shape.codeFlow, code);
     const pkce = MCP_OAUTH_PKCE;
-    const explicitNoPkce = MCP_OAUTH_EXPLICIT_NO_PKCE;
     const lineNumber = (index) => content.slice(0, index).split('\n').length;
     const lineText = (index) => (content.split('\n')[lineNumber(index) - 1] || '').trim().slice(0, 180);
     const findings = [];
@@ -858,7 +928,8 @@ export class MCPSecurityAgent extends BaseAgent {
       if (!scope) continue;
 
       const scopeContent = code.slice(scope.start, scope.end);
-      if (pkce.test(scopeContent) && !explicitNoPkce.test(scopeContent)) continue;
+      const mitigationContent = maskStrings(scopeContent, true);
+      if (pkce.test(mitigationContent) && !hasExplicitNoPkce(scopeContent)) continue;
       if (reportedScopes.has(scope.start)) continue;
       if (this.isSuppressed(lineText(flowMatch.index), 'high')) continue;
       reportedScopes.add(scope.start);
@@ -931,7 +1002,8 @@ export class MCPSecurityAgent extends BaseAgent {
       if (!scope || reportedScopes.has(scope.start)) continue;
 
       const scopeContent = code.slice(scope.start, scope.end);
-      if (MCP_OAUTH_PKCE.test(scopeContent) && !MCP_OAUTH_EXPLICIT_NO_PKCE.test(scopeContent)) continue;
+      const mitigationContent = maskStrings(scopeContent, true);
+      if (MCP_OAUTH_PKCE.test(mitigationContent) && !hasExplicitNoPkce(scopeContent)) continue;
       if (this.isSuppressed(lineText(flowMatch.index), 'high')) continue;
       reportedScopes.add(scope.start);
 

--- a/cli/agents/mcp-security-agent.js
+++ b/cli/agents/mcp-security-agent.js
@@ -555,14 +555,15 @@ function braceDepthAt(code, scope, index) {
 }
 
 function objectScopeContaining(code, scopes, firstIndex, secondIndex) {
+  const structuralCode = maskStrings(code);
   return scopes
     .filter((scope) => (
       scope.start <= firstIndex
       && firstIndex < scope.end
       && scope.start <= secondIndex
       && secondIndex < scope.end
-      && braceDepthAt(code, scope, firstIndex) === 1
-      && braceDepthAt(code, scope, secondIndex) === 1
+      && braceDepthAt(structuralCode, scope, firstIndex) === 1
+      && braceDepthAt(structuralCode, scope, secondIndex) === 1
     ))
     .sort((left, right) => (left.end - left.start) - (right.end - right.start))[0] || null;
 }
@@ -661,16 +662,21 @@ function hasExplicitNoPkce(content) {
   ));
 }
 
-function hasTokenRelatedMitigation(scopeContent, tokenName, mitigation) {
-  if (!tokenName) return mitigation.test(scopeContent);
+function hasTokenRelatedMitigation(scopeContent, tokenName, mitigation, directTokenReference) {
+  const tokenReference = tokenName
+    ? new RegExp(`\\b${tokenName.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')}\\b`)
+    : directTokenReference ? maskStrings(directTokenReference) : null;
+  if (!tokenReference) return false;
 
-  const tokenReference = new RegExp(`\\b${tokenName.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')}\\b`);
+  const referencesToken = (content) => tokenName
+    ? tokenReference.test(content)
+    : content.includes(tokenReference);
   return allRegexMatches(mitigation, scopeContent).some((match) => {
-    if (tokenReference.test(match[0])) return true;
+    if (referencesToken(match[0])) return true;
 
     const callEnd = scopeContent.indexOf(')', match.index);
     const end = callEnd === -1 ? Math.min(scopeContent.length, match.index + 280) : callEnd + 1;
-    return tokenReference.test(scopeContent.slice(match.index, end));
+    return referencesToken(scopeContent.slice(match.index, end));
   });
 }
 
@@ -876,8 +882,18 @@ export class MCPSecurityAgent extends BaseAgent {
 
       const scopeContent = code.slice(scope.start, scope.end);
       const mitigationContent = maskStrings(scopeContent);
-      const hasAudienceValidation = hasTokenRelatedMitigation(mitigationContent, incoming[1], audienceValidation);
-      const hasTokenExchange = hasTokenRelatedMitigation(mitigationContent, incoming[1], tokenExchange);
+      const hasAudienceValidation = hasTokenRelatedMitigation(
+        mitigationContent,
+        incoming[1],
+        audienceValidation,
+        incoming[0],
+      );
+      const hasTokenExchange = hasTokenRelatedMitigation(
+        mitigationContent,
+        incoming[1],
+        tokenExchange,
+        incoming[0],
+      );
       if (hasAudienceValidation || hasTokenExchange) continue;
       if (this.isSuppressed(lineText(incoming.index), 'high')) continue;
 

--- a/cli/agents/mcp-security-agent.js
+++ b/cli/agents/mcp-security-agent.js
@@ -19,7 +19,7 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { BaseAgent, createFinding } from './base-agent.js';
+import { BaseAgent, createFinding, languageOf } from './base-agent.js';
 
 // =============================================================================
 // MCP SECURITY PATTERNS
@@ -249,6 +249,50 @@ const OFFICIAL_MCP_SERVERS = new Set([
   '@modelcontextprotocol/server-sequential-thinking',
 ]);
 
+// OAuth request shapes are deliberately language-scoped. These rules inspect
+// source code rather than MCP JSON, so a JS header expression must not be
+// allowed to report on a Python, Ruby, or Go file by accident.
+const MCP_OAUTH_SHAPES = {
+  js: {
+    inboundToken: /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*[^;\n]*\b(?:req|request|ctx|event)\b[^;\n]*(?:authorization|bearer|headers)\b[^;\n]*;?/gi,
+    directToken: /\b(?:req|request|ctx|event)\b[^;\n]*(?:authorization|bearer|headers)\b[^;\n]*/gi,
+    outboundRequest: /\b(?:fetch|axios(?:\.[A-Za-z_$][\w$]*)?|got|https?\.request)\s*\(/i,
+    audienceValidation: /(?:\baudience\b\s*[:=]|\b(?:claims?|payload|token)\b[^\n;]{0,120}\baud\b\s*(?:===|!==|==|!=|=)|\b(?:validate|verify|check|assert)\w*[^\n;]{0,120}\baud(?:ience)?\b)/i,
+    staticClientId: /["']?\bclient[_-]?id\b["']?\s*(?:=>|:=|[:=])\s*(["'])(.*?)\1/gi,
+    codeFlow: /(?:["']?\bresponse[_-]?type\b["']?\s*[:=]\s*["']code["']|["']?\bgrant[_-]?type\b["']?\s*[:=]\s*["']authorization[_-]?code["']|\bauthorization[_-]?code\b|["']?\bauthorization[_-]?endpoint\b["']?[^\n;]{0,240}["']?\btoken[_-]?endpoint\b["']?)/i,
+  },
+  python: {
+    inboundToken: /\b([A-Za-z_]\w*)\s*=\s*(?:request|req|ctx|context)\b[^\n]*(?:headers?|authorization|bearer)[^\n]*/gi,
+    directToken: /\b(?:request|req|ctx|context)\b[^\n]*(?:headers?|authorization|bearer)[^\n]*/gi,
+    outboundRequest: /\b(?:requests|httpx)\.(?:get|post|put|patch|delete|request)\s*\(|\b(?:urllib\.request\.)?urlopen\s*\(/i,
+    audienceValidation: /(?:\baudience\b\s*=|["']aud["']\s*\]|\b(?:claims?|payload)\b[^\n]{0,120}\baud\b\s*(?:==|!=|in\b))/i,
+    staticClientId: /["']?\bclient[_-]?id\b["']?\s*(?:=>|:=|[:=])\s*(["'])(.*?)\1/gi,
+    codeFlow: /(?:["']?\bresponse[_-]?type\b["']?\s*[:=]\s*["']code["']|["']?\bgrant[_-]?type\b["']?\s*[:=]\s*["']authorization[_-]?code["']|\bauthorization[_-]?code\b|["']?\bauthorization[_-]?endpoint\b["']?[^\n]{0,240}["']?\btoken[_-]?endpoint\b["']?)/i,
+  },
+  ruby: {
+    inboundToken: /\b([A-Za-z_]\w*)\s*=\s*(?:request|req|context|env|headers)\b[^\n]*(?:headers?|authorization|bearer)[^\n]*/gi,
+    directToken: /\b(?:request|req|context|env|headers)\b[^\n]*(?:headers?|authorization|bearer)[^\n]*/gi,
+    outboundRequest: /\b(?:Net::HTTP|Faraday|HTTParty|RestClient)\b[\s\S]{0,120}\b(?:get|post|put|delete|request|call)\b\s*[.(]/i,
+    audienceValidation: /(?:\baudience\s*[:=]|["']aud["']\s*=>|\b(?:claims?|payload)\b[^\n]{0,120}\baud\b\s*(?:==|!=|=~))/i,
+    staticClientId: /["']?\bclient[_-]?id\b["']?\s*(?:=>|:=|[:=])\s*(["'])(.*?)\1/gi,
+    codeFlow: /(?:["']?\bresponse[_-]?type\b["']?\s*[:=]\s*["']code["']|["']?\bgrant[_-]?type\b["']?\s*[:=]\s*["']authorization[_-]?code["']|\bauthorization[_-]?code\b|["']?\bauthorization[_-]?endpoint\b["']?[^\n]{0,240}["']?\btoken[_-]?endpoint\b["']?)/i,
+  },
+  go: {
+    inboundToken: /\b([A-Za-z_]\w*)\s*:?=\s*(?:r|req|request)\.Header\.Get\(\s*["']Authorization["']\s*\)/gi,
+    directToken: /\b(?:r|req|request)\.Header\.Get\(\s*["']Authorization["']\s*\)/gi,
+    outboundRequest: /\b(?:http\.(?:NewRequest|Get|Post|PostForm)|[A-Za-z_]\w*\.Do)\s*\(/i,
+    audienceValidation: /(?:\b(?:Audience|VerifyAudience)\b|["']aud["']\s*[:=]|\b(?:claims?|payload)\b[\s\S]{0,120}\baud\b\s*(?:==|!=))/i,
+    staticClientId: /["']?\b(?:client[_-]?id|clientID)\b["']?\s*(?:=>|:=|[:=])\s*(["'])(.*?)\1/gi,
+    codeFlow: /(?:["']?\bresponse[_-]?type\b["']?\s*[:=]\s*["']code["']|["']?\bgrant[_-]?type\b["']?\s*[:=]\s*["']authorization[_-]?code["']|\bauthorization[_-]?code\b|["']?\bauthorization[_-]?endpoint\b["']?[\s\S]{0,240}["']?\btoken[_-]?endpoint\b["']?)/i,
+  },
+};
+
+const MCP_OAUTH_DYNAMIC_REGISTRATION = /["']?(?:dynamic[_-]?client[_-]?registration|dynamicClientRegistration|allow[_-]?dynamic[_-]?registration|enable[_-]?dynamic[_-]?client[_-]?registration|dynamicRegistration|registerClients|RegisterClient)["']?\s*(?:=>|:=|[:=])\s*(?:true|["']?enabled["']?)/i;
+const MCP_OAUTH_TOKEN_EXCHANGE = /(?:exchangeToken|token[_-]?exchange|subject_token|RFC\s*8693|urn:ietf:params:oauth:grant-type:token-exchange)/i;
+const MCP_OAUTH_PKCE = /(?:\bcode[_-]?challenge\b|\bcode[_-]?verifier\b|\buse[_-]?pkce\b|\bpkce\b)/i;
+const MCP_OAUTH_EXPLICIT_NO_PKCE = /(?:["']?\b(?:use[_-]?pkce|pkce)\b["']?\s*[:=]\s*(?:false|null|["']?disabled["']?)|["']?\bcode[_-]?challenge\b["']?\s*[:=]\s*null)/i;
+const MCP_OAUTH_MARKER = /(?:\bMCP(?:::|[-_.])?(?:Server|Proxy)\b|@modelcontextprotocol|\bmcp[._-](?:server|proxy)\b|mcp\.NewServer)/i;
+
 // =============================================================================
 // MCP SECURITY AGENT
 // =============================================================================
@@ -274,6 +318,10 @@ export class MCPSecurityAgent extends BaseAgent {
 
     for (const file of codeFiles) {
       findings = findings.concat(this.scanFileWithPatterns(file, PATTERNS));
+      findings = findings.concat(this._checkOAuthTokenPassthrough(file));
+      findings = findings.concat(this._checkOAuthAudienceValidation(file));
+      findings = findings.concat(this._checkOAuthConfusedDeputy(file));
+      findings = findings.concat(this._checkOAuthPkce(file));
     }
 
     // ── 2. Scan MCP config files ─────────────────────────────────────────
@@ -286,6 +334,7 @@ export class MCPSecurityAgent extends BaseAgent {
     for (const file of configFiles) {
       findings = findings.concat(this.scanFileWithPatterns(file, PATTERNS));
       findings = findings.concat(this._checkConfigFile(file));
+      findings = findings.concat(this._checkOAuthConfig(file));
     }
 
     // ── 3. Check for MCP server files without auth patterns ──────────────
@@ -318,6 +367,278 @@ export class MCPSecurityAgent extends BaseAgent {
     }
 
     return findings;
+  }
+
+  /**
+   * Detect an inbound MCP bearer token copied into a downstream request.
+   *
+   * Request/header syntax is language-specific. Each supported language gets
+   * its own shape so a JavaScript expression cannot report on Python, Ruby,
+   * or Go by accident (issue #105).
+   */
+  _checkOAuthTokenPassthrough(filePath) {
+    const shape = MCP_OAUTH_SHAPES[languageOf(filePath)];
+    if (!shape) return [];
+
+    const content = this.readFile(filePath);
+    if (!content || !MCP_OAUTH_MARKER.test(content)) {
+      return [];
+    }
+
+    const inbound = shape.inboundToken;
+    inbound.lastIndex = 0;
+    const outbound = shape.outboundRequest;
+    const direct = shape.directToken;
+    direct.lastIndex = 0;
+    const lineNumber = (index) => content.slice(0, index).split('\n').length;
+    const lineText = (index) => (content.split('\n')[lineNumber(index) - 1] || '').trim().slice(0, 180);
+    const makeFinding = (requestIndex) => {
+      if (this.isSuppressed(lineText(requestIndex), 'high')) return null;
+
+      return createFinding({
+        file: filePath,
+        line: lineNumber(requestIndex),
+        column: 1,
+        severity: 'high',
+        category: this.category,
+        rule: 'MCP_UPSTREAM_TOKEN_PASSTHROUGH',
+        title: 'MCP: Inbound OAuth Token Passed Through Downstream',
+        description: 'An MCP tool reads an inbound authorization token and forwards it unchanged to a downstream request. This can bypass audience validation and downstream trust boundaries.',
+        matched: lineText(requestIndex),
+        confidence: 'high',
+        cwe: 'CWE-345',
+        owasp: 'ASI03:2026',
+        fix: 'Validate the inbound token for the MCP server and use RFC 8693 token exchange to mint a downstream-audience token instead of forwarding it unchanged.',
+      });
+    };
+
+    let incoming;
+    while ((incoming = inbound.exec(content)) !== null) {
+      const tokenName = incoming[1];
+      const searchStart = incoming.index + incoming[0].length;
+      const searchWindow = content.slice(searchStart, searchStart + 1200);
+      const requestMatch = searchWindow.match(outbound);
+      if (!requestMatch) continue;
+
+      const requestIndex = searchStart + requestMatch.index;
+      const requestContext = content.slice(requestIndex, requestIndex + 600);
+      const tokenReference = new RegExp(`\\b${tokenName}\\b`);
+      if (!/(?:authorization|bearer|headers)/i.test(requestContext) || !tokenReference.test(requestContext)) {
+        continue;
+      }
+
+      const finding = makeFinding(requestIndex);
+      if (finding) return [finding];
+    }
+
+    let directMatch;
+    while ((directMatch = direct.exec(content)) !== null) {
+      const directIndex = directMatch.index;
+      const beforeStart = Math.max(0, directIndex - 200);
+      const beforeWindow = content.slice(beforeStart, directIndex);
+      const beforeRequest = beforeWindow.match(outbound);
+      if (!beforeRequest) continue;
+      const requestIndex = beforeStart + beforeRequest.index;
+
+      const requestContext = content.slice(requestIndex, Math.max(requestIndex + 600, directIndex + directMatch[0].length));
+      if (!/(?:authorization|bearer|headers)/i.test(requestContext)) continue;
+
+      const finding = makeFinding(requestIndex);
+      if (finding) return [finding];
+    }
+
+    return [];
+  }
+
+  /**
+   * Detect an inbound MCP token that is accepted without an audience check.
+   *
+   * The MCP authorization guidance requires tokens to be issued for the MCP
+   * server itself. Token exchange is a valid alternative because it mints a
+   * new token for the downstream audience.
+   */
+  _checkOAuthAudienceValidation(filePath) {
+    const shape = MCP_OAUTH_SHAPES[languageOf(filePath)];
+    if (!shape) return [];
+
+    const content = this.readFile(filePath);
+    if (!content || !MCP_OAUTH_MARKER.test(content)) {
+      return [];
+    }
+
+    const inbound = shape.inboundToken;
+    inbound.lastIndex = 0;
+    const direct = shape.directToken;
+    direct.lastIndex = 0;
+    const audienceValidation = shape.audienceValidation;
+    const tokenExchange = MCP_OAUTH_TOKEN_EXCHANGE;
+    const lineNumber = (index) => content.slice(0, index).split('\n').length;
+    const lineText = (index) => (content.split('\n')[lineNumber(index) - 1] || '').trim().slice(0, 180);
+    const incoming = inbound.exec(content) || direct.exec(content);
+
+    if (!incoming || audienceValidation.test(content) || tokenExchange.test(content)) return [];
+    if (this.isSuppressed(lineText(incoming.index), 'high')) return [];
+
+    return [createFinding({
+      file: filePath,
+      line: lineNumber(incoming.index),
+      column: 1,
+      severity: 'high',
+      category: this.category,
+      rule: 'MCP_TOKEN_AUDIENCE_UNVALIDATED',
+      title: 'MCP: Inbound OAuth Token Audience Not Validated',
+      description: 'An MCP server accepts an inbound authorization token without checking that its audience is the MCP server. Tokens issued for another resource can then cross the MCP trust boundary.',
+      matched: lineText(incoming.index),
+      confidence: 'medium',
+      cwe: 'CWE-287',
+      owasp: 'A07:2021',
+      fix: 'Validate the token audience against the MCP server resource before accepting it, or use RFC 8693 token exchange to mint a token for the target audience.',
+    })];
+  }
+
+  /**
+   * Detect a static OAuth client id used alongside dynamic client
+   * registration in an MCP proxy.
+   */
+  _checkOAuthConfusedDeputy(filePath) {
+    const shape = MCP_OAUTH_SHAPES[languageOf(filePath)];
+    if (!shape) return [];
+
+    const content = this.readFile(filePath);
+    if (!content || !MCP_OAUTH_MARKER.test(content)) {
+      return [];
+    }
+
+    const staticClientId = shape.staticClientId;
+    staticClientId.lastIndex = 0;
+    const dynamicRegistration = MCP_OAUTH_DYNAMIC_REGISTRATION;
+    const lineNumber = (index) => content.slice(0, index).split('\n').length;
+    const lineText = (index) => (content.split('\n')[lineNumber(index) - 1] || '').trim().slice(0, 180);
+    let client;
+
+    while ((client = staticClientId.exec(content)) !== null) {
+      if (/\$\{|\b(?:process\.env|os\.environ|getenv|ENV\[|os\.Getenv)\b/i.test(client[2])) continue;
+      const scopeStart = Math.max(0, client.index - 600);
+      const scope = content.slice(scopeStart, client.index + 600);
+      if (!dynamicRegistration.test(scope)) continue;
+      if (this.isSuppressed(lineText(client.index), 'high')) return [];
+
+      return [createFinding({
+        file: filePath,
+        line: lineNumber(client.index),
+        column: 1,
+        severity: 'high',
+        category: this.category,
+        rule: 'MCP_STATIC_CLIENT_ID_DYNAMIC_REG',
+        title: 'MCP: Static OAuth Client ID With Dynamic Registration',
+        description: 'An MCP proxy combines a fixed third-party OAuth client_id with dynamic client registration. This can enable a confused deputy attack that reuses consent for an attacker-controlled client.',
+        matched: lineText(client.index),
+        confidence: 'medium',
+        cwe: 'CWE-441',
+        owasp: 'A07:2021',
+        fix: 'Use per-client consent and validate registered client_id and redirect_uri values before starting the third-party authorization flow.',
+      })];
+    }
+
+    return [];
+  }
+
+  /**
+   * Detect an OAuth authorization-code flow that does not use PKCE.
+   */
+  _checkOAuthPkce(filePath) {
+    const shape = MCP_OAUTH_SHAPES[languageOf(filePath)];
+    if (!shape) return [];
+
+    const content = this.readFile(filePath);
+    if (!content || !MCP_OAUTH_MARKER.test(content)) {
+      return [];
+    }
+
+    const codeFlow = shape.codeFlow;
+    const pkce = MCP_OAUTH_PKCE;
+    const explicitNoPkce = MCP_OAUTH_EXPLICIT_NO_PKCE;
+    const flowMatch = codeFlow.exec(content);
+    if (!flowMatch || (pkce.test(content) && !explicitNoPkce.test(content))) return [];
+
+    const lineNumber = (index) => content.slice(0, index).split('\n').length;
+    const lineText = (index) => (content.split('\n')[lineNumber(index) - 1] || '').trim().slice(0, 180);
+    if (this.isSuppressed(lineText(flowMatch.index), 'high')) return [];
+
+    return [createFinding({
+      file: filePath,
+      line: lineNumber(flowMatch.index),
+      column: 1,
+      severity: 'high',
+      category: this.category,
+      rule: 'MCP_OAUTH_NO_PKCE',
+      title: 'MCP: OAuth Authorization-Code Flow Without PKCE',
+      description: 'An MCP OAuth authorization-code flow does not use PKCE. An intercepted authorization code can then be redeemed by an attacker.',
+      matched: lineText(flowMatch.index),
+      confidence: 'medium',
+      cwe: 'CWE-352',
+      owasp: 'A07:2021',
+      fix: 'Use a cryptographically random code_verifier and send its S256 code_challenge with every authorization-code request.',
+    })];
+  }
+
+  /**
+   * Check project MCP JSON for OAuth proxy settings. JSON configs have no
+   * source-language extension, so they use their own key/value shapes.
+   */
+  _checkOAuthConfig(filePath) {
+    const content = this.readFile(filePath);
+    if (!content) return [];
+
+    const staticClientId = /["']?\bclient[_-]?id\b["']?\s*[:=]\s*(["'])(.*?)\1/gi;
+    const lineNumber = (index) => content.slice(0, index).split('\n').length;
+    const lineText = (index) => (content.split('\n')[lineNumber(index) - 1] || '').trim().slice(0, 180);
+    let client;
+
+    while ((client = staticClientId.exec(content)) !== null) {
+      if (/\$\{|\b(?:process\.env|os\.environ|getenv|ENV\[|os\.Getenv)\b/i.test(client[2])) continue;
+      const scope = content.slice(Math.max(0, client.index - 600), client.index + 600);
+      if (!MCP_OAUTH_DYNAMIC_REGISTRATION.test(scope)) continue;
+
+      return [createFinding({
+        file: filePath,
+        line: lineNumber(client.index),
+        column: 1,
+        severity: 'high',
+        category: this.category,
+        rule: 'MCP_STATIC_CLIENT_ID_DYNAMIC_REG',
+        title: 'MCP: Static OAuth Client ID With Dynamic Registration',
+        description: 'An MCP proxy combines a fixed third-party OAuth client_id with dynamic client registration. This can enable a confused deputy attack that reuses consent for an attacker-controlled client.',
+        matched: lineText(client.index),
+        confidence: 'medium',
+        cwe: 'CWE-441',
+        owasp: 'A07:2021',
+        fix: 'Use per-client consent and validate registered client_id and redirect_uri values before starting the third-party authorization flow.',
+      })];
+    }
+
+    const flowMatch = MCP_OAUTH_SHAPES.js.codeFlow.exec(content);
+    if (flowMatch && (!MCP_OAUTH_PKCE.test(content) || MCP_OAUTH_EXPLICIT_NO_PKCE.test(content))) {
+      if (this.isSuppressed(lineText(flowMatch.index), 'high')) return [];
+
+      return [createFinding({
+        file: filePath,
+        line: lineNumber(flowMatch.index),
+        column: 1,
+        severity: 'high',
+        category: this.category,
+        rule: 'MCP_OAUTH_NO_PKCE',
+        title: 'MCP: OAuth Authorization-Code Flow Without PKCE',
+        description: 'An MCP OAuth authorization-code flow does not use PKCE. An intercepted authorization code can then be redeemed by an attacker.',
+        matched: lineText(flowMatch.index),
+        confidence: 'medium',
+        cwe: 'CWE-352',
+        owasp: 'A07:2021',
+        fix: 'Use a cryptographically random code_verifier and send its S256 code_challenge with every authorization-code request.',
+      })];
+    }
+
+    return [];
   }
 
   /**

--- a/cli/agents/mcp-security-agent.js
+++ b/cli/agents/mcp-security-agent.js
@@ -306,6 +306,14 @@ function isOAuthTokenName(name) {
     || normalized === 'accesstoken';
 }
 
+function escapeRegex(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function identifierReferenceRegex(name) {
+  return new RegExp(`(?:^|[^\\w$])${escapeRegex(name)}(?![\\w$])`);
+}
+
 function sourceLineHelpers(content) {
   const lines = content.split('\n');
   const lineStarts = [0];
@@ -330,13 +338,13 @@ function sourceLineHelpers(content) {
 function createSourceContext(filePath, content) {
   const language = languageOf(filePath);
   const code = content && stripComments(content, language);
+  const hasOAuthMarker = code && MCP_OAUTH_MARKER.test(code);
   return {
     content,
     language,
     code,
-    structuralCode: code && MCP_OAUTH_MARKER.test(code)
-      ? maskStrings(code, false, language)
-      : null,
+    structuralCode: hasOAuthMarker ? maskStrings(code, false, language) : null,
+    keyCode: hasOAuthMarker ? maskStrings(code, true, language) : null,
     lineHelpers: null,
   };
 }
@@ -344,6 +352,21 @@ function createSourceContext(filePath, content) {
 function sourceLineHelpersFor(source) {
   if (!source.lineHelpers) source.lineHelpers = sourceLineHelpers(source.content);
   return source.lineHelpers;
+}
+
+function stringDelimiterAt(content, index, language) {
+  const char = content[index];
+  if (
+    language === 'python'
+    && (char === '\'' || char === '"')
+    && content[index + 1] === char
+    && content[index + 2] === char
+  ) {
+    return char.repeat(3);
+  }
+  if (char === '\'' || char === '"') return char;
+  if ((language === 'js' || language === 'go' || language === 'ruby') && char === '`') return char;
+  return null;
 }
 
 function createStaticClientIdDynamicRegFinding({ file, line, category, matched }) {
@@ -418,7 +441,8 @@ function stripComments(content, language) {
       const isGoRawString = language === 'go' && quote === '`';
       if (char === '\\' && !isGoRawString) {
         index += 1;
-      } else if (char === quote) {
+      } else if (content.startsWith(quote, index)) {
+        index += quote.length - 1;
         state = 'code';
         quote = '';
       }
@@ -447,9 +471,11 @@ function stripComments(content, language) {
       continue;
     }
 
-    if (char === '\'' || char === '"' || ((language === 'js' || language === 'go' || language === 'ruby') && char === '`')) {
-      quote = char;
+    const delimiter = stringDelimiterAt(content, index, language);
+    if (delimiter) {
+      quote = delimiter;
       state = 'string';
+      index += delimiter.length - 1;
     }
   }
 
@@ -475,12 +501,17 @@ function maskStrings(content, preserveObjectKeys = false, language = 'js') {
       const isGoRawString = language === 'go' && quote === '`';
       if (char === '\\' && !isGoRawString) {
         index += 1;
-      } else if (char === quote) {
-        let next = index + 1;
+      } else if (content.startsWith(quote, index)) {
+        const stringEnd = index + quote.length - 1;
+        let next = stringEnd + 1;
         while (next < content.length && /\s/.test(content[next])) next += 1;
         const isRubyHashKey = language === 'ruby' && content[next] === '=' && content[next + 1] === '>';
-        if (!preserveObjectKeys || (content[next] !== ':' && !isRubyHashKey)) blankRange(stringStart, index);
-        blank(index);
+        const preserveKey = quote.length === 1
+          && preserveObjectKeys
+          && (content[next] === ':' || isRubyHashKey);
+        if (!preserveKey) blankRange(stringStart, stringEnd);
+        else blankRange(index, stringEnd);
+        index = stringEnd;
         state = 'code';
         quote = '';
         stringStart = -1;
@@ -490,10 +521,12 @@ function maskStrings(content, preserveObjectKeys = false, language = 'js') {
       continue;
     }
 
-    if (char === '\'' || char === '"' || char === '`') {
-      quote = char;
+    const delimiter = stringDelimiterAt(content, index, language);
+    if (delimiter) {
+      quote = delimiter;
       state = 'string';
       stringStart = index;
+      index += delimiter.length - 1;
     }
   }
 
@@ -518,9 +551,24 @@ function findBracePairs(content, language, structuralCode = null) {
   return pairs;
 }
 
+function rubyBlockDepthDelta(line) {
+  const trimmed = line.trim();
+  if (!trimmed) return 0;
+
+  const blockKeyword = /(?:^|=\s*)(?:def|class|module|if|unless|case|begin|while|until|for)\b/;
+  const loopKeyword = /(?:^|=\s*)(?:while|until|for)\b/;
+  let opens = blockKeyword.test(trimmed) ? 1 : 0;
+  if (!loopKeyword.test(trimmed) && /\bdo\b(?:\s*\|[^|]*\|)?\s*$/.test(trimmed)) opens += 1;
+
+  const closes = (trimmed.match(/\bend\b/g) || []).length;
+  return opens - closes;
+}
+
 function sourceFunctionScopes(content, language, structuralCode = null) {
   if (language === 'python' || language === 'ruby') {
     const lines = content.split('\n');
+    const scopeCode = structuralCode ?? maskStrings(stripComments(content, language), false, language);
+    const scopeLines = scopeCode.split('\n');
     const offsets = [];
     let offset = 0;
     for (const line of lines) {
@@ -530,7 +578,7 @@ function sourceFunctionScopes(content, language, structuralCode = null) {
 
     const scopes = [];
     for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
-      const line = lines[lineIndex];
+      const line = scopeLines[lineIndex];
       const match = language === 'python'
         ? line.match(/^(\s*)(?:async\s+)?def\s+/)
         : line.match(/^(\s*)def\s+/);
@@ -540,8 +588,8 @@ function sourceFunctionScopes(content, language, structuralCode = null) {
       let endLine = lines.length;
       if (language === 'python') {
         for (let nextLine = lineIndex + 1; nextLine < lines.length; nextLine += 1) {
-          if (!lines[nextLine].trim()) continue;
-          const nextIndent = lines[nextLine].match(/^\s*/)[0].replace(/\t/g, '    ').length;
+          if (!scopeLines[nextLine].trim()) continue;
+          const nextIndent = scopeLines[nextLine].match(/^\s*/)[0].replace(/\t/g, '    ').length;
           if (nextIndent <= indent) {
             endLine = nextLine;
             break;
@@ -550,9 +598,8 @@ function sourceFunctionScopes(content, language, structuralCode = null) {
       } else {
         let depth = 1;
         for (let nextLine = lineIndex + 1; nextLine < lines.length; nextLine += 1) {
-          if (/^\s*def\b/.test(lines[nextLine])) depth += 1;
-          if (/^\s*end\b/.test(lines[nextLine])) depth -= 1;
-          if (depth === 0) {
+          depth += rubyBlockDepthDelta(scopeLines[nextLine]);
+          if (depth <= 0) {
             endLine = nextLine + 1;
             break;
           }
@@ -634,7 +681,7 @@ function isMcpToolHandlerScope(code, scope, language) {
     const decorator = previousLine.match(/^@([A-Za-z_]\w*)\.tool(?:\([^)]*\))?$/);
     if (!decorator) return false;
 
-    const receiver = decorator[1].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const receiver = escapeRegex(decorator[1]);
     return new RegExp(`\\b${receiver}\\s*=\\s*FastMCP\\s*\\(`).test(code);
   }
 
@@ -670,6 +717,11 @@ function allRegexMatches(regex, content) {
   return matches;
 }
 
+function allVisibleRegexMatches(regex, content, visibleContent) {
+  return allRegexMatches(regex, content)
+    .filter((match) => visibleContent[match.index] === content[match.index]);
+}
+
 function isQuotedObjectKeyAt(content, index, language = 'js') {
   const quote = content[index];
   if (quote !== '\'' && quote !== '"') return false;
@@ -701,7 +753,7 @@ function hasExplicitNoPkce(content, language = 'js') {
 
 function hasTokenRelatedMitigation(scopeContent, tokenName, mitigation, directTokenReference) {
   const tokenReference = tokenName
-    ? new RegExp(`\\b${tokenName.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')}\\b`)
+    ? identifierReferenceRegex(tokenName)
     : directTokenReference ? maskStrings(directTokenReference) : null;
   if (!tokenReference) return false;
 
@@ -813,8 +865,8 @@ export class MCPSecurityAgent extends BaseAgent {
     }
 
     const scopes = sourceFunctionScopes(content, language, source.structuralCode);
-    const inboundCandidates = allRegexMatches(shape.inboundToken, code);
-    const directCandidates = allRegexMatches(shape.directToken, code)
+    const inboundCandidates = allVisibleRegexMatches(shape.inboundToken, code, source.structuralCode);
+    const directCandidates = allVisibleRegexMatches(shape.directToken, code, source.structuralCode)
       .filter((direct) => !inboundCandidates.some((inbound) => (
         inbound.index <= direct.index && direct.index < inbound.index + inbound[0].length
       )));
@@ -846,13 +898,13 @@ export class MCPSecurityAgent extends BaseAgent {
       const scope = sourceScopeContaining(content, code, language, scopes, incoming.index, incoming.index + incoming[0].length);
       if (!scope || !isMcpToolHandlerScope(code, scope, language)) continue;
       const searchStart = incoming.index + incoming[0].length;
-      const searchWindow = code.slice(searchStart, Math.min(scope.end, searchStart + 1200));
+      const searchWindow = source.structuralCode.slice(searchStart, Math.min(scope.end, searchStart + 1200));
       const requestMatch = searchWindow.match(outbound);
       if (!requestMatch) continue;
 
       const requestIndex = searchStart + requestMatch.index;
-      const requestContext = code.slice(requestIndex, Math.min(scope.end, requestIndex + 600));
-      const tokenReference = new RegExp(`\\b${tokenName}\\b`);
+      const requestContext = source.keyCode.slice(requestIndex, Math.min(scope.end, requestIndex + 600));
+      const tokenReference = identifierReferenceRegex(tokenName);
       if (!/(?:authorization|bearer|headers)/i.test(requestContext) || !tokenReference.test(requestContext)) {
         continue;
       }
@@ -866,12 +918,12 @@ export class MCPSecurityAgent extends BaseAgent {
       const scope = sourceScopeContaining(content, code, language, scopes, directIndex, directIndex + directMatch[0].length);
       if (!scope || !isMcpToolHandlerScope(code, scope, language)) continue;
       const beforeStart = Math.max(scope.start, directIndex - 200);
-      const beforeWindow = code.slice(beforeStart, directIndex);
+      const beforeWindow = source.structuralCode.slice(beforeStart, directIndex);
       const beforeRequest = beforeWindow.match(outbound);
       if (!beforeRequest) continue;
       const requestIndex = beforeStart + beforeRequest.index;
 
-      const requestContext = code.slice(requestIndex, Math.min(scope.end, Math.max(requestIndex + 600, directIndex + directMatch[0].length)));
+      const requestContext = source.keyCode.slice(requestIndex, Math.min(scope.end, Math.max(requestIndex + 600, directIndex + directMatch[0].length)));
       if (!/(?:authorization|bearer|headers)/i.test(requestContext)) continue;
 
       const finding = makeFinding(requestIndex);
@@ -900,8 +952,8 @@ export class MCPSecurityAgent extends BaseAgent {
     }
 
     const scopes = sourceFunctionScopes(content, language, source.structuralCode);
-    const inboundCandidates = allRegexMatches(shape.inboundToken, code);
-    const directCandidates = allRegexMatches(shape.directToken, code)
+    const inboundCandidates = allVisibleRegexMatches(shape.inboundToken, code, source.structuralCode);
+    const directCandidates = allVisibleRegexMatches(shape.directToken, code, source.structuralCode)
       .filter((direct) => !inboundCandidates.some((inbound) => (
         inbound.index <= direct.index && direct.index < inbound.index + inbound[0].length
       )));
@@ -920,8 +972,9 @@ export class MCPSecurityAgent extends BaseAgent {
 
       const scopeContent = code.slice(scope.start, scope.end);
       const mitigationContent = maskStrings(scopeContent, false, language);
+      const audienceMitigationContent = maskStrings(scopeContent, true, language);
       const hasAudienceValidation = hasTokenRelatedMitigation(
-        mitigationContent,
+        audienceMitigationContent,
         incoming[1],
         audienceValidation,
         incoming[0],
@@ -972,8 +1025,8 @@ export class MCPSecurityAgent extends BaseAgent {
     }
 
     const objectScopes = sourceObjectScopes(content, language, source.structuralCode);
-    const clients = allRegexMatches(shape.staticClientId, code);
-    const registrations = allRegexMatches(MCP_OAUTH_DYNAMIC_REGISTRATION, code);
+    const clients = allVisibleRegexMatches(shape.staticClientId, code, source.keyCode);
+    const registrations = allVisibleRegexMatches(MCP_OAUTH_DYNAMIC_REGISTRATION, code, source.keyCode);
     const { lineNumber, lineText } = sourceLineHelpersFor(source);
 
     for (const client of clients) {
@@ -1010,7 +1063,7 @@ export class MCPSecurityAgent extends BaseAgent {
 
     const objectScopes = sourceObjectScopes(content, language, source.structuralCode);
     const functionScopes = sourceFunctionScopes(content, language, source.structuralCode);
-    const codeFlows = allRegexMatches(shape.codeFlow, code);
+    const codeFlows = allVisibleRegexMatches(shape.codeFlow, code, source.keyCode);
     const pkce = MCP_OAUTH_PKCE;
     const { lineNumber, lineText } = sourceLineHelpersFor(source);
     const findings = [];
@@ -1048,17 +1101,19 @@ export class MCPSecurityAgent extends BaseAgent {
     if (!content) return [];
 
     const code = stripComments(content, 'js');
-    const objectScopes = sourceObjectScopes(content, 'js');
+    const structuralCode = maskStrings(code, false, 'js');
+    const keyCode = maskStrings(code, true, 'js');
+    const objectScopes = sourceObjectScopes(content, 'js', structuralCode);
     const staticClientId = /["']?\bclient[_-]?id\b["']?\s*[:=]\s*(["'])(.*?)\1/gi;
-    const clients = allRegexMatches(staticClientId, code);
-    const registrations = allRegexMatches(MCP_OAUTH_DYNAMIC_REGISTRATION, code);
+    const clients = allVisibleRegexMatches(staticClientId, code, keyCode);
+    const registrations = allVisibleRegexMatches(MCP_OAUTH_DYNAMIC_REGISTRATION, code, keyCode);
     const { lineNumber, lineText } = sourceLineHelpers(content);
     const findings = [];
 
     for (const client of clients) {
       if (/\$\{|\b(?:process\.env|os\.environ|getenv|ENV\[|os\.Getenv)\b/i.test(client[2])) continue;
       const registration = registrations.find((candidate) => (
-        objectScopeContaining(code, objectScopes, client.index, candidate.index, 'js')
+        objectScopeContaining(code, objectScopes, client.index, candidate.index, 'js', structuralCode)
       ));
       if (!registration || this.isSuppressed(lineText(client.index), 'high')) continue;
 
@@ -1072,8 +1127,8 @@ export class MCPSecurityAgent extends BaseAgent {
     }
 
     const reportedScopes = new Set();
-    for (const flowMatch of allRegexMatches(MCP_OAUTH_SHAPES.js.codeFlow, code)) {
-      const scope = objectScopeContaining(code, objectScopes, flowMatch.index, flowMatch.index, 'js');
+    for (const flowMatch of allVisibleRegexMatches(MCP_OAUTH_SHAPES.js.codeFlow, code, keyCode)) {
+      const scope = objectScopeContaining(code, objectScopes, flowMatch.index, flowMatch.index, 'js', structuralCode);
       if (!scope || reportedScopes.has(scope.start)) continue;
 
       const scopeContent = code.slice(scope.start, scope.end);

--- a/cli/agents/mcp-security-agent.js
+++ b/cli/agents/mcp-security-agent.js
@@ -570,6 +570,47 @@ function rubyBlockDepthDelta(line) {
   return opens - closes;
 }
 
+function matchingParenthesisEnd(code, openIndex) {
+  let depth = 0;
+  for (let index = openIndex; index < code.length; index += 1) {
+    if (code[index] === '(') depth += 1;
+    if (code[index] !== ')') continue;
+
+    depth -= 1;
+    if (depth === 0) return index + 1;
+  }
+  return -1;
+}
+
+function rubyMcpServerBindings(code) {
+  return new Set(allRegexMatches(
+    /\b([A-Za-z_]\w*)\s*=\s*MCP::Server\.new\b/g,
+    code,
+  ).map((match) => match[1]));
+}
+
+function rubyMcpToolBlockStarts(code) {
+  const serverBindings = rubyMcpServerBindings(code);
+  const starts = new Set();
+  const registration = /\b(?:(MCP::Tool)\.define|([A-Za-z_]\w*)\.define_tool)\s*\(/g;
+
+  for (const match of allRegexMatches(registration, code)) {
+    const receiver = match[2];
+    if (receiver && !serverBindings.has(receiver)) continue;
+
+    const openIndex = match.index + match[0].lastIndexOf('(');
+    const callEnd = matchingParenthesisEnd(code, openIndex);
+    if (callEnd === -1) continue;
+
+    const block = code.slice(callEnd).match(/^\s*do(?:\s*\|[^|]*\|)?/);
+    if (!block) continue;
+
+    const doIndex = callEnd + block[0].search(/\bdo\b/);
+    starts.add(code.lastIndexOf('\n', doIndex - 1) + 1);
+  }
+  return starts;
+}
+
 function sourceFunctionScopes(content, language, structuralCode = null) {
   if (language === 'python' || language === 'ruby') {
     const lines = content.split('\n');
@@ -583,14 +624,16 @@ function sourceFunctionScopes(content, language, structuralCode = null) {
     }
 
     const scopes = [];
+    const rubyToolBlocks = language === 'ruby' ? rubyMcpToolBlockStarts(scopeCode) : null;
     for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
       const line = scopeLines[lineIndex];
       const match = language === 'python'
         ? line.match(/^(\s*)(?:async\s+)?def\s+/)
         : line.match(/^(\s*)def\s+/);
-      if (!match) continue;
+      const isRubyToolBlock = rubyToolBlocks?.has(offsets[lineIndex]) ?? false;
+      if (!match && !isRubyToolBlock) continue;
 
-      const indent = match[1].replace(/\t/g, '    ').length;
+      const indent = (match?.[1] ?? line.match(/^\s*/)[0]).replace(/\t/g, '    ').length;
       let endLine = lines.length;
       if (language === 'python') {
         for (let nextLine = lineIndex + 1; nextLine < lines.length; nextLine += 1) {
@@ -756,6 +799,9 @@ function isMcpToolHandlerScope(code, scope, language) {
     return new RegExp(`\\b${receiver}\\s*=\\s*FastMCP\\s*\\(`).test(code);
   }
 
+  if (language === 'ruby') return rubyMcpToolBlockStarts(code).has(scope.start);
+  if (language === 'go') return isGoMcpToolHandlerScope(code, scope);
+
   if (language !== 'js') return false;
 
   const prefixStart = Math.max(0, scope.start - 320);
@@ -785,14 +831,69 @@ function isMcpToolHandlerScope(code, scope, language) {
   );
 }
 
+function goMcpServerBindings(code) {
+  return new Set(allRegexMatches(
+    /\b(?:var\s+)?([A-Za-z_]\w*)\s*(?::=|=)\s*mcp\.NewServer\s*\(/g,
+    code,
+  ).map((match) => match[1]));
+}
+
+function goMcpToolRegistrations(code) {
+  const serverBindings = goMcpServerBindings(code);
+  const registrations = [];
+  const registration = /\b(?:mcp\.AddTool|([A-Za-z_]\w*)\.AddTool)\s*\(/g;
+
+  for (const match of allRegexMatches(registration, code)) {
+    const receiver = match[1];
+    if (receiver && !serverBindings.has(receiver)) continue;
+
+    const openIndex = match.index + match[0].lastIndexOf('(');
+    const callEnd = matchingParenthesisEnd(code, openIndex);
+    if (callEnd === -1) continue;
+
+    const call = code.slice(match.index, callEnd);
+    if (!receiver
+      && ![...serverBindings].some((binding) => new RegExp(`\\b${escapeRegex(binding)}\\b`).test(call))
+      && !/\bmcp\.NewServer\s*\(/.test(call)) {
+      continue;
+    }
+    registrations.push({ start: match.index, end: callEnd, call });
+  }
+  return registrations;
+}
+
+function goFunctionName(code, scope) {
+  const prefix = code.slice(Math.max(0, scope.start - 320), scope.start);
+  return prefix.match(/\bfunc\s+([A-Za-z_]\w*)\s*\([^{}]*$/)?.[1] ?? null;
+}
+
+function isGoMcpToolHandlerScope(code, scope) {
+  const registrations = goMcpToolRegistrations(code);
+  if (registrations.some((registration) => (
+    registration.start <= scope.start && scope.end <= registration.end
+  ))) {
+    return true;
+  }
+
+  const functionName = goFunctionName(code, scope);
+  if (!functionName) return false;
+  const handlerReference = new RegExp(`\\b${escapeRegex(functionName)}\\b`);
+  return registrations.some((registration) => handlerReference.test(registration.call));
+}
+
 function isMcpOAuthFunctionScope(code, scope, language) {
   if (language === 'js' || language === 'python') {
     return isMcpToolHandlerScope(code, scope, language);
   }
 
   const scopeContent = code.slice(scope.start, scope.end);
-  if (language === 'ruby') return /\b(?:MCPServer|MCP(?:::\w+)+)\.new\b/.test(scopeContent);
-  if (language === 'go') return /\bmcp\.NewServer\s*\(/.test(scopeContent);
+  if (language === 'ruby') {
+    return rubyMcpToolBlockStarts(code).has(scope.start)
+      || /\b(?:MCPServer|MCP(?:::\w+)+)\.new\b/.test(scopeContent);
+  }
+  if (language === 'go') {
+    return isGoMcpToolHandlerScope(code, scope) || /\bmcp\.NewServer\s*\(/.test(scopeContent);
+  }
   return false;
 }
 
@@ -1033,7 +1134,7 @@ export class MCPSecurityAgent extends BaseAgent {
       const requestIndex = searchStart + requestMatch.index;
       const requestContext = source.keyCode.slice(requestIndex, Math.min(scope.end, requestIndex + 600));
       const tokenReference = identifierReferenceRegex(tokenName);
-      if (!/(?:authorization|bearer|headers)/i.test(requestContext) || !tokenReference.test(requestContext)) {
+      if (!/(?:authorization|bearer|headers?)/i.test(requestContext) || !tokenReference.test(requestContext)) {
         continue;
       }
 
@@ -1052,7 +1153,7 @@ export class MCPSecurityAgent extends BaseAgent {
       const requestIndex = beforeStart + beforeRequest.index;
 
       const requestContext = source.keyCode.slice(requestIndex, Math.min(scope.end, Math.max(requestIndex + 600, directIndex + directMatch[0].length)));
-      if (!/(?:authorization|bearer|headers)/i.test(requestContext)) continue;
+      if (!/(?:authorization|bearer|headers?)/i.test(requestContext)) continue;
 
       const finding = makeFinding(requestIndex);
       if (finding) return [finding];

--- a/cli/agents/mcp-security-agent.js
+++ b/cli/agents/mcp-security-agent.js
@@ -382,7 +382,8 @@ function stripComments(content, language) {
     }
 
     if (state === 'string') {
-      if (char === '\\') {
+      const isGoRawString = language === 'go' && quote === '`';
+      if (char === '\\' && !isGoRawString) {
         index += 1;
       } else if (char === quote) {
         state = 'code';
@@ -413,7 +414,7 @@ function stripComments(content, language) {
       continue;
     }
 
-    if (char === '\'' || char === '"' || (language === 'js' && char === '`')) {
+    if (char === '\'' || char === '"' || ((language === 'js' || language === 'go' || language === 'ruby') && char === '`')) {
       quote = char;
       state = 'string';
     }
@@ -422,7 +423,7 @@ function stripComments(content, language) {
   return output.join('');
 }
 
-function maskStrings(content, preserveObjectKeys = false) {
+function maskStrings(content, preserveObjectKeys = false, language = 'js') {
   const output = [...content];
   let state = 'code';
   let quote = '';
@@ -438,12 +439,14 @@ function maskStrings(content, preserveObjectKeys = false) {
   for (let index = 0; index < content.length; index += 1) {
     const char = content[index];
     if (state === 'string') {
-      if (char === '\\') {
+      const isGoRawString = language === 'go' && quote === '`';
+      if (char === '\\' && !isGoRawString) {
         index += 1;
       } else if (char === quote) {
         let next = index + 1;
         while (next < content.length && /\s/.test(content[next])) next += 1;
-        if (!preserveObjectKeys || content[next] !== ':') blankRange(stringStart, index);
+        const isRubyHashKey = language === 'ruby' && content[next] === '=' && content[next + 1] === '>';
+        if (!preserveObjectKeys || (content[next] !== ':' && !isRubyHashKey)) blankRange(stringStart, index);
         blank(index);
         state = 'code';
         quote = '';
@@ -467,7 +470,7 @@ function maskStrings(content, preserveObjectKeys = false) {
 }
 
 function findBracePairs(content, language) {
-  const code = maskStrings(stripComments(content, language));
+  const code = maskStrings(stripComments(content, language), false, language);
   const stack = [];
   const pairs = [];
 
@@ -528,7 +531,7 @@ function sourceFunctionScopes(content, language) {
     return scopes;
   }
 
-  const code = maskStrings(stripComments(content, language));
+  const code = maskStrings(stripComments(content, language), false, language);
   return findBracePairs(content, language)
     .filter(({ start }) => isFunctionBrace(code, start, language));
 }
@@ -540,7 +543,7 @@ function isFunctionBrace(code, start, language) {
 }
 
 function sourceObjectScopes(content, language) {
-  const code = maskStrings(stripComments(content, language));
+  const code = maskStrings(stripComments(content, language), false, language);
   return findBracePairs(content, language)
     .filter(({ start }) => !isFunctionBrace(code, start, language));
 }
@@ -554,8 +557,8 @@ function braceDepthAt(code, scope, index) {
   return depth;
 }
 
-function objectScopeContaining(code, scopes, firstIndex, secondIndex) {
-  const structuralCode = maskStrings(code);
+function objectScopeContaining(code, scopes, firstIndex, secondIndex, language = 'js') {
+  const structuralCode = maskStrings(code, false, language);
   return scopes
     .filter((scope) => (
       scope.start <= firstIndex
@@ -634,7 +637,7 @@ function allRegexMatches(regex, content) {
   return matches;
 }
 
-function isQuotedObjectKeyAt(content, index) {
+function isQuotedObjectKeyAt(content, index, language = 'js') {
   const quote = content[index];
   if (quote !== '\'' && quote !== '"') return false;
 
@@ -651,14 +654,15 @@ function isQuotedObjectKeyAt(content, index) {
 
   let next = end + 1;
   while (next < content.length && /\s/.test(content[next])) next += 1;
-  return content[next] === ':';
+  return content[next] === ':'
+    || (language === 'ruby' && content[next] === '=' && content[next + 1] === '>');
 }
 
-function hasExplicitNoPkce(content) {
-  const masked = maskStrings(content);
+function hasExplicitNoPkce(content, language = 'js') {
+  const masked = maskStrings(content, false, language);
   return allRegexMatches(MCP_OAUTH_EXPLICIT_NO_PKCE, content).some((match) => (
     masked[match.index] === content[match.index]
-    || isQuotedObjectKeyAt(content, match.index)
+    || isQuotedObjectKeyAt(content, match.index, language)
   ));
 }
 
@@ -881,7 +885,7 @@ export class MCPSecurityAgent extends BaseAgent {
       if (!scope || seenScopes.has(scope.start)) continue;
 
       const scopeContent = code.slice(scope.start, scope.end);
-      const mitigationContent = maskStrings(scopeContent);
+      const mitigationContent = maskStrings(scopeContent, false, language);
       const hasAudienceValidation = hasTokenRelatedMitigation(
         mitigationContent,
         incoming[1],
@@ -941,7 +945,7 @@ export class MCPSecurityAgent extends BaseAgent {
     for (const client of clients) {
       if (/\$\{|\b(?:process\.env|os\.environ|getenv|ENV\[|os\.Getenv)\b/i.test(client[2])) continue;
       for (const registration of registrations) {
-        const scope = objectScopeContaining(code, objectScopes, client.index, registration.index);
+        const scope = objectScopeContaining(code, objectScopes, client.index, registration.index, language);
         if (!scope || this.isSuppressed(lineText(client.index), 'high')) continue;
 
         return [createStaticClientIdDynamicRegFinding({
@@ -979,13 +983,13 @@ export class MCPSecurityAgent extends BaseAgent {
     const reportedScopes = new Set();
 
     for (const flowMatch of codeFlows) {
-      const scope = objectScopeContaining(code, objectScopes, flowMatch.index, flowMatch.index)
+      const scope = objectScopeContaining(code, objectScopes, flowMatch.index, flowMatch.index, language)
         || sourceScopeContaining(content, code, language, functionScopes, flowMatch.index, flowMatch.index + flowMatch[0].length);
       if (!scope) continue;
 
       const scopeContent = code.slice(scope.start, scope.end);
-      const mitigationContent = maskStrings(scopeContent, true);
-      if (pkce.test(mitigationContent) && !hasExplicitNoPkce(scopeContent)) continue;
+      const mitigationContent = maskStrings(scopeContent, true, language);
+      if (pkce.test(mitigationContent) && !hasExplicitNoPkce(scopeContent, language)) continue;
       if (reportedScopes.has(scope.start)) continue;
       if (this.isSuppressed(lineText(flowMatch.index), 'high')) continue;
       reportedScopes.add(scope.start);
@@ -1020,7 +1024,7 @@ export class MCPSecurityAgent extends BaseAgent {
     for (const client of clients) {
       if (/\$\{|\b(?:process\.env|os\.environ|getenv|ENV\[|os\.Getenv)\b/i.test(client[2])) continue;
       const registration = registrations.find((candidate) => (
-        objectScopeContaining(code, objectScopes, client.index, candidate.index)
+        objectScopeContaining(code, objectScopes, client.index, candidate.index, 'js')
       ));
       if (!registration || this.isSuppressed(lineText(client.index), 'high')) continue;
 
@@ -1035,12 +1039,12 @@ export class MCPSecurityAgent extends BaseAgent {
 
     const reportedScopes = new Set();
     for (const flowMatch of allRegexMatches(MCP_OAUTH_SHAPES.js.codeFlow, code)) {
-      const scope = objectScopeContaining(code, objectScopes, flowMatch.index, flowMatch.index);
+      const scope = objectScopeContaining(code, objectScopes, flowMatch.index, flowMatch.index, 'js');
       if (!scope || reportedScopes.has(scope.start)) continue;
 
       const scopeContent = code.slice(scope.start, scope.end);
-      const mitigationContent = maskStrings(scopeContent, true);
-      if (MCP_OAUTH_PKCE.test(mitigationContent) && !hasExplicitNoPkce(scopeContent)) continue;
+      const mitigationContent = maskStrings(scopeContent, true, 'js');
+      if (MCP_OAUTH_PKCE.test(mitigationContent) && !hasExplicitNoPkce(scopeContent, 'js')) continue;
       if (this.isSuppressed(lineText(flowMatch.index), 'high')) continue;
       reportedScopes.add(scope.start);
 

--- a/cli/agents/mcp-security-agent.js
+++ b/cli/agents/mcp-security-agent.js
@@ -548,7 +548,17 @@ function sourceScopeContaining(content, code, language, scopes, start, end = sta
 }
 
 function isMcpToolHandlerScope(code, scope, language) {
-  if (language !== 'js') return true;
+  if (language === 'python') {
+    const precedingLines = code.slice(0, scope.start).split('\n');
+    const previousLine = precedingLines.at(-2)?.trim() || '';
+    const decorator = previousLine.match(/^@([A-Za-z_]\w*)\.tool(?:\([^)]*\))?$/);
+    if (!decorator) return false;
+
+    const receiver = decorator[1].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp(`\\b${receiver}\\s*=\\s*FastMCP\\s*\\(`).test(code);
+  }
+
+  if (language !== 'js') return false;
 
   const prefix = code.slice(Math.max(0, scope.start - 320), scope.start);
   const registrations = allRegexMatches(/(?:\.\s*tool|\b(?:registerTool|addTool))\s*\(/gi, prefix);

--- a/cli/agents/mcp-security-agent.js
+++ b/cli/agents/mcp-security-agent.js
@@ -252,13 +252,16 @@ const OFFICIAL_MCP_SERVERS = new Set([
 // OAuth request shapes are deliberately language-scoped. These rules inspect
 // source code rather than MCP JSON, so a JS header expression must not be
 // allowed to report on a Python, Ruby, or Go file by accident.
+const MCP_TOOL_REGISTRATION = /(?:\.\s*tool|\b(?:registerTool|addTool))\s*\(/gi;
+const MCP_OAUTH_STATIC_CLIENT_ID = /["']?\bclient[_-]?id\b["']?\s*(?:=>|:=|[:=])\s*(["'])(.*?)\1/gi;
+const MCP_OAUTH_CODE_FLOW = /(?:["']?\bresponse[_-]?type\b["']?\s*[:=]\s*["']code["']|["']?\bgrant[_-]?type\b["']?\s*[:=]\s*["']authorization[_-]?code["']|\bauthorization[_-]?code\b|["']?\bauthorization[_-]?endpoint\b["']?[^\n]{0,240}["']?\btoken[_-]?endpoint\b["']?)/i;
 const MCP_OAUTH_SHAPES = {
   js: {
     inboundToken: /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*[^;\n]*\b(?:req|request|ctx|event)\b[^;\n]*(?:\.(?:authorization|bearer)\b|\[\s*['"](?:authorization|bearer|http_authorization)['"]\s*\]|(?:get|header)\s*\(\s*['"](?:authorization|bearer)['"])/gi,
     directToken: /\b(?:req|request|ctx|event)\b[^;\n]*(?:\.(?:authorization|bearer)\b|\[\s*['"](?:authorization|bearer|http_authorization)['"]\s*\]|(?:get|header)\s*\(\s*['"](?:authorization|bearer)['"])/gi,
     outboundRequest: /\b(?:fetch|axios(?:\.[A-Za-z_$][\w$]*)?|got|https?\.request)\s*\(/i,
     audienceValidation: /(?:\b(?:verify|decode|validate|check|assert)\w*[^\n;]{0,180}\baud(?:ience)?\b|\b(?:claims?|payload)\b[^\n;]{0,120}\baud\b\s*(?:===|!==|==|!=|=))/i,
-    staticClientId: /["']?\bclient[_-]?id\b["']?\s*(?:=>|:=|[:=])\s*(["'])(.*?)\1/gi,
+    staticClientId: MCP_OAUTH_STATIC_CLIENT_ID,
     codeFlow: /(?:["']?\bresponse[_-]?type\b["']?\s*[:=]\s*["']code["']|["']?\bgrant[_-]?type\b["']?\s*[:=]\s*["']authorization[_-]?code["']|\bauthorization[_-]?code\b|["']?\bauthorization[_-]?endpoint\b["']?[^\n;]{0,240}["']?\btoken[_-]?endpoint\b["']?)/i,
   },
   python: {
@@ -266,16 +269,16 @@ const MCP_OAUTH_SHAPES = {
     directToken: /\b(?:request|req|ctx|context)\b[^\n]*(?:\.(?:authorization|bearer)\b|\[\s*['"](?:authorization|bearer|http_authorization)['"]\s*\]|\.get\s*\(\s*['"](?:authorization|bearer)['"])/gi,
     outboundRequest: /\b(?:requests|httpx)\.(?:get|post|put|patch|delete|request)\s*\(|\b(?:urllib\.request\.)?urlopen\s*\(/i,
     audienceValidation: /(?:\b(?:verify|decode|validate|check|assert)\w*[^\n]{0,180}\baud(?:ience)?\b|\b(?:claims?|payload)\b[^\n]{0,120}\b(?:aud|audience)\b\s*(?:==|!=|in\b|=))/i,
-    staticClientId: /["']?\bclient[_-]?id\b["']?\s*(?:=>|:=|[:=])\s*(["'])(.*?)\1/gi,
-    codeFlow: /(?:["']?\bresponse[_-]?type\b["']?\s*[:=]\s*["']code["']|["']?\bgrant[_-]?type\b["']?\s*[:=]\s*["']authorization[_-]?code["']|\bauthorization[_-]?code\b|["']?\bauthorization[_-]?endpoint\b["']?[^\n]{0,240}["']?\btoken[_-]?endpoint\b["']?)/i,
+    staticClientId: MCP_OAUTH_STATIC_CLIENT_ID,
+    codeFlow: MCP_OAUTH_CODE_FLOW,
   },
   ruby: {
     inboundToken: /\b([A-Za-z_]\w*)\s*=\s*(?:request|req|context|env|headers)\b[^\n]*(?:\.(?:authorization|bearer)\b|\[\s*['"](?:authorization|bearer|http_authorization)['"]\s*\])/gi,
     directToken: /\b(?:request|req|context|env|headers)\b[^\n]*(?:\.(?:authorization|bearer)\b|\[\s*['"](?:authorization|bearer|http_authorization)['"]\s*\])/gi,
     outboundRequest: /\b(?:Net::HTTP|Faraday|HTTParty|RestClient)\b[\s\S]{0,120}\b(?:get|post|put|delete|request|call)\b\s*[.(]/i,
     audienceValidation: /(?:\b(?:verify|decode|validate|check|assert)\w*[^\n]{0,180}\baud(?:ience)?\b|\b(?:claims?|payload)\b[^\n]{0,120}\b(?:aud|audience)\b\s*(?:==|!=|=~|=>))/i,
-    staticClientId: /["']?\bclient[_-]?id\b["']?\s*(?:=>|:=|[:=])\s*(["'])(.*?)\1/gi,
-    codeFlow: /(?:["']?\bresponse[_-]?type\b["']?\s*[:=]\s*["']code["']|["']?\bgrant[_-]?type\b["']?\s*[:=]\s*["']authorization[_-]?code["']|\bauthorization[_-]?code\b|["']?\bauthorization[_-]?endpoint\b["']?[^\n]{0,240}["']?\btoken[_-]?endpoint\b["']?)/i,
+    staticClientId: MCP_OAUTH_STATIC_CLIENT_ID,
+    codeFlow: MCP_OAUTH_CODE_FLOW,
   },
   go: {
     inboundToken: /\b([A-Za-z_]\w*)\s*:?=\s*(?:r|req|request)\.Header\.Get\(\s*["']Authorization["']\s*\)/gi,
@@ -301,6 +304,49 @@ function isOAuthTokenName(name) {
     || normalized === 'auth'
     || normalized.startsWith('auth_')
     || normalized === 'accesstoken';
+}
+
+function sourceLineHelpers(content) {
+  const lines = content.split('\n');
+  const lineNumber = (index) => content.slice(0, index).split('\n').length;
+  const lineText = (index) => (lines[lineNumber(index) - 1] || '').trim().slice(0, 180);
+  return { lineNumber, lineText };
+}
+
+function createStaticClientIdDynamicRegFinding({ file, line, category, matched }) {
+  return createFinding({
+    file,
+    line,
+    column: 1,
+    severity: 'high',
+    category,
+    rule: 'MCP_STATIC_CLIENT_ID_DYNAMIC_REG',
+    title: 'MCP: Static OAuth Client ID With Dynamic Registration',
+    description: 'An MCP proxy combines a fixed third-party OAuth client_id with dynamic client registration. This can enable a confused deputy attack that reuses consent for an attacker-controlled client.',
+    matched,
+    confidence: 'medium',
+    cwe: 'CWE-441',
+    owasp: 'A07:2021',
+    fix: 'Use per-client consent and validate registered client_id and redirect_uri values before starting the third-party authorization flow.',
+  });
+}
+
+function createOAuthNoPkceFinding({ file, line, category, matched }) {
+  return createFinding({
+    file,
+    line,
+    column: 1,
+    severity: 'high',
+    category,
+    rule: 'MCP_OAUTH_NO_PKCE',
+    title: 'MCP: OAuth Authorization-Code Flow Without PKCE',
+    description: 'An MCP OAuth authorization-code flow does not use PKCE. An intercepted authorization code can then be redeemed by an attacker.',
+    matched,
+    confidence: 'medium',
+    cwe: 'CWE-352',
+    owasp: 'A07:2021',
+    fix: 'Use a cryptographically random code_verifier and send its S256 code_challenge with every authorization-code request.',
+  });
 }
 
 function stripComments(content, language) {
@@ -483,11 +529,8 @@ function sourceFunctionScopes(content, language) {
   }
 
   const code = maskStrings(stripComments(content, language));
-  return findBracePairs(content, language).filter(({ start }) => {
-    const prefix = code.slice(Math.max(0, start - 180), start);
-    if (language === 'go') return /\bfunc\b[\s\S]{0,160}$/.test(prefix);
-    return /\bfunction\b[\s\S]{0,160}$|=>\s*$/.test(prefix);
-  });
+  return findBracePairs(content, language)
+    .filter(({ start }) => isFunctionBrace(code, start, language));
 }
 
 function isFunctionBrace(code, start, language) {
@@ -561,7 +604,7 @@ function isMcpToolHandlerScope(code, scope, language) {
   if (language !== 'js') return false;
 
   const prefix = code.slice(Math.max(0, scope.start - 320), scope.start);
-  const registrations = allRegexMatches(/(?:\.\s*tool|\b(?:registerTool|addTool))\s*\(/gi, prefix);
+  const registrations = allRegexMatches(MCP_TOOL_REGISTRATION, prefix);
   if (registrations.length) {
     const registration = registrations.at(-1);
     const callbackHeader = prefix.slice(registration.index);
@@ -570,7 +613,7 @@ function isMcpToolHandlerScope(code, scope, language) {
   }
 
   const localHeader = code.slice(scope.start, Math.min(code.length, scope.start + 320));
-  const localRegistration = allRegexMatches(/(?:\.\s*tool|\b(?:registerTool|addTool))\s*\(/gi, localHeader)[0];
+  const localRegistration = allRegexMatches(MCP_TOOL_REGISTRATION, localHeader)[0];
   if (!localRegistration) return false;
 
   const callbackHeader = localHeader.slice(localRegistration.index);
@@ -732,8 +775,7 @@ export class MCPSecurityAgent extends BaseAgent {
         inbound.index <= direct.index && direct.index < inbound.index + inbound[0].length
       )));
     const outbound = shape.outboundRequest;
-    const lineNumber = (index) => content.slice(0, index).split('\n').length;
-    const lineText = (index) => (content.split('\n')[lineNumber(index) - 1] || '').trim().slice(0, 180);
+    const { lineNumber, lineText } = sourceLineHelpers(content);
     const makeFinding = (requestIndex) => {
       if (this.isSuppressed(lineText(requestIndex), 'high')) return null;
 
@@ -823,8 +865,7 @@ export class MCPSecurityAgent extends BaseAgent {
       .sort((left, right) => left.index - right.index);
     const audienceValidation = shape.audienceValidation;
     const tokenExchange = MCP_OAUTH_TOKEN_EXCHANGE;
-    const lineNumber = (index) => content.slice(0, index).split('\n').length;
-    const lineText = (index) => (content.split('\n')[lineNumber(index) - 1] || '').trim().slice(0, 180);
+    const { lineNumber, lineText } = sourceLineHelpers(content);
     const findings = [];
     const seenScopes = new Set();
 
@@ -879,8 +920,7 @@ export class MCPSecurityAgent extends BaseAgent {
     const objectScopes = sourceObjectScopes(content, language);
     const clients = allRegexMatches(shape.staticClientId, code);
     const registrations = allRegexMatches(MCP_OAUTH_DYNAMIC_REGISTRATION, code);
-    const lineNumber = (index) => content.slice(0, index).split('\n').length;
-    const lineText = (index) => (content.split('\n')[lineNumber(index) - 1] || '').trim().slice(0, 180);
+    const { lineNumber, lineText } = sourceLineHelpers(content);
 
     for (const client of clients) {
       if (/\$\{|\b(?:process\.env|os\.environ|getenv|ENV\[|os\.Getenv)\b/i.test(client[2])) continue;
@@ -888,20 +928,11 @@ export class MCPSecurityAgent extends BaseAgent {
         const scope = objectScopeContaining(code, objectScopes, client.index, registration.index);
         if (!scope || this.isSuppressed(lineText(client.index), 'high')) continue;
 
-        return [createFinding({
+        return [createStaticClientIdDynamicRegFinding({
           file: filePath,
           line: lineNumber(client.index),
-          column: 1,
-          severity: 'high',
           category: this.category,
-          rule: 'MCP_STATIC_CLIENT_ID_DYNAMIC_REG',
-          title: 'MCP: Static OAuth Client ID With Dynamic Registration',
-          description: 'An MCP proxy combines a fixed third-party OAuth client_id with dynamic client registration. This can enable a confused deputy attack that reuses consent for an attacker-controlled client.',
           matched: lineText(client.index),
-          confidence: 'medium',
-          cwe: 'CWE-441',
-          owasp: 'A07:2021',
-          fix: 'Use per-client consent and validate registered client_id and redirect_uri values before starting the third-party authorization flow.',
         })];
       }
     }
@@ -927,8 +958,7 @@ export class MCPSecurityAgent extends BaseAgent {
     const functionScopes = sourceFunctionScopes(content, language);
     const codeFlows = allRegexMatches(shape.codeFlow, code);
     const pkce = MCP_OAUTH_PKCE;
-    const lineNumber = (index) => content.slice(0, index).split('\n').length;
-    const lineText = (index) => (content.split('\n')[lineNumber(index) - 1] || '').trim().slice(0, 180);
+    const { lineNumber, lineText } = sourceLineHelpers(content);
     const findings = [];
     const reportedScopes = new Set();
 
@@ -944,20 +974,11 @@ export class MCPSecurityAgent extends BaseAgent {
       if (this.isSuppressed(lineText(flowMatch.index), 'high')) continue;
       reportedScopes.add(scope.start);
 
-      findings.push(createFinding({
+      findings.push(createOAuthNoPkceFinding({
         file: filePath,
         line: lineNumber(flowMatch.index),
-        column: 1,
-        severity: 'high',
         category: this.category,
-        rule: 'MCP_OAUTH_NO_PKCE',
-        title: 'MCP: OAuth Authorization-Code Flow Without PKCE',
-        description: 'An MCP OAuth authorization-code flow does not use PKCE. An intercepted authorization code can then be redeemed by an attacker.',
         matched: lineText(flowMatch.index),
-        confidence: 'medium',
-        cwe: 'CWE-352',
-        owasp: 'A07:2021',
-        fix: 'Use a cryptographically random code_verifier and send its S256 code_challenge with every authorization-code request.',
       }));
     }
 
@@ -977,8 +998,7 @@ export class MCPSecurityAgent extends BaseAgent {
     const staticClientId = /["']?\bclient[_-]?id\b["']?\s*[:=]\s*(["'])(.*?)\1/gi;
     const clients = allRegexMatches(staticClientId, code);
     const registrations = allRegexMatches(MCP_OAUTH_DYNAMIC_REGISTRATION, code);
-    const lineNumber = (index) => content.slice(0, index).split('\n').length;
-    const lineText = (index) => (content.split('\n')[lineNumber(index) - 1] || '').trim().slice(0, 180);
+    const { lineNumber, lineText } = sourceLineHelpers(content);
     const findings = [];
 
     for (const client of clients) {
@@ -988,20 +1008,11 @@ export class MCPSecurityAgent extends BaseAgent {
       ));
       if (!registration || this.isSuppressed(lineText(client.index), 'high')) continue;
 
-      findings.push(createFinding({
+      findings.push(createStaticClientIdDynamicRegFinding({
         file: filePath,
         line: lineNumber(client.index),
-        column: 1,
-        severity: 'high',
         category: this.category,
-        rule: 'MCP_STATIC_CLIENT_ID_DYNAMIC_REG',
-        title: 'MCP: Static OAuth Client ID With Dynamic Registration',
-        description: 'An MCP proxy combines a fixed third-party OAuth client_id with dynamic client registration. This can enable a confused deputy attack that reuses consent for an attacker-controlled client.',
         matched: lineText(client.index),
-        confidence: 'medium',
-        cwe: 'CWE-441',
-        owasp: 'A07:2021',
-        fix: 'Use per-client consent and validate registered client_id and redirect_uri values before starting the third-party authorization flow.',
       }));
       break;
     }
@@ -1017,20 +1028,11 @@ export class MCPSecurityAgent extends BaseAgent {
       if (this.isSuppressed(lineText(flowMatch.index), 'high')) continue;
       reportedScopes.add(scope.start);
 
-      findings.push(createFinding({
+      findings.push(createOAuthNoPkceFinding({
         file: filePath,
         line: lineNumber(flowMatch.index),
-        column: 1,
-        severity: 'high',
         category: this.category,
-        rule: 'MCP_OAUTH_NO_PKCE',
-        title: 'MCP: OAuth Authorization-Code Flow Without PKCE',
-        description: 'An MCP OAuth authorization-code flow does not use PKCE. An intercepted authorization code can then be redeemed by an attacker.',
         matched: lineText(flowMatch.index),
-        confidence: 'medium',
-        cwe: 'CWE-352',
-        owasp: 'A07:2021',
-        fix: 'Use a cryptographically random code_verifier and send its S256 code_challenge with every authorization-code request.',
       }));
     }
 

--- a/cli/agents/mcp-security-agent.js
+++ b/cli/agents/mcp-security-agent.js
@@ -705,6 +705,48 @@ function isMcpToolHandlerScope(code, scope, language) {
   return callback !== -1 && !/[{};]/.test(callbackHeader.slice(0, callback));
 }
 
+function isMcpOAuthFunctionScope(code, scope, language) {
+  if (language === 'js' || language === 'python') {
+    return isMcpToolHandlerScope(code, scope, language);
+  }
+
+  const scopeContent = code.slice(scope.start, scope.end);
+  if (language === 'ruby') return /\b(?:MCPServer|MCP(?:::\w+)+)\.new\b/.test(scopeContent);
+  if (language === 'go') return /\bmcp\.NewServer\s*\(/.test(scopeContent);
+  return false;
+}
+
+function isMcpOAuthTopLevelObject(code, scope, language) {
+  const prefix = code.slice(0, scope.start);
+
+  if (language === 'js') {
+    if (/\b(?:new\s+)?McpServer\s*\([^)]*$/.test(prefix)) return true;
+    if (/\b(?:server|mcp)\s*\.\s*(?:tool|registerTool|addTool)\s*\([^)]*$/.test(prefix)) return true;
+
+    const declaration = prefix.match(/\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*$/);
+    if (!declaration) return false;
+
+    const binding = escapeRegex(declaration[1]);
+    const suffix = code.slice(scope.end);
+    return new RegExp(`\\b(?:server|mcp)\\s*\\.\\s*(?:tool|registerTool|addTool)\\s*\\([\\s\\S]{0,600}\\b${binding}\\b`).test(suffix)
+      || new RegExp(`\\b(?:new\\s+)?McpServer\\s*\\([\\s\\S]{0,600}\\b${binding}\\b`).test(suffix);
+  }
+
+  if (language === 'python') return /\b(?:FastMCP|MCP)\s*\([^)]*$/.test(prefix);
+  if (language === 'ruby') return /\bMCP(?:::\w+)+\b|\bMCPServer\b/.test(prefix);
+  if (language === 'go') return /\bmcp\.NewServer\s*\(/.test(prefix);
+  return false;
+}
+
+function isMcpOAuthSourceScope(code, language, scope, functionScopes, scopeKind) {
+  if (!scope) return false;
+  if (scopeKind === 'function') return isMcpOAuthFunctionScope(code, scope, language);
+
+  const functionScope = scopeContaining(functionScopes, scope.start, scope.end);
+  if (functionScope) return isMcpOAuthFunctionScope(code, functionScope, language);
+  return isMcpOAuthTopLevelObject(code, scope, language);
+}
+
 function allRegexMatches(regex, content) {
   const flags = regex.flags.includes('g') ? regex.flags : `${regex.flags}g`;
   const scanner = new RegExp(regex.source, flags);
@@ -968,7 +1010,11 @@ export class MCPSecurityAgent extends BaseAgent {
     for (const incoming of candidates) {
       if (incoming[1] && !isOAuthTokenName(incoming[1])) continue;
       const scope = sourceScopeContaining(content, code, language, scopes, incoming.index, incoming.index + incoming[0].length);
-      if (!scope || seenScopes.has(scope.start)) continue;
+      if (
+        !scope
+        || !isMcpOAuthSourceScope(source.structuralCode, language, scope, scopes, 'function')
+        || seenScopes.has(scope.start)
+      ) continue;
 
       const scopeContent = code.slice(scope.start, scope.end);
       const mitigationContent = maskStrings(scopeContent, false, language);
@@ -1070,9 +1116,24 @@ export class MCPSecurityAgent extends BaseAgent {
     const reportedScopes = new Set();
 
     for (const flowMatch of codeFlows) {
-      const scope = objectScopeContaining(code, objectScopes, flowMatch.index, flowMatch.index, language, source.structuralCode)
+      const objectScope = objectScopeContaining(
+        code,
+        objectScopes,
+        flowMatch.index,
+        flowMatch.index,
+        language,
+        source.structuralCode,
+      );
+      const scope = objectScope
         || sourceScopeContaining(content, code, language, functionScopes, flowMatch.index, flowMatch.index + flowMatch[0].length);
       if (!scope) continue;
+      if (!isMcpOAuthSourceScope(
+        source.structuralCode,
+        language,
+        scope,
+        functionScopes,
+        objectScope ? 'object' : 'function',
+      )) continue;
 
       const scopeContent = code.slice(scope.start, scope.end);
       const mitigationContent = maskStrings(scopeContent, true, language);

--- a/cli/agents/mcp-security-agent.js
+++ b/cli/agents/mcp-security-agent.js
@@ -295,6 +295,12 @@ const MCP_OAUTH_TOKEN_EXCHANGE = /(?:exchangeToken|token[_-]?exchange|subject_to
 const MCP_OAUTH_PKCE = /(?:\bcode[_-]?challenge\b|\bcode[_-]?verifier\b|\b(?:use[_-]?pkce|pkce)\b\s*[:=]|\b(?:generate|create|build)\w*code[_-]?(?:challenge|verifier)\b)/i;
 const MCP_OAUTH_EXPLICIT_NO_PKCE = /(?:["']?\b(?:use[_-]?pkce|pkce)\b["']?\s*[:=]\s*(?:false|null|["']?disabled["']?)|["']?\bcode[_-]?challenge\b["']?\s*[:=]\s*null)/i;
 const MCP_OAUTH_MARKER = /(?:\bMCP(?:::|[-_.])?(?:Server|Proxy)\b|@modelcontextprotocol|\bmcp[._-](?:server|proxy)\b|mcp\.NewServer)/i;
+const MCP_OAUTH_TOKEN_SOURCE_ANCHORS = {
+  js: /\b(?:req|request|ctx|event)\b\s*(?:\.\s*(?:headers?|authorization|bearer|get|header)\b|\[)/i,
+  python: /\b(?:request|req|ctx|context)\b\s*(?:\.\s*(?:headers?|authorization|bearer|get)\b|\[)/i,
+  ruby: /\b(?:request|req|context|env|headers)\b\s*(?:\.\s*(?:authorization|bearer)\b|\[)/i,
+  go: /\b(?:r|req|request)\.Header\.Get\s*\(/i,
+};
 
 function isOAuthTokenName(name) {
   const normalized = String(name || '').toLowerCase();
@@ -674,14 +680,51 @@ function sourceScopeContaining(content, code, language, scopes, start, end = sta
   };
 }
 
+function isDirectMcpCallback(callbackHeader) {
+  const functionMatch = allRegexMatches(/\bfunction\b/g, callbackHeader).at(-1);
+  const callback = Math.max(
+    callbackHeader.lastIndexOf('=>'),
+    functionMatch?.index ?? -1,
+  );
+  if (callback === -1 || /;/.test(callbackHeader.slice(0, callback))) return false;
+
+  let parentheses = 0;
+  let braces = 0;
+  for (let index = 0; index < callback; index += 1) {
+    if (callbackHeader[index] === '(') parentheses += 1;
+    if (callbackHeader[index] === ')') parentheses -= 1;
+    if (callbackHeader[index] === '{') braces += 1;
+    if (callbackHeader[index] === '}') braces -= 1;
+  }
+  return parentheses === 1 && braces === 0;
+}
+
+function pythonMcpToolDecoratorReceiver(code, scope) {
+  const lines = code.slice(0, scope.start).split('\n');
+  let depth = 0;
+
+  for (let lineIndex = lines.length - 2; lineIndex >= 0; lineIndex -= 1) {
+    const line = lines[lineIndex].trim();
+    if (!line) {
+      if (depth === 0) break;
+      continue;
+    }
+
+    depth += (line.match(/\)/g) || []).length - (line.match(/\(/g) || []).length;
+    const decorator = line.match(/^@([A-Za-z_]\w*)\.tool(?:\s*\(|\s*$)/);
+    if (decorator && depth === 0) return decorator[1];
+    if (depth === 0) break;
+  }
+
+  return null;
+}
+
 function isMcpToolHandlerScope(code, scope, language) {
   if (language === 'python') {
-    const precedingLines = code.slice(0, scope.start).split('\n');
-    const previousLine = precedingLines.at(-2)?.trim() || '';
-    const decorator = previousLine.match(/^@([A-Za-z_]\w*)\.tool(?:\([^)]*\))?$/);
-    if (!decorator) return false;
+    const receiverName = pythonMcpToolDecoratorReceiver(code, scope);
+    if (!receiverName) return false;
 
-    const receiver = escapeRegex(decorator[1]);
+    const receiver = escapeRegex(receiverName);
     return new RegExp(`\\b${receiver}\\s*=\\s*FastMCP\\s*\\(`).test(code);
   }
 
@@ -692,8 +735,7 @@ function isMcpToolHandlerScope(code, scope, language) {
   if (registrations.length) {
     const registration = registrations.at(-1);
     const callbackHeader = prefix.slice(registration.index);
-    const callback = callbackHeader.search(/=>|\bfunction\b/);
-    return callback !== -1 && !/[{};]/.test(callbackHeader.slice(0, callback));
+    return isDirectMcpCallback(callbackHeader);
   }
 
   const localHeader = code.slice(scope.start, Math.min(code.length, scope.start + 320));
@@ -701,8 +743,7 @@ function isMcpToolHandlerScope(code, scope, language) {
   if (!localRegistration) return false;
 
   const callbackHeader = localHeader.slice(localRegistration.index);
-  const callback = callbackHeader.search(/=>|\bfunction\b/);
-  return callback !== -1 && !/[{};]/.test(callbackHeader.slice(0, callback));
+  return isDirectMcpCallback(callbackHeader);
 }
 
 function isMcpOAuthFunctionScope(code, scope, language) {
@@ -762,6 +803,12 @@ function allRegexMatches(regex, content) {
 function allVisibleRegexMatches(regex, content, visibleContent) {
   return allRegexMatches(regex, content)
     .filter((match) => visibleContent[match.index] === content[match.index]);
+}
+
+function allVisibleOAuthTokenCandidates(regex, content, structuralCode, language) {
+  const sourceAnchor = MCP_OAUTH_TOKEN_SOURCE_ANCHORS[language];
+  return allVisibleRegexMatches(regex, content, structuralCode)
+    .filter((match) => sourceAnchor.test(structuralCode.slice(match.index, match.index + match[0].length)));
 }
 
 function isQuotedObjectKeyAt(content, index, language = 'js') {
@@ -907,8 +954,8 @@ export class MCPSecurityAgent extends BaseAgent {
     }
 
     const scopes = sourceFunctionScopes(content, language, source.structuralCode);
-    const inboundCandidates = allVisibleRegexMatches(shape.inboundToken, code, source.structuralCode);
-    const directCandidates = allVisibleRegexMatches(shape.directToken, code, source.structuralCode)
+    const inboundCandidates = allVisibleOAuthTokenCandidates(shape.inboundToken, code, source.structuralCode, language);
+    const directCandidates = allVisibleOAuthTokenCandidates(shape.directToken, code, source.structuralCode, language)
       .filter((direct) => !inboundCandidates.some((inbound) => (
         inbound.index <= direct.index && direct.index < inbound.index + inbound[0].length
       )));
@@ -938,7 +985,7 @@ export class MCPSecurityAgent extends BaseAgent {
       const tokenName = incoming[1];
       if (!isOAuthTokenName(tokenName)) continue;
       const scope = sourceScopeContaining(content, code, language, scopes, incoming.index, incoming.index + incoming[0].length);
-      if (!scope || !isMcpToolHandlerScope(code, scope, language)) continue;
+      if (!scope || !isMcpToolHandlerScope(source.structuralCode, scope, language)) continue;
       const searchStart = incoming.index + incoming[0].length;
       const searchWindow = source.structuralCode.slice(searchStart, Math.min(scope.end, searchStart + 1200));
       const requestMatch = searchWindow.match(outbound);
@@ -958,7 +1005,7 @@ export class MCPSecurityAgent extends BaseAgent {
     for (const directMatch of directCandidates) {
       const directIndex = directMatch.index;
       const scope = sourceScopeContaining(content, code, language, scopes, directIndex, directIndex + directMatch[0].length);
-      if (!scope || !isMcpToolHandlerScope(code, scope, language)) continue;
+      if (!scope || !isMcpToolHandlerScope(source.structuralCode, scope, language)) continue;
       const beforeStart = Math.max(scope.start, directIndex - 200);
       const beforeWindow = source.structuralCode.slice(beforeStart, directIndex);
       const beforeRequest = beforeWindow.match(outbound);
@@ -994,8 +1041,8 @@ export class MCPSecurityAgent extends BaseAgent {
     }
 
     const scopes = sourceFunctionScopes(content, language, source.structuralCode);
-    const inboundCandidates = allVisibleRegexMatches(shape.inboundToken, code, source.structuralCode);
-    const directCandidates = allVisibleRegexMatches(shape.directToken, code, source.structuralCode)
+    const inboundCandidates = allVisibleOAuthTokenCandidates(shape.inboundToken, code, source.structuralCode, language);
+    const directCandidates = allVisibleOAuthTokenCandidates(shape.directToken, code, source.structuralCode, language)
       .filter((direct) => !inboundCandidates.some((inbound) => (
         inbound.index <= direct.index && direct.index < inbound.index + inbound[0].length
       )));

--- a/cli/agents/mcp-security-agent.js
+++ b/cli/agents/mcp-security-agent.js
@@ -254,26 +254,26 @@ const OFFICIAL_MCP_SERVERS = new Set([
 // allowed to report on a Python, Ruby, or Go file by accident.
 const MCP_OAUTH_SHAPES = {
   js: {
-    inboundToken: /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*[^;\n]*\b(?:req|request|ctx|event)\b[^;\n]*(?:authorization|bearer|headers)\b[^;\n]*;?/gi,
-    directToken: /\b(?:req|request|ctx|event)\b[^;\n]*(?:authorization|bearer|headers)\b[^;\n]*/gi,
+    inboundToken: /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*[^;\n]*\b(?:req|request|ctx|event)\b[^;\n]*(?:\.(?:authorization|bearer)\b|\[\s*['"](?:authorization|bearer|http_authorization)['"]\s*\]|(?:get|header)\s*\(\s*['"](?:authorization|bearer)['"])/gi,
+    directToken: /\b(?:req|request|ctx|event)\b[^;\n]*(?:\.(?:authorization|bearer)\b|\[\s*['"](?:authorization|bearer|http_authorization)['"]\s*\]|(?:get|header)\s*\(\s*['"](?:authorization|bearer)['"])/gi,
     outboundRequest: /\b(?:fetch|axios(?:\.[A-Za-z_$][\w$]*)?|got|https?\.request)\s*\(/i,
-    audienceValidation: /(?:\baudience\b\s*[:=]|\b(?:claims?|payload|token)\b[^\n;]{0,120}\baud\b\s*(?:===|!==|==|!=|=)|\b(?:validate|verify|check|assert)\w*[^\n;]{0,120}\baud(?:ience)?\b)/i,
+    audienceValidation: /(?:\b(?:verify|decode|validate|check|assert)\w*[^\n;]{0,180}\baud(?:ience)?\b|\b(?:claims?|payload)\b[^\n;]{0,120}\baud\b\s*(?:===|!==|==|!=|=))/i,
     staticClientId: /["']?\bclient[_-]?id\b["']?\s*(?:=>|:=|[:=])\s*(["'])(.*?)\1/gi,
     codeFlow: /(?:["']?\bresponse[_-]?type\b["']?\s*[:=]\s*["']code["']|["']?\bgrant[_-]?type\b["']?\s*[:=]\s*["']authorization[_-]?code["']|\bauthorization[_-]?code\b|["']?\bauthorization[_-]?endpoint\b["']?[^\n;]{0,240}["']?\btoken[_-]?endpoint\b["']?)/i,
   },
   python: {
-    inboundToken: /\b([A-Za-z_]\w*)\s*=\s*(?:request|req|ctx|context)\b[^\n]*(?:headers?|authorization|bearer)[^\n]*/gi,
-    directToken: /\b(?:request|req|ctx|context)\b[^\n]*(?:headers?|authorization|bearer)[^\n]*/gi,
+    inboundToken: /\b([A-Za-z_]\w*)\s*=\s*(?:request|req|ctx|context)\b[^\n]*(?:\.(?:authorization|bearer)\b|\[\s*['"](?:authorization|bearer|http_authorization)['"]\s*\]|\.get\s*\(\s*['"](?:authorization|bearer)['"])/gi,
+    directToken: /\b(?:request|req|ctx|context)\b[^\n]*(?:\.(?:authorization|bearer)\b|\[\s*['"](?:authorization|bearer|http_authorization)['"]\s*\]|\.get\s*\(\s*['"](?:authorization|bearer)['"])/gi,
     outboundRequest: /\b(?:requests|httpx)\.(?:get|post|put|patch|delete|request)\s*\(|\b(?:urllib\.request\.)?urlopen\s*\(/i,
-    audienceValidation: /(?:\baudience\b\s*=|["']aud["']\s*\]|\b(?:claims?|payload)\b[^\n]{0,120}\baud\b\s*(?:==|!=|in\b))/i,
+    audienceValidation: /(?:\b(?:verify|decode|validate|check|assert)\w*[^\n]{0,180}\baud(?:ience)?\b|\b(?:claims?|payload)\b[^\n]{0,120}\b(?:aud|audience)\b\s*(?:==|!=|in\b|=))/i,
     staticClientId: /["']?\bclient[_-]?id\b["']?\s*(?:=>|:=|[:=])\s*(["'])(.*?)\1/gi,
     codeFlow: /(?:["']?\bresponse[_-]?type\b["']?\s*[:=]\s*["']code["']|["']?\bgrant[_-]?type\b["']?\s*[:=]\s*["']authorization[_-]?code["']|\bauthorization[_-]?code\b|["']?\bauthorization[_-]?endpoint\b["']?[^\n]{0,240}["']?\btoken[_-]?endpoint\b["']?)/i,
   },
   ruby: {
-    inboundToken: /\b([A-Za-z_]\w*)\s*=\s*(?:request|req|context|env|headers)\b[^\n]*(?:headers?|authorization|bearer)[^\n]*/gi,
-    directToken: /\b(?:request|req|context|env|headers)\b[^\n]*(?:headers?|authorization|bearer)[^\n]*/gi,
+    inboundToken: /\b([A-Za-z_]\w*)\s*=\s*(?:request|req|context|env|headers)\b[^\n]*(?:\.(?:authorization|bearer)\b|\[\s*['"](?:authorization|bearer|http_authorization)['"]\s*\])/gi,
+    directToken: /\b(?:request|req|context|env|headers)\b[^\n]*(?:\.(?:authorization|bearer)\b|\[\s*['"](?:authorization|bearer|http_authorization)['"]\s*\])/gi,
     outboundRequest: /\b(?:Net::HTTP|Faraday|HTTParty|RestClient)\b[\s\S]{0,120}\b(?:get|post|put|delete|request|call)\b\s*[.(]/i,
-    audienceValidation: /(?:\baudience\s*[:=]|["']aud["']\s*=>|\b(?:claims?|payload)\b[^\n]{0,120}\baud\b\s*(?:==|!=|=~))/i,
+    audienceValidation: /(?:\b(?:verify|decode|validate|check|assert)\w*[^\n]{0,180}\baud(?:ience)?\b|\b(?:claims?|payload)\b[^\n]{0,120}\b(?:aud|audience)\b\s*(?:==|!=|=~|=>))/i,
     staticClientId: /["']?\bclient[_-]?id\b["']?\s*(?:=>|:=|[:=])\s*(["'])(.*?)\1/gi,
     codeFlow: /(?:["']?\bresponse[_-]?type\b["']?\s*[:=]\s*["']code["']|["']?\bgrant[_-]?type\b["']?\s*[:=]\s*["']authorization[_-]?code["']|\bauthorization[_-]?code\b|["']?\bauthorization[_-]?endpoint\b["']?[^\n]{0,240}["']?\btoken[_-]?endpoint\b["']?)/i,
   },
@@ -281,7 +281,7 @@ const MCP_OAUTH_SHAPES = {
     inboundToken: /\b([A-Za-z_]\w*)\s*:?=\s*(?:r|req|request)\.Header\.Get\(\s*["']Authorization["']\s*\)/gi,
     directToken: /\b(?:r|req|request)\.Header\.Get\(\s*["']Authorization["']\s*\)/gi,
     outboundRequest: /\b(?:http\.(?:NewRequest|Get|Post|PostForm)|[A-Za-z_]\w*\.Do)\s*\(/i,
-    audienceValidation: /(?:\b(?:Audience|VerifyAudience)\b|["']aud["']\s*[:=]|\b(?:claims?|payload)\b[\s\S]{0,120}\baud\b\s*(?:==|!=))/i,
+    audienceValidation: /(?:\b(?:VerifyAudience|ValidateAudience|ParseWithClaims)\b|\b(?:claims?|payload)\b[\s\S]{0,120}\baud(?:ience)?\b\s*(?:==|!=))/i,
     staticClientId: /["']?\b(?:client[_-]?id|clientID)\b["']?\s*(?:=>|:=|[:=])\s*(["'])(.*?)\1/gi,
     codeFlow: /(?:["']?\bresponse[_-]?type\b["']?\s*[:=]\s*["']code["']|["']?\bgrant[_-]?type\b["']?\s*[:=]\s*["']authorization[_-]?code["']|\bauthorization[_-]?code\b|["']?\bauthorization[_-]?endpoint\b["']?[\s\S]{0,240}["']?\btoken[_-]?endpoint\b["']?)/i,
   },
@@ -289,9 +289,269 @@ const MCP_OAUTH_SHAPES = {
 
 const MCP_OAUTH_DYNAMIC_REGISTRATION = /["']?(?:dynamic[_-]?client[_-]?registration|dynamicClientRegistration|allow[_-]?dynamic[_-]?registration|enable[_-]?dynamic[_-]?client[_-]?registration|dynamicRegistration|registerClients|RegisterClient)["']?\s*(?:=>|:=|[:=])\s*(?:true|["']?enabled["']?)/i;
 const MCP_OAUTH_TOKEN_EXCHANGE = /(?:exchangeToken|token[_-]?exchange|subject_token|RFC\s*8693|urn:ietf:params:oauth:grant-type:token-exchange)/i;
-const MCP_OAUTH_PKCE = /(?:\bcode[_-]?challenge\b|\bcode[_-]?verifier\b|\buse[_-]?pkce\b|\bpkce\b)/i;
+const MCP_OAUTH_PKCE = /(?:\bcode[_-]?challenge\b|\bcode[_-]?verifier\b|\b(?:use[_-]?pkce|pkce)\b\s*[:=]|\b(?:generate|create|build)\w*code[_-]?(?:challenge|verifier)\b)/i;
 const MCP_OAUTH_EXPLICIT_NO_PKCE = /(?:["']?\b(?:use[_-]?pkce|pkce)\b["']?\s*[:=]\s*(?:false|null|["']?disabled["']?)|["']?\bcode[_-]?challenge\b["']?\s*[:=]\s*null)/i;
 const MCP_OAUTH_MARKER = /(?:\bMCP(?:::|[-_.])?(?:Server|Proxy)\b|@modelcontextprotocol|\bmcp[._-](?:server|proxy)\b|mcp\.NewServer)/i;
+
+function isOAuthTokenName(name) {
+  const normalized = String(name || '').toLowerCase();
+  return normalized.includes('token')
+    || normalized.includes('bearer')
+    || normalized.includes('authorization')
+    || normalized === 'auth'
+    || normalized.startsWith('auth_')
+    || normalized === 'accesstoken';
+}
+
+function stripComments(content, language) {
+  const supportsLineSlashComments = language === 'js' || language === 'go';
+  const output = [...content];
+  let state = 'code';
+  let quote = '';
+
+  const blank = (index) => {
+    if (output[index] !== '\n' && output[index] !== '\r') output[index] = ' ';
+  };
+
+  for (let index = 0; index < content.length; index += 1) {
+    const char = content[index];
+    const next = content[index + 1];
+
+    if (state === 'line-comment') {
+      if (char === '\n' || char === '\r') state = 'code';
+      else blank(index);
+      continue;
+    }
+
+    if (state === 'block-comment') {
+      if (char === '*' && next === '/') {
+        blank(index);
+        blank(index + 1);
+        index += 1;
+        state = 'code';
+      } else {
+        blank(index);
+      }
+      continue;
+    }
+
+    if (state === 'string') {
+      if (char === '\\') {
+        index += 1;
+      } else if (char === quote) {
+        state = 'code';
+        quote = '';
+      }
+      continue;
+    }
+
+    if (supportsLineSlashComments && char === '/' && next === '/') {
+      blank(index);
+      blank(index + 1);
+      index += 1;
+      state = 'line-comment';
+      continue;
+    }
+
+    if (supportsLineSlashComments && char === '/' && next === '*') {
+      blank(index);
+      blank(index + 1);
+      index += 1;
+      state = 'block-comment';
+      continue;
+    }
+
+    if ((language === 'python' || language === 'ruby') && char === '#') {
+      blank(index);
+      state = 'line-comment';
+      continue;
+    }
+
+    if (char === '\'' || char === '"' || (language === 'js' && char === '`')) {
+      quote = char;
+      state = 'string';
+    }
+  }
+
+  return output.join('');
+}
+
+function maskStrings(content) {
+  const output = [...content];
+  let state = 'code';
+  let quote = '';
+
+  const blank = (index) => {
+    if (output[index] !== '\n' && output[index] !== '\r') output[index] = ' ';
+  };
+
+  for (let index = 0; index < content.length; index += 1) {
+    const char = content[index];
+    if (state === 'string') {
+      if (char === '\\') {
+        blank(index);
+        if (index + 1 < content.length) {
+          blank(index + 1);
+          index += 1;
+        }
+      } else if (char === quote) {
+        blank(index);
+        state = 'code';
+        quote = '';
+      } else {
+        blank(index);
+      }
+      continue;
+    }
+
+    if (char === '\'' || char === '"' || char === '`') {
+      quote = char;
+      state = 'string';
+      blank(index);
+    }
+  }
+
+  return output.join('');
+}
+
+function findBracePairs(content, language) {
+  const code = maskStrings(stripComments(content, language));
+  const stack = [];
+  const pairs = [];
+
+  for (let index = 0; index < code.length; index += 1) {
+    if (code[index] === '{') {
+      stack.push(index);
+    } else if (code[index] === '}' && stack.length) {
+      pairs.push({ start: stack.pop(), end: index + 1 });
+    }
+  }
+
+  return pairs;
+}
+
+function sourceFunctionScopes(content, language) {
+  if (language === 'python' || language === 'ruby') {
+    const lines = content.split('\n');
+    const offsets = [];
+    let offset = 0;
+    for (const line of lines) {
+      offsets.push(offset);
+      offset += line.length + 1;
+    }
+
+    const scopes = [];
+    for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+      const line = lines[lineIndex];
+      const match = language === 'python'
+        ? line.match(/^(\s*)(?:async\s+)?def\s+/)
+        : line.match(/^(\s*)def\s+/);
+      if (!match) continue;
+
+      const indent = match[1].replace(/\t/g, '    ').length;
+      let endLine = lines.length;
+      if (language === 'python') {
+        for (let nextLine = lineIndex + 1; nextLine < lines.length; nextLine += 1) {
+          if (!lines[nextLine].trim()) continue;
+          const nextIndent = lines[nextLine].match(/^\s*/)[0].replace(/\t/g, '    ').length;
+          if (nextIndent <= indent) {
+            endLine = nextLine;
+            break;
+          }
+        }
+      } else {
+        let depth = 1;
+        for (let nextLine = lineIndex + 1; nextLine < lines.length; nextLine += 1) {
+          if (/^\s*def\b/.test(lines[nextLine])) depth += 1;
+          if (/^\s*end\b/.test(lines[nextLine])) depth -= 1;
+          if (depth === 0) {
+            endLine = nextLine + 1;
+            break;
+          }
+        }
+      }
+
+      scopes.push({ start: offsets[lineIndex], end: offsets[endLine] ?? content.length });
+    }
+    return scopes;
+  }
+
+  const code = maskStrings(stripComments(content, language));
+  return findBracePairs(content, language).filter(({ start }) => {
+    const prefix = code.slice(Math.max(0, start - 180), start);
+    if (language === 'go') return /\bfunc\b[\s\S]{0,160}$/.test(prefix);
+    return /\bfunction\b[\s\S]{0,160}$|=>\s*$/.test(prefix);
+  });
+}
+
+function isFunctionBrace(code, start, language) {
+  const prefix = code.slice(Math.max(0, start - 180), start);
+  if (language === 'go') return /\bfunc\b[\s\S]{0,160}$/.test(prefix);
+  return language === 'js' && /\bfunction\b[\s\S]{0,160}$|=>\s*$/.test(prefix);
+}
+
+function sourceObjectScopes(content, language) {
+  const code = maskStrings(stripComments(content, language));
+  return findBracePairs(content, language)
+    .filter(({ start }) => !isFunctionBrace(code, start, language));
+}
+
+function braceDepthAt(code, scope, index) {
+  let depth = 0;
+  for (let position = scope.start; position < index; position += 1) {
+    if (code[position] === '{') depth += 1;
+    if (code[position] === '}') depth -= 1;
+  }
+  return depth;
+}
+
+function objectScopeContaining(code, scopes, firstIndex, secondIndex) {
+  return scopes
+    .filter((scope) => (
+      scope.start <= firstIndex
+      && firstIndex < scope.end
+      && scope.start <= secondIndex
+      && secondIndex < scope.end
+      && braceDepthAt(code, scope, firstIndex) === 1
+      && braceDepthAt(code, scope, secondIndex) === 1
+    ))
+    .sort((left, right) => (left.end - left.start) - (right.end - right.start))[0] || null;
+}
+
+function scopeContaining(scopes, start, end = start + 1) {
+  return scopes
+    .filter((scope) => scope.start <= start && end <= scope.end)
+    .sort((left, right) => (left.end - left.start) - (right.end - right.start))[0] || null;
+}
+
+function sourceScopeContaining(content, code, language, scopes, start, end = start + 1) {
+  const scope = scopeContaining(scopes, start, end);
+  if (scope || language !== 'js') return scope;
+
+  const arrow = code.lastIndexOf('=>', start);
+  if (arrow === -1) return null;
+
+  const lineStart = code.lastIndexOf('\n', arrow - 1) + 1;
+  const statementEnd = code.indexOf(');', start);
+  const lineEndIndex = code.indexOf('\n', start);
+  const lineEnd = lineEndIndex === -1 ? content.length : lineEndIndex + 1;
+  return {
+    start: lineStart,
+    end: statementEnd === -1 ? lineEnd : statementEnd + 2,
+  };
+}
+
+function allRegexMatches(regex, content) {
+  const flags = regex.flags.includes('g') ? regex.flags : `${regex.flags}g`;
+  const scanner = new RegExp(regex.source, flags);
+  const matches = [];
+  let match;
+  while ((match = scanner.exec(content)) !== null) {
+    matches.push(match);
+    if (!match[0]) scanner.lastIndex += 1;
+  }
+  return matches;
+}
 
 // =============================================================================
 // MCP SECURITY AGENT
@@ -377,19 +637,23 @@ export class MCPSecurityAgent extends BaseAgent {
    * or Go by accident (issue #105).
    */
   _checkOAuthTokenPassthrough(filePath) {
-    const shape = MCP_OAUTH_SHAPES[languageOf(filePath)];
+    const language = languageOf(filePath);
+    const shape = MCP_OAUTH_SHAPES[language];
     if (!shape) return [];
 
     const content = this.readFile(filePath);
-    if (!content || !MCP_OAUTH_MARKER.test(content)) {
+    const code = content && stripComments(content, language);
+    if (!code || !MCP_OAUTH_MARKER.test(code)) {
       return [];
     }
 
-    const inbound = shape.inboundToken;
-    inbound.lastIndex = 0;
+    const scopes = sourceFunctionScopes(content, language);
+    const inboundCandidates = allRegexMatches(shape.inboundToken, code);
+    const directCandidates = allRegexMatches(shape.directToken, code)
+      .filter((direct) => !inboundCandidates.some((inbound) => (
+        inbound.index <= direct.index && direct.index < inbound.index + inbound[0].length
+      )));
     const outbound = shape.outboundRequest;
-    const direct = shape.directToken;
-    direct.lastIndex = 0;
     const lineNumber = (index) => content.slice(0, index).split('\n').length;
     const lineText = (index) => (content.split('\n')[lineNumber(index) - 1] || '').trim().slice(0, 180);
     const makeFinding = (requestIndex) => {
@@ -412,16 +676,18 @@ export class MCPSecurityAgent extends BaseAgent {
       });
     };
 
-    let incoming;
-    while ((incoming = inbound.exec(content)) !== null) {
+    for (const incoming of inboundCandidates) {
       const tokenName = incoming[1];
+      if (!isOAuthTokenName(tokenName)) continue;
+      const scope = sourceScopeContaining(content, code, language, scopes, incoming.index, incoming.index + incoming[0].length);
+      if (!scope) continue;
       const searchStart = incoming.index + incoming[0].length;
-      const searchWindow = content.slice(searchStart, searchStart + 1200);
+      const searchWindow = code.slice(searchStart, Math.min(scope.end, searchStart + 1200));
       const requestMatch = searchWindow.match(outbound);
       if (!requestMatch) continue;
 
       const requestIndex = searchStart + requestMatch.index;
-      const requestContext = content.slice(requestIndex, requestIndex + 600);
+      const requestContext = code.slice(requestIndex, Math.min(scope.end, requestIndex + 600));
       const tokenReference = new RegExp(`\\b${tokenName}\\b`);
       if (!/(?:authorization|bearer|headers)/i.test(requestContext) || !tokenReference.test(requestContext)) {
         continue;
@@ -431,16 +697,17 @@ export class MCPSecurityAgent extends BaseAgent {
       if (finding) return [finding];
     }
 
-    let directMatch;
-    while ((directMatch = direct.exec(content)) !== null) {
+    for (const directMatch of directCandidates) {
       const directIndex = directMatch.index;
-      const beforeStart = Math.max(0, directIndex - 200);
-      const beforeWindow = content.slice(beforeStart, directIndex);
+      const scope = sourceScopeContaining(content, code, language, scopes, directIndex, directIndex + directMatch[0].length);
+      if (!scope) continue;
+      const beforeStart = Math.max(scope.start, directIndex - 200);
+      const beforeWindow = code.slice(beforeStart, directIndex);
       const beforeRequest = beforeWindow.match(outbound);
       if (!beforeRequest) continue;
       const requestIndex = beforeStart + beforeRequest.index;
 
-      const requestContext = content.slice(requestIndex, Math.max(requestIndex + 600, directIndex + directMatch[0].length));
+      const requestContext = code.slice(requestIndex, Math.min(scope.end, Math.max(requestIndex + 600, directIndex + directMatch[0].length)));
       if (!/(?:authorization|bearer|headers)/i.test(requestContext)) continue;
 
       const finding = makeFinding(requestIndex);
@@ -462,38 +729,55 @@ export class MCPSecurityAgent extends BaseAgent {
     if (!shape) return [];
 
     const content = this.readFile(filePath);
-    if (!content || !MCP_OAUTH_MARKER.test(content)) {
+    const language = languageOf(filePath);
+    const code = content && stripComments(content, language);
+    if (!code || !MCP_OAUTH_MARKER.test(code)) {
       return [];
     }
 
-    const inbound = shape.inboundToken;
-    inbound.lastIndex = 0;
-    const direct = shape.directToken;
-    direct.lastIndex = 0;
+    const scopes = sourceFunctionScopes(content, language);
+    const inboundCandidates = allRegexMatches(shape.inboundToken, code);
+    const directCandidates = allRegexMatches(shape.directToken, code)
+      .filter((direct) => !inboundCandidates.some((inbound) => (
+        inbound.index <= direct.index && direct.index < inbound.index + inbound[0].length
+      )));
+    const candidates = [...inboundCandidates, ...directCandidates]
+      .sort((left, right) => left.index - right.index);
     const audienceValidation = shape.audienceValidation;
     const tokenExchange = MCP_OAUTH_TOKEN_EXCHANGE;
     const lineNumber = (index) => content.slice(0, index).split('\n').length;
     const lineText = (index) => (content.split('\n')[lineNumber(index) - 1] || '').trim().slice(0, 180);
-    const incoming = inbound.exec(content) || direct.exec(content);
+    const findings = [];
+    const seenScopes = new Set();
 
-    if (!incoming || audienceValidation.test(content) || tokenExchange.test(content)) return [];
-    if (this.isSuppressed(lineText(incoming.index), 'high')) return [];
+    for (const incoming of candidates) {
+      if (incoming[1] && !isOAuthTokenName(incoming[1])) continue;
+      const scope = sourceScopeContaining(content, code, language, scopes, incoming.index, incoming.index + incoming[0].length);
+      if (!scope || seenScopes.has(scope.start)) continue;
 
-    return [createFinding({
-      file: filePath,
-      line: lineNumber(incoming.index),
-      column: 1,
-      severity: 'high',
-      category: this.category,
-      rule: 'MCP_TOKEN_AUDIENCE_UNVALIDATED',
-      title: 'MCP: Inbound OAuth Token Audience Not Validated',
-      description: 'An MCP server accepts an inbound authorization token without checking that its audience is the MCP server. Tokens issued for another resource can then cross the MCP trust boundary.',
-      matched: lineText(incoming.index),
-      confidence: 'medium',
-      cwe: 'CWE-287',
-      owasp: 'A07:2021',
-      fix: 'Validate the token audience against the MCP server resource before accepting it, or use RFC 8693 token exchange to mint a token for the target audience.',
-    })];
+      const scopeContent = code.slice(scope.start, scope.end);
+      if (audienceValidation.test(scopeContent) || tokenExchange.test(scopeContent)) continue;
+      if (this.isSuppressed(lineText(incoming.index), 'high')) continue;
+
+      seenScopes.add(scope.start);
+      findings.push(createFinding({
+        file: filePath,
+        line: lineNumber(incoming.index),
+        column: 1,
+        severity: 'high',
+        category: this.category,
+        rule: 'MCP_TOKEN_AUDIENCE_UNVALIDATED',
+        title: 'MCP: Inbound OAuth Token Audience Not Validated',
+        description: 'An MCP server accepts an inbound authorization token without checking that its audience is the MCP server. Tokens issued for another resource can then cross the MCP trust boundary.',
+        matched: lineText(incoming.index),
+        confidence: 'medium',
+        cwe: 'CWE-287',
+        owasp: 'A07:2021',
+        fix: 'Validate the token audience against the MCP server resource before accepting it, or use RFC 8693 token exchange to mint a token for the target audience.',
+      }));
+    }
+
+    return findings;
   }
 
   /**
@@ -501,43 +785,44 @@ export class MCPSecurityAgent extends BaseAgent {
    * registration in an MCP proxy.
    */
   _checkOAuthConfusedDeputy(filePath) {
-    const shape = MCP_OAUTH_SHAPES[languageOf(filePath)];
+    const language = languageOf(filePath);
+    const shape = MCP_OAUTH_SHAPES[language];
     if (!shape) return [];
 
     const content = this.readFile(filePath);
-    if (!content || !MCP_OAUTH_MARKER.test(content)) {
+    const code = content && stripComments(content, language);
+    if (!code || !MCP_OAUTH_MARKER.test(code)) {
       return [];
     }
 
-    const staticClientId = shape.staticClientId;
-    staticClientId.lastIndex = 0;
-    const dynamicRegistration = MCP_OAUTH_DYNAMIC_REGISTRATION;
+    const objectScopes = sourceObjectScopes(content, language);
+    const clients = allRegexMatches(shape.staticClientId, code);
+    const registrations = allRegexMatches(MCP_OAUTH_DYNAMIC_REGISTRATION, code);
     const lineNumber = (index) => content.slice(0, index).split('\n').length;
     const lineText = (index) => (content.split('\n')[lineNumber(index) - 1] || '').trim().slice(0, 180);
-    let client;
 
-    while ((client = staticClientId.exec(content)) !== null) {
+    for (const client of clients) {
       if (/\$\{|\b(?:process\.env|os\.environ|getenv|ENV\[|os\.Getenv)\b/i.test(client[2])) continue;
-      const scopeStart = Math.max(0, client.index - 600);
-      const scope = content.slice(scopeStart, client.index + 600);
-      if (!dynamicRegistration.test(scope)) continue;
-      if (this.isSuppressed(lineText(client.index), 'high')) return [];
+      for (const registration of registrations) {
+        const scope = objectScopeContaining(code, objectScopes, client.index, registration.index);
+        if (!scope || this.isSuppressed(lineText(client.index), 'high')) continue;
 
-      return [createFinding({
-        file: filePath,
-        line: lineNumber(client.index),
-        column: 1,
-        severity: 'high',
-        category: this.category,
-        rule: 'MCP_STATIC_CLIENT_ID_DYNAMIC_REG',
-        title: 'MCP: Static OAuth Client ID With Dynamic Registration',
-        description: 'An MCP proxy combines a fixed third-party OAuth client_id with dynamic client registration. This can enable a confused deputy attack that reuses consent for an attacker-controlled client.',
-        matched: lineText(client.index),
-        confidence: 'medium',
-        cwe: 'CWE-441',
-        owasp: 'A07:2021',
-        fix: 'Use per-client consent and validate registered client_id and redirect_uri values before starting the third-party authorization flow.',
-      })];
+        return [createFinding({
+          file: filePath,
+          line: lineNumber(client.index),
+          column: 1,
+          severity: 'high',
+          category: this.category,
+          rule: 'MCP_STATIC_CLIENT_ID_DYNAMIC_REG',
+          title: 'MCP: Static OAuth Client ID With Dynamic Registration',
+          description: 'An MCP proxy combines a fixed third-party OAuth client_id with dynamic client registration. This can enable a confused deputy attack that reuses consent for an attacker-controlled client.',
+          matched: lineText(client.index),
+          confidence: 'medium',
+          cwe: 'CWE-441',
+          owasp: 'A07:2021',
+          fix: 'Use per-client consent and validate registered client_id and redirect_uri values before starting the third-party authorization flow.',
+        })];
+      }
     }
 
     return [];
@@ -547,81 +832,38 @@ export class MCPSecurityAgent extends BaseAgent {
    * Detect an OAuth authorization-code flow that does not use PKCE.
    */
   _checkOAuthPkce(filePath) {
-    const shape = MCP_OAUTH_SHAPES[languageOf(filePath)];
+    const language = languageOf(filePath);
+    const shape = MCP_OAUTH_SHAPES[language];
     if (!shape) return [];
 
     const content = this.readFile(filePath);
-    if (!content || !MCP_OAUTH_MARKER.test(content)) {
+    const code = content && stripComments(content, language);
+    if (!code || !MCP_OAUTH_MARKER.test(code)) {
       return [];
     }
 
-    const codeFlow = shape.codeFlow;
+    const objectScopes = sourceObjectScopes(content, language);
+    const functionScopes = sourceFunctionScopes(content, language);
+    const codeFlows = allRegexMatches(shape.codeFlow, code);
     const pkce = MCP_OAUTH_PKCE;
     const explicitNoPkce = MCP_OAUTH_EXPLICIT_NO_PKCE;
-    const flowMatch = codeFlow.exec(content);
-    if (!flowMatch || (pkce.test(content) && !explicitNoPkce.test(content))) return [];
-
     const lineNumber = (index) => content.slice(0, index).split('\n').length;
     const lineText = (index) => (content.split('\n')[lineNumber(index) - 1] || '').trim().slice(0, 180);
-    if (this.isSuppressed(lineText(flowMatch.index), 'high')) return [];
+    const findings = [];
+    const reportedScopes = new Set();
 
-    return [createFinding({
-      file: filePath,
-      line: lineNumber(flowMatch.index),
-      column: 1,
-      severity: 'high',
-      category: this.category,
-      rule: 'MCP_OAUTH_NO_PKCE',
-      title: 'MCP: OAuth Authorization-Code Flow Without PKCE',
-      description: 'An MCP OAuth authorization-code flow does not use PKCE. An intercepted authorization code can then be redeemed by an attacker.',
-      matched: lineText(flowMatch.index),
-      confidence: 'medium',
-      cwe: 'CWE-352',
-      owasp: 'A07:2021',
-      fix: 'Use a cryptographically random code_verifier and send its S256 code_challenge with every authorization-code request.',
-    })];
-  }
+    for (const flowMatch of codeFlows) {
+      const scope = objectScopeContaining(code, objectScopes, flowMatch.index, flowMatch.index)
+        || sourceScopeContaining(content, code, language, functionScopes, flowMatch.index, flowMatch.index + flowMatch[0].length);
+      if (!scope) continue;
 
-  /**
-   * Check project MCP JSON for OAuth proxy settings. JSON configs have no
-   * source-language extension, so they use their own key/value shapes.
-   */
-  _checkOAuthConfig(filePath) {
-    const content = this.readFile(filePath);
-    if (!content) return [];
+      const scopeContent = code.slice(scope.start, scope.end);
+      if (pkce.test(scopeContent) && !explicitNoPkce.test(scopeContent)) continue;
+      if (reportedScopes.has(scope.start)) continue;
+      if (this.isSuppressed(lineText(flowMatch.index), 'high')) continue;
+      reportedScopes.add(scope.start);
 
-    const staticClientId = /["']?\bclient[_-]?id\b["']?\s*[:=]\s*(["'])(.*?)\1/gi;
-    const lineNumber = (index) => content.slice(0, index).split('\n').length;
-    const lineText = (index) => (content.split('\n')[lineNumber(index) - 1] || '').trim().slice(0, 180);
-    let client;
-
-    while ((client = staticClientId.exec(content)) !== null) {
-      if (/\$\{|\b(?:process\.env|os\.environ|getenv|ENV\[|os\.Getenv)\b/i.test(client[2])) continue;
-      const scope = content.slice(Math.max(0, client.index - 600), client.index + 600);
-      if (!MCP_OAUTH_DYNAMIC_REGISTRATION.test(scope)) continue;
-
-      return [createFinding({
-        file: filePath,
-        line: lineNumber(client.index),
-        column: 1,
-        severity: 'high',
-        category: this.category,
-        rule: 'MCP_STATIC_CLIENT_ID_DYNAMIC_REG',
-        title: 'MCP: Static OAuth Client ID With Dynamic Registration',
-        description: 'An MCP proxy combines a fixed third-party OAuth client_id with dynamic client registration. This can enable a confused deputy attack that reuses consent for an attacker-controlled client.',
-        matched: lineText(client.index),
-        confidence: 'medium',
-        cwe: 'CWE-441',
-        owasp: 'A07:2021',
-        fix: 'Use per-client consent and validate registered client_id and redirect_uri values before starting the third-party authorization flow.',
-      })];
-    }
-
-    const flowMatch = MCP_OAUTH_SHAPES.js.codeFlow.exec(content);
-    if (flowMatch && (!MCP_OAUTH_PKCE.test(content) || MCP_OAUTH_EXPLICIT_NO_PKCE.test(content))) {
-      if (this.isSuppressed(lineText(flowMatch.index), 'high')) return [];
-
-      return [createFinding({
+      findings.push(createFinding({
         file: filePath,
         line: lineNumber(flowMatch.index),
         column: 1,
@@ -635,10 +877,82 @@ export class MCPSecurityAgent extends BaseAgent {
         cwe: 'CWE-352',
         owasp: 'A07:2021',
         fix: 'Use a cryptographically random code_verifier and send its S256 code_challenge with every authorization-code request.',
-      })];
+      }));
     }
 
-    return [];
+    return findings;
+  }
+
+  /**
+   * Check project MCP JSON for OAuth proxy settings. JSON configs have no
+   * source-language extension, so they use their own key/value shapes.
+   */
+  _checkOAuthConfig(filePath) {
+    const content = this.readFile(filePath);
+    if (!content) return [];
+
+    const code = stripComments(content, 'js');
+    const objectScopes = sourceObjectScopes(content, 'js');
+    const staticClientId = /["']?\bclient[_-]?id\b["']?\s*[:=]\s*(["'])(.*?)\1/gi;
+    const clients = allRegexMatches(staticClientId, code);
+    const registrations = allRegexMatches(MCP_OAUTH_DYNAMIC_REGISTRATION, code);
+    const lineNumber = (index) => content.slice(0, index).split('\n').length;
+    const lineText = (index) => (content.split('\n')[lineNumber(index) - 1] || '').trim().slice(0, 180);
+    const findings = [];
+
+    for (const client of clients) {
+      if (/\$\{|\b(?:process\.env|os\.environ|getenv|ENV\[|os\.Getenv)\b/i.test(client[2])) continue;
+      const registration = registrations.find((candidate) => (
+        objectScopeContaining(code, objectScopes, client.index, candidate.index)
+      ));
+      if (!registration || this.isSuppressed(lineText(client.index), 'high')) continue;
+
+      findings.push(createFinding({
+        file: filePath,
+        line: lineNumber(client.index),
+        column: 1,
+        severity: 'high',
+        category: this.category,
+        rule: 'MCP_STATIC_CLIENT_ID_DYNAMIC_REG',
+        title: 'MCP: Static OAuth Client ID With Dynamic Registration',
+        description: 'An MCP proxy combines a fixed third-party OAuth client_id with dynamic client registration. This can enable a confused deputy attack that reuses consent for an attacker-controlled client.',
+        matched: lineText(client.index),
+        confidence: 'medium',
+        cwe: 'CWE-441',
+        owasp: 'A07:2021',
+        fix: 'Use per-client consent and validate registered client_id and redirect_uri values before starting the third-party authorization flow.',
+      }));
+      break;
+    }
+
+    const reportedScopes = new Set();
+    for (const flowMatch of allRegexMatches(MCP_OAUTH_SHAPES.js.codeFlow, code)) {
+      const scope = objectScopeContaining(code, objectScopes, flowMatch.index, flowMatch.index);
+      if (!scope || reportedScopes.has(scope.start)) continue;
+
+      const scopeContent = code.slice(scope.start, scope.end);
+      if (MCP_OAUTH_PKCE.test(scopeContent) && !MCP_OAUTH_EXPLICIT_NO_PKCE.test(scopeContent)) continue;
+      if (this.isSuppressed(lineText(flowMatch.index), 'high')) continue;
+      reportedScopes.add(scope.start);
+
+      findings.push(createFinding({
+        file: filePath,
+        line: lineNumber(flowMatch.index),
+        column: 1,
+        severity: 'high',
+        category: this.category,
+        rule: 'MCP_OAUTH_NO_PKCE',
+        title: 'MCP: OAuth Authorization-Code Flow Without PKCE',
+        description: 'An MCP OAuth authorization-code flow does not use PKCE. An intercepted authorization code can then be redeemed by an attacker.',
+        matched: lineText(flowMatch.index),
+        confidence: 'medium',
+        cwe: 'CWE-352',
+        owasp: 'A07:2021',
+        fix: 'Use a cryptographically random code_verifier and send its S256 code_challenge with every authorization-code request.',
+      }));
+    }
+
+    return findings;
   }
 
   /**


### PR DESCRIPTION
## Summary

Implements [#104](https://github.com/asamassekou10/ship-safe/issues/104) by adding four targeted OAuth security checks to `MCPSecurityAgent`:

- `MCP_UPSTREAM_TOKEN_PASSTHROUGH` — inbound MCP authorization tokens forwarded downstream
- `MCP_TOKEN_AUDIENCE_UNVALIDATED` — inbound tokens accepted without audience validation or token exchange
- `MCP_STATIC_CLIENT_ID_DYNAMIC_REG` — static OAuth client IDs combined with dynamic client registration
- `MCP_OAUTH_NO_PKCE` — authorization-code flows without effective PKCE protection

## Detection scope

The implementation is intentionally conservative.

JavaScript/TypeScript passthrough detection supports direct `.tool(...)`, `registerTool(...)`, and `addTool(...)` callback handlers, including schema/configuration arguments. Callback ownership is tied to the handler’s own function scope, so neighboring sibling functions are not incorrectly treated as MCP handlers.

Python support covers synchronous and asynchronous functions directly decorated with FastMCP `.tool(...)`, including multiline decorators. Generic `@tool` decorators are not treated as MCP handlers.

Ruby and Go passthrough detection is intentionally not claimed because reliable handler binding would require broader symbol or call-graph analysis.

Audience and PKCE source checks require an MCP-owned scope instead of relying only on a file-level MCP marker. Unrelated OAuth flows in MCP-containing files are therefore ignored. `.mcp.json` configuration scanning remains separate and unchanged.

Static client IDs and dynamic registration must belong to the same object or configuration scope. Audience validation and token exchange must be conservatively associated with the same inbound token before suppressing a finding.

Comments and non-semantic string contents are excluded from structural and mitigation matching, while required quoted object/hash keys remain supported across the validated language patterns.

`MCP_TOKEN_FORWARD_ENV` remains a separate finding. It covers credentials passed through MCP or agent configuration, while these rules focus on inbound OAuth token handling and OAuth protocol configuration.

No new dependencies, AST framework, call-graph layer, or symbol-resolution system was added.

## Validation

- Focused OAuth tests: **67/67 passed**
- Related MCP/language tests: **70/71 passed** — 1 known Windows symlink `EPERM`
- Full suite: **572/577 passed** — 5 known baseline failures
- Benchmarks: **12/12 detection scenarios**, **12/12 clean controls**
- ESLint: **0 errors**
- `git diff --check`: **clean**
- No new failures compared with the base branch

The five full-suite failures are the existing stalled-stdout and Windows symlink environment failures also present on the base branch.

Base comparison: [2bc9fe3](https://github.com/asamassekou10/ship-safe/commit/2bc9fe37295e08d601eb87673e000b494de8d90a)

Related: [#104](https://github.com/asamassekou10/ship-safe/issues/104)