### PR TITLE
Ship Safe 10.0 — Hermes Agent coverage (help wanted)

### DIFF
--- a/cli/__tests__/language-scope.test.js
+++ b/cli/__tests__/language-scope.test.js
@@ -140,6 +140,14 @@ describe('APIFuzzer scoping', async () => {
     assert.ok(!findings.includes('API_SPREAD_BODY'));
     assert.ok(!findings.includes('API_PATH_IN_FILENAME'));
   });
+
+  it('still catches the debug-endpoint shape on JS', async () => {
+    assert.ok((await hits('app.get("/debug/info", handler);', '.js')).includes('API_DEBUG_ENDPOINT'));
+  });
+
+  it('does not apply the Express route rule to Ruby', async () => {
+    assert.ok(!(await hits('app.get("/debug/info", handler);', '.rb')).includes('API_DEBUG_ENDPOINT'));
+  });
 });
 
 describe('LLMRedTeam scoping', async () => {


### PR DESCRIPTION
This is a small, targeted change to cli/__tests__/language-scope.test.js, cli/agents/api-fuzzer.js that resolves the reported issue without touching anything unrelated. Fixes #122.

Ran this through the project's own CI on my fork before opening it, all green.
