### PR TITLE
fix: distinguish SQL queries from shell commands

### DIFF
--- a/cli/__tests__/vibe-coding-agent.test.js
+++ b/cli/__tests__/vibe-coding-agent.test.js
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+
+import { VibeCodingAgent } from '../agents/vibe-coding-agent.js';
+
+const tempDirs = [];
+
+function writeFixture(source) {
+  const rootPath = fs.mkdtempSync(path.join(os.tmpdir(), 'ship-safe-vibe-sql-'));
+  const file = path.join(rootPath, 'fixture.js');
+  fs.writeFileSync(file, source);
+  tempDirs.push(rootPath);
+  return { rootPath, file };
+}
+
+async function scan(source) {
+  const { rootPath, file } = writeFixture(source);
+  return new VibeCodingAgent().analyze({
+    rootPath,
+    files: [file],
+    recon: {},
+    options: {},
+  });
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('VibeCodingAgent SQL interpolation detection', () => {
+  it('does not classify an interpolated shell command as SQL injection', async () => {
+    const findings = await scan('exec(`deploy ${userInput}`);');
+
+    assert.equal(
+      findings.some((finding) => finding.rule === 'VIBE_NO_PARAMETERIZED_QUERY'),
+      false,
+    );
+  });
+
+  it('detects an interpolated SQL template passed to a query method', async () => {
+    const findings = await scan('db.query(`SELECT * FROM users WHERE id = ${userInput}`);');
+
+    assert.equal(
+      findings.some((finding) => finding.rule === 'VIBE_NO_PARAMETERIZED_QUERY'),
+      true,
+    );
+  });
+
+  it('detects concatenated SQL passed to an execute method', async () => {
+    const findings = await scan('db.execute("DELETE FROM users WHERE id = " + userInput);');
+
+    assert.equal(
+      findings.some((finding) => finding.rule === 'VIBE_NO_PARAMETERIZED_QUERY'),
+      true,
+    );
+  });
+});

--- a/cli/__tests__/vibe-coding-agent.test.js
+++ b/cli/__tests__/vibe-coding-agent.test.js
@@ -34,6 +34,7 @@ afterEach(() => {
 
 describe('VibeCodingAgent SQL interpolation detection', () => {
   it('does not classify an interpolated shell command as SQL injection', async () => {
+    // Shell interpolation belongs to command-injection detection, not SQL detection.
     const findings = await scan('exec(`deploy ${userInput}`);');
 
     assert.equal(

--- a/cli/agents/vibe-coding-agent.js
+++ b/cli/agents/vibe-coding-agent.js
@@ -174,7 +174,7 @@ const PATTERNS = [
   {
     rule: 'VIBE_NO_PARAMETERIZED_QUERY',
     title: 'Vibe Code: String Concatenation in SQL',
-    regex: /(?:query|execute|raw|exec)\s*\(\s*(?:`[^`]*\$\{|['"][^'"]*['"]\s*\+\s*(?:req|request|body|params|query|input|user|data))/g,
+    regex: /(?:query|execute|raw)\s*\(\s*(?:`(?=[^`]*\b(?:select|insert|update|delete|replace|merge|alter|drop|create|truncate|with)\b)[^`]*\$\{|['"](?=[^'"]*\b(?:select|insert|update|delete|replace|merge|alter|drop|create|truncate|with)\b)[^'"]*['"]\s*\+\s*(?:req|request|body|params|query|input|user|data))/gi,
     severity: 'critical',
     cwe: 'CWE-89',
     owasp: 'A03:2021',


### PR DESCRIPTION
## Summary

- stop treating generic `exec()` shell calls as SQL query execution
- require an SQL operation inside interpolated strings before reporting `VIBE_NO_PARAMETERIZED_QUERY`
- add regression coverage for the live PR-bot false positive and positive SQL cases

## Why

The live PR bot correctly found command injection in an intentionally vulnerable control, but also classified the same shell template as an unparameterized SQL query. This keeps the command-injection finding while removing the duplicate, incorrect SQL finding.

## Validation

- 533 tests passing
- lint: 0 errors
- corpus benchmark: 12/12 scenarios and 12/12 clean controls
- isolated self-scan: 0 findings
- git diff check passing