### PR TITLE
fix: scope API fuzzer rules to JavaScript

### DIFF
--- a/cli/__tests__/language-scope.test.js
+++ b/cli/__tests__/language-scope.test.js
@@ -108,6 +108,40 @@ describe('SSRFProber scoping', async () => {
   });
 });
 
+describe('APIFuzzer scoping', async () => {
+  const { APIFuzzer } = await import('../agents/api-fuzzer.js');
+
+  const hits = async (code, ext) => {
+    const { dir, file } = tmpFile(code, ext);
+    try {
+      const f = await new APIFuzzer().analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+      return f.map(x => x.rule);
+    } finally { cleanup(dir); }
+  };
+
+  it('still catches Express upload and route shapes in JavaScript', async () => {
+    const findings = await hits(
+      'router.post("/upload", (req, res) => { const body = { ...req.body }; path.join(dir, req.file.originalname); });',
+      '.js'
+    );
+
+    assert.ok(findings.includes('API_NO_AUTH_CHECK'));
+    assert.ok(findings.includes('API_SPREAD_BODY'));
+    assert.ok(findings.includes('API_PATH_IN_FILENAME'));
+  });
+
+  it('does not apply Express upload and route rules to Python', async () => {
+    const findings = await hits(
+      'router.post("/upload", (req, res) => { const body = { ...req.body }; path.join(dir, req.file.originalname); })',
+      '.py'
+    );
+
+    assert.ok(!findings.includes('API_NO_AUTH_CHECK'));
+    assert.ok(!findings.includes('API_SPREAD_BODY'));
+    assert.ok(!findings.includes('API_PATH_IN_FILENAME'));
+  });
+});
+
 describe('LLMRedTeam scoping', async () => {
   const { LLMRedTeam } = await import('../agents/llm-redteam.js');
 

--- a/cli/agents/api-fuzzer.js
+++ b/cli/agents/api-fuzzer.js
@@ -15,6 +15,7 @@ const PATTERNS = [
   // ── Missing Authentication ─────────────────────────────────────────────────
   {
     rule: 'API_NO_AUTH_CHECK',
+    langs: ['js'], // Express route registration and req callback syntax.
     title: 'API: Route Without Auth Check',
     regex: /(?:app|router)\.(?:post|put|patch|delete)\s*\(\s*['"][^'"]+['"]\s*,\s*(?:async\s+)?(?:\(req|function)/g,
     severity: 'high',
@@ -39,6 +40,7 @@ const PATTERNS = [
   },
   {
     rule: 'API_SPREAD_BODY',
+    langs: ['js'], // Object spread is JavaScript/TypeScript syntax.
     title: 'API: Spread Request Body into Operation',
     regex: /\.\.\.\s*(?:req\.body|request\.body|ctx\.request\.body)/g,
     severity: 'high',
@@ -51,6 +53,7 @@ const PATTERNS = [
   // ── Error Handling ─────────────────────────────────────────────────────────
   {
     rule: 'API_STACK_TRACE_RESPONSE',
+    langs: ['js'], // res.json/res.send and Koa's ctx.body are Node web APIs.
     title: 'API: Stack Trace in Response',
     regex: /(?:res\.(?:json|send|status)|ctx\.body)\s*\(\s*(?:\{[^}]*(?:err\.stack|error\.stack|err\.message|error\.message)|err\b|error\b)/g,
     severity: 'medium',
@@ -63,6 +66,7 @@ const PATTERNS = [
   // ── Data Exposure ──────────────────────────────────────────────────────────
   {
     rule: 'API_EXCESSIVE_DATA',
+    langs: ['js'], // res.json/res.send and Koa's ctx.body are Node web APIs.
     title: 'API: Returning Full Database Object',
     regex: /(?:res\.json|res\.send|ctx\.body)\s*\(\s*(?:user|users|record|result|data|row|document)\s*\)/g,
     severity: 'medium',
@@ -76,6 +80,7 @@ const PATTERNS = [
   // ── File Upload ────────────────────────────────────────────────────────────
   {
     rule: 'API_UNRESTRICTED_UPLOAD',
+    langs: ['js'], // multer, formidable, busboy, and multiparty are Node packages.
     title: 'API: Unrestricted File Upload',
     regex: /(?:multer|formidable|busboy|multiparty)\s*\(/g,
     severity: 'medium',
@@ -87,6 +92,7 @@ const PATTERNS = [
   },
   {
     rule: 'API_UPLOAD_NO_TYPE_CHECK',
+    langs: ['js'], // Multer file properties are specific to Node upload middleware.
     title: 'API: File Upload Without Type Validation',
     // Same failure as API_PATH_IN_FILENAME in 9.6.4: an Express upload rule
     // matching Python. `filename)` and `filename;` occur in every language that
@@ -103,6 +109,7 @@ const PATTERNS = [
   },
   {
     rule: 'API_PATH_IN_FILENAME',
+    langs: ['js'], // path.join with multer/Express request properties is Node-specific.
     title: 'API: Path Traversal in File Upload',
     // Two boundaries matter here, and the original pattern had neither.
     //
@@ -136,6 +143,7 @@ const PATTERNS = [
   },
   {
     rule: 'GRAPHQL_NO_DEPTH_LIMIT',
+    langs: ['js'], // Apollo Server, Yoga, and makeExecutableSchema are JS APIs.
     title: 'GraphQL: No Query Depth Limit',
     regex: /(?:ApolloServer|GraphQLServer|createYoga|makeExecutableSchema)\s*\(/g,
     severity: 'medium',
@@ -158,6 +166,7 @@ const PATTERNS = [
   // ── API Versioning & Documentation ─────────────────────────────────────────
   {
     rule: 'API_DEBUG_ENDPOINT',
+    langs: ['js'], // app/router route registration is Express syntax.
     title: 'API: Debug/Test Endpoint in Code',
     regex: /(?:app|router)\.(?:get|post|all)\s*\(\s*['"]\/(?:debug|test|admin|internal|_internal|healthcheck\/debug)/gi,
     severity: 'high',
@@ -170,6 +179,7 @@ const PATTERNS = [
   // ── Response Headers ───────────────────────────────────────────────────────
   {
     rule: 'API_NO_SECURITY_HEADERS',
+    langs: ['js'], // app.use/app.listen are Express APIs.
     title: 'API: Missing Security Headers (Helmet)',
     regex: /app\.(?:use|listen)\s*\(/g,
     severity: 'low',
@@ -193,6 +203,7 @@ const PATTERNS = [
   },
   {
     rule: 'API_SECRET_IN_URL',
+    langs: ['js'], // app/router route registration is Express syntax.
     title: 'API: Sensitive Data in URL Parameters',
     regex: /(?:app|router)\.(?:get|post)\s*\(\s*['"][^'"]*(?::token|:apiKey|:password|:secret|:key)\b/g,
     severity: 'high',
@@ -205,6 +216,7 @@ const PATTERNS = [
   // ── Server Configuration ───────────────────────────────────────────────────
   {
     rule: 'API_TRUST_PROXY',
+    langs: ['js'], // app.set('trust proxy', ...) is Express configuration.
     title: 'API: Trust Proxy Not Configured',
     regex: /app\.set\s*\(\s*['"]trust proxy['"]\s*,\s*true\s*\)/g,
     severity: 'low',
@@ -217,6 +229,7 @@ const PATTERNS = [
   // ── Denial of Service ──────────────────────────────────────────────────────
   {
     rule: 'API_LARGE_BODY_NO_LIMIT',
+    langs: ['js'], // express.json and bodyParser.json are Node middleware.
     title: 'API: No Request Body Size Limit',
     regex: /(?:express\.json|bodyParser\.json)\s*\(\s*\)/g,
     severity: 'medium',


### PR DESCRIPTION
## Summary
- add JavaScript language scopes only to APIFuzzer rules tied to Express, Node middleware, or JavaScript syntax
- leave potentially cross-language rules unscoped
- add APIFuzzer regression tests showing the scoped rules still fire in JavaScript and stay off Python

## Verification
- `node --test cli/__tests__/*.test.js`
- `npx eslint cli/` (0 errors; existing repository warnings remain)
- `node benchmarks/false-positives/run.mjs --clone`

## Benchmark comparison
- NodeGoat: unchanged at 74 findings, including 9 critical
- DVWA: unchanged at 71 findings, including 1 critical
- clean corpus: 858 findings versus the checked-in baseline's 844; Hermes changed from 787 to 801 findings while remaining at 101 critical

The scoped rules are intentionally limited to unambiguous JavaScript/Express shapes. Cross-language patterns are left unchanged to avoid silent detection loss.