### PR TITLE
test: validate PR finding attribution

### DIFF
--- a/docs/pr-review-attribution-control.md
+++ b/docs/pr-review-attribution-control.md
@@ -1,0 +1,5 @@
+# PR review attribution control
+
+This temporary documentation-only change validates that Ship Safe compares a
+pull request against its exact base revision before attributing findings to the
+change. It does not modify executable code, dependencies, or security policy.


### PR DESCRIPTION
Temporary maintainer validation for the hosted PR review bot.

This PR changes documentation only. It should produce no introduced security
findings; any repository-wide findings must be labeled pre-existing.

This PR will be closed without merging after validation.
