### PR TITLE
test: validate introduced security finding

### DIFF
--- a/validation/pr-bot-command-injection.js
+++ b/validation/pr-bot-command-injection.js
@@ -1,0 +1,6 @@
+import { exec } from 'node:child_process';
+
+// Intentionally vulnerable maintainer fixture. This branch will not be merged.
+export function runUntrustedCommand(userInput) {
+  exec(`deploy ${userInput}`);
+}

--- a/validation/pr-bot-command-injection.js
+++ b/validation/pr-bot-command-injection.js
@@ -1,6 +1,6 @@
 import { exec } from 'node:child_process';
 
-// Intentionally vulnerable maintainer fixture. This branch will not be merged.
+// Intentionally vulnerable maintainer fixture for live bot validation. This will not be merged.
 export function runUntrustedCommand(userInput) {
   exec(`deploy ${userInput}`);
 }


### PR DESCRIPTION
Temporary maintainer validation for the hosted PR review bot.

This PR intentionally introduces an interpolated `exec()` command-injection
fixture. Ship Safe should identify it as a new PR finding while keeping existing
repository findings labeled pre-existing.

This PR will be closed without merging after validation.
