### PR TITLE
test: verify GitHub App PR review flow

### DIFF
--- a/docs/pr-review-bot-e2e-test.md
+++ b/docs/pr-review-bot-e2e-test.md
@@ -1,0 +1,3 @@
+# PR review bot smoke test
+
+This documentation-only change verifies that the Ship Safe GitHub App can scan a pull request and publish its deterministic findings with an optional Kimi advisory.

--- a/docs/pr-review-bot-e2e-test.md
+++ b/docs/pr-review-bot-e2e-test.md
@@ -7,3 +7,5 @@ The follow-up commit exercises the same review path after a pull request is upda
 This line is intentionally documentation-only for the production webhook smoke test.
 
 The scanner should report this pull request without requiring a local CLI install.
+
+This line verifies the bundled scanner dependency fix in production.

--- a/docs/pr-review-bot-e2e-test.md
+++ b/docs/pr-review-bot-e2e-test.md
@@ -5,3 +5,5 @@ This documentation-only change verifies that the Ship Safe GitHub App can scan a
 The follow-up commit exercises the same review path after a pull request is updated.
 
 This line is intentionally documentation-only for the production webhook smoke test.
+
+The scanner should report this pull request without requiring a local CLI install.

--- a/docs/pr-review-bot-e2e-test.md
+++ b/docs/pr-review-bot-e2e-test.md
@@ -9,3 +9,5 @@ This line is intentionally documentation-only for the production webhook smoke t
 The scanner should report this pull request without requiring a local CLI install.
 
 This line verifies the bundled scanner dependency fix in production.
+
+Final end-to-end verification after the clean deployment.

--- a/docs/pr-review-bot-e2e-test.md
+++ b/docs/pr-review-bot-e2e-test.md
@@ -3,3 +3,5 @@
 This documentation-only change verifies that the Ship Safe GitHub App can scan a pull request and publish its deterministic findings with an optional Kimi advisory.
 
 The follow-up commit exercises the same review path after a pull request is updated.
+
+This line is intentionally documentation-only for the production webhook smoke test.

--- a/docs/pr-review-bot-e2e-test.md
+++ b/docs/pr-review-bot-e2e-test.md
@@ -15,3 +15,5 @@ Final end-to-end verification after the clean deployment.
 Final production runtime verification after the dependency tracing fix.
 
 Final production verification after aligning the audit command flags.
+
+Final verification for report-aware handling of below-threshold audit exits.

--- a/docs/pr-review-bot-e2e-test.md
+++ b/docs/pr-review-bot-e2e-test.md
@@ -13,3 +13,5 @@ This line verifies the bundled scanner dependency fix in production.
 Final end-to-end verification after the clean deployment.
 
 Final production runtime verification after the dependency tracing fix.
+
+Final production verification after aligning the audit command flags.

--- a/docs/pr-review-bot-e2e-test.md
+++ b/docs/pr-review-bot-e2e-test.md
@@ -11,3 +11,5 @@ The scanner should report this pull request without requiring a local CLI instal
 This line verifies the bundled scanner dependency fix in production.
 
 Final end-to-end verification after the clean deployment.
+
+Final production runtime verification after the dependency tracing fix.

--- a/docs/pr-review-bot-e2e-test.md
+++ b/docs/pr-review-bot-e2e-test.md
@@ -1,3 +1,5 @@
 # PR review bot smoke test
 
 This documentation-only change verifies that the Ship Safe GitHub App can scan a pull request and publish its deterministic findings with an optional Kimi advisory.
+
+The follow-up commit exercises the same review path after a pull request is updated.


### PR DESCRIPTION
## Purpose

This is a documentation-only smoke test for the Ship Safe GitHub App. It should verify that a pull request triggers the deterministic scan and the optional Kimi K3 advisory without changing runtime code.

## Validation

- Documentation-only change
- Do not merge; close after the webhook review is confirmed