### PR TITLE
fix: reduce scanner false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [9.7.6] - 2026-08-28
+
+### Fixed
+- Reduced false positives in authentication rate-limit, file-upload type
+  validation, document.write XSS, SSRF, and typosquat detection.
+- Dependency findings now render a stable package name when the scanner
+  receives a vulnerability record with `name` or only `id`.
+
 ## [9.7.5] - 2026-08-19
 
 ### Added

--- a/cli/__tests__/false-positive-calibration.test.js
+++ b/cli/__tests__/false-positive-calibration.test.js
@@ -1,0 +1,174 @@
+/**
+ * Regression tests for scanner rules that previously treated ordinary source
+ * data as executable security-sensitive code.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { AuthBypassAgent } from '../agents/auth-bypass-agent.js';
+import { APIFuzzer } from '../agents/api-fuzzer.js';
+import { InjectionTester } from '../agents/injection-tester.js';
+import { SSRFProber } from '../agents/ssrf-prober.js';
+import { SupplyChainAudit } from '../agents/supply-chain-agent.js';
+import { dependencyName } from '../commands/deps.js';
+
+function fixture(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-fp-'));
+  const paths = Object.entries(files).map(([name, content]) => {
+    const file = path.join(dir, name);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, content);
+    return file;
+  });
+  return { dir, paths };
+}
+
+function context(dir, paths) {
+  return { rootPath: dir, files: paths, recon: {}, options: {} };
+}
+
+function cleanup(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+}
+
+describe('false-positive calibration', () => {
+  it('does not treat auth links as missing-rate-limit endpoints', async () => {
+    const { dir, paths } = fixture({
+      'Nav.tsx': '<Link href="/login">Log in</Link>\n<Link href="/signup">Get started</Link>',
+    });
+    try {
+      const findings = await new AuthBypassAgent().analyze(context(dir, paths));
+      assert.equal(findings.filter(f => f.rule === 'NO_RATE_LIMIT_LOGIN').length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('still detects a mutation route for an auth endpoint', async () => {
+    const { dir, paths } = fixture({
+      'auth.js': 'app.post("/api/auth/login", authMiddleware, loginHandler);',
+    });
+    try {
+      const findings = await new AuthBypassAgent().analyze(context(dir, paths));
+      assert.ok(findings.some(f => f.rule === 'NO_RATE_LIMIT_LOGIN'));
+    } finally { cleanup(dir); }
+  });
+
+  it('does not treat ordinary API filename fields as upload metadata', async () => {
+    const { dir, paths } = fixture({
+      'github.ts': 'const file = item as Record<string, unknown>;\nreturn { filename: file.filename };',
+    });
+    try {
+      const findings = await new APIFuzzer().analyze(context(dir, paths));
+      assert.equal(findings.filter(f => f.rule === 'API_UPLOAD_NO_TYPE_CHECK').length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('still detects an upload filename used without type validation', async () => {
+    const { dir, paths } = fixture({
+      'upload.js': 'import multer from "multer";\nconst upload = multer();\napp.post("/upload", upload.single("file"), (req, res) => res.send(req.file.originalname));',
+    });
+    try {
+      const findings = await new APIFuzzer().analyze(context(dir, paths));
+      assert.ok(findings.some(f => f.rule === 'API_UPLOAD_NO_TYPE_CHECK'));
+    } finally { cleanup(dir); }
+  });
+
+  it('does not treat document.write inside a browser expression string as outer-file XSS', async () => {
+    const { dir, paths } = fixture({
+      'cdp.mjs': 'await evaluate("document.open(); document.write(\'<body>\'); document.close(); true");',
+    });
+    try {
+      const findings = await new InjectionTester().analyze(context(dir, paths));
+      assert.equal(findings.filter(f => f.rule === 'XSS_DOCUMENT_WRITE').length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('still detects a direct document.write call', async () => {
+    const { dir, paths } = fixture({
+      'page.js': 'document.write(userInput);',
+    });
+    try {
+      const findings = await new InjectionTester().analyze(context(dir, paths));
+      assert.ok(findings.some(f => f.rule === 'XSS_DOCUMENT_WRITE'));
+    } finally { cleanup(dir); }
+  });
+
+  it('does not treat a metadata blocklist as metadata access', async () => {
+    const { dir, paths } = fixture({
+      'request-security.ts': "if (hostname === 'metadata.google.internal') return false;\nif (hostname === '169.254.169.254') return false;",
+    });
+    try {
+      const findings = await new SSRFProber().analyze(context(dir, paths));
+      assert.equal(findings.filter(f => f.rule === 'SSRF_CLOUD_METADATA').length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('still detects a request to a cloud metadata endpoint', async () => {
+    const { dir, paths } = fixture({
+      'metadata.js': 'const response = await fetch("http://169.254.169.254/latest/meta-data/");',
+    });
+    try {
+      const findings = await new SSRFProber().analyze(context(dir, paths));
+      assert.ok(findings.some(f => f.rule === 'SSRF_CLOUD_METADATA'));
+    } finally { cleanup(dir); }
+  });
+
+  it('does not treat fixed URLs, same-origin client calls, or robots metadata as SSRF', async () => {
+    const { dir, paths } = fixture({
+      'pages.tsx': 'const url = process.env.CMS_URL;\nawait fetch(url);\nawait client.fetch(`/repos/${owner}/${repo}/issues/${id}`);\nawait fetch(`/api/findings?${params}`);\nconst metadata = { robots: { follow: true } };\nredirect("/security");',
+    });
+    try {
+      const findings = await new SSRFProber().analyze(context(dir, paths));
+      assert.equal(findings.filter(f => f.rule.startsWith('SSRF_')).length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('still detects request-derived URLs and redirect options', async () => {
+    const { dir, paths } = fixture({
+      'route.js': 'await fetch(req.query.url);\nawait fetch(`https://${req.query.host}/avatar`);\nawait fetch(target, { redirect: "follow" });',
+    });
+    try {
+      const findings = await new SSRFProber().analyze(context(dir, paths));
+      assert.ok(findings.some(f => f.rule === 'SSRF_USER_URL_FETCH'));
+      assert.ok(findings.some(f => f.rule === 'SSRF_URL_TEMPLATE'));
+      assert.ok(findings.some(f => f.rule === 'SSRF_REDIRECT_FOLLOW'));
+    } finally { cleanup(dir); }
+  });
+
+  it('does not treat a fixed Chrome DevTools loopback endpoint as SSRF', async () => {
+    const { dir, paths } = fixture({
+      'cdp.mjs': 'await fetch(`http://127.0.0.1:${port}/json/list`);',
+    });
+    try {
+      const findings = await new SSRFProber().analyze(context(dir, paths));
+      assert.equal(findings.filter(f => f.rule === 'SSRF_INTERNAL_IP').length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('allows exact popular packages while retaining typo detection', async () => {
+    const safe = fixture({
+      'package.json': JSON.stringify({ dependencies: { next: '^15.3.1' } }),
+    });
+    const suspect = fixture({
+      'package.json': JSON.stringify({ dependencies: { nexxt: '^15.3.1' } }),
+    });
+    try {
+      const safeFindings = await new SupplyChainAudit().analyze(context(safe.dir, safe.paths));
+      const suspectFindings = await new SupplyChainAudit().analyze(context(suspect.dir, suspect.paths));
+      assert.equal(safeFindings.filter(f => f.rule === 'TYPOSQUAT_SUSPECT').length, 0);
+      assert.ok(suspectFindings.some(f => f.rule === 'TYPOSQUAT_SUSPECT'));
+    } finally {
+      cleanup(safe.dir);
+      cleanup(suspect.dir);
+    }
+  });
+
+  it('uses normalized dependency names in every report format', () => {
+    assert.equal(dependencyName({ name: 'next' }), 'next');
+    assert.equal(dependencyName({ id: 'CVE-2026-0001' }), 'CVE-2026-0001');
+    assert.equal(dependencyName({}), 'unknown');
+  });
+});

--- a/cli/agents/api-fuzzer.js
+++ b/cli/agents/api-fuzzer.js
@@ -94,12 +94,12 @@ const PATTERNS = [
     rule: 'API_UPLOAD_NO_TYPE_CHECK',
     langs: ['js'], // Multer file properties are specific to Node upload middleware.
     title: 'API: File Upload Without Type Validation',
-    // Same failure as API_PATH_IN_FILENAME in 9.6.4: an Express upload rule
-    // matching Python. `filename)` and `filename;` occur in every language that
-    // has a variable called filename — `os.path.basename(filename)` alone
-    // accounted for much of the 104 hits on hermes-agent. Require the multer
-    // property access that marks the value as upload-controlled.
-    regex: /\b(?:file|files\[\d*\]|req\.file|req\.files\[\d*\])\s*\.\s*(?:originalname|filename)\s*(?:\)|;|,|\})/g,
+    // A property named `filename` is common in API payloads (GitHub's file
+    // objects are one example). Only inspect the file values exposed by an
+    // upload handler; the surrounding upload-context check below rejects
+    // ordinary data models and API response objects.
+    regex: /\b(?:file|files\s*\[[^\]\n]+\]|req\s*\.\s*files?\s*(?:\[[^\]\n]+\])?)\s*\.\s*(?:originalname|filename)\b/g,
+    skipComments: true,
     severity: 'high',
     cwe: 'CWE-434',
     owasp: 'A04:2021',
@@ -297,7 +297,11 @@ export class APIFuzzer extends BaseAgent {
 
     let findings = [];
     for (const file of codeFiles) {
-      findings = findings.concat(this.scanFileWithPatterns(file, PATTERNS));
+      const content = this.readFile(file);
+      const patterns = content && /\b(?:multer|formidable|busboy|multiparty)\b|\breq\s*\.\s*files?\b|\b(?:upload|uploader)\s*\.\s*(?:single|array|fields)\s*\(/i.test(content)
+        ? PATTERNS
+        : PATTERNS.filter(pattern => pattern.rule !== 'API_UPLOAD_NO_TYPE_CHECK');
+      findings = findings.concat(this.scanFileWithPatterns(file, patterns, content));
     }
 
     // ── Project-level: Rate limiting check ────────────────────────────────────

--- a/cli/agents/auth-bypass-agent.js
+++ b/cli/agents/auth-bypass-agent.js
@@ -8,7 +8,7 @@
  */
 
 import path from 'path';
-import { BaseAgent, createFinding } from './base-agent.js';
+import { BaseAgent, createFinding, isInsideJavaScriptNonCode } from './base-agent.js';
 
 const PATTERNS = [
   // ── JWT Issues ─────────────────────────────────────────────────────────────
@@ -237,7 +237,13 @@ const PATTERNS = [
   {
     rule: 'NO_RATE_LIMIT_LOGIN',
     title: 'No Rate Limiting on Authentication',
-    regex: /(?<!\w)(?:\/login|\/signin|\/auth|\/register|\/signup|\/reset-password)\s*['"]/g,
+    // A link to /login is navigation, not an authentication endpoint. Require
+    // a mutation route registration so presentational JSX cannot become a
+    // medium-severity auth finding merely by containing an auth URL.
+    regex: /\b(?:app|router|server|fastify)\s*\.\s*(?:post|put|patch|delete|all)\s*\(\s*['"]\/(?:[^'"`/\n]+\/)*(?:login|signin|auth|register|signup|reset-password)(?:\/[^'"`\n]*)?['"]\s*,/gi,
+    langs: ['js'],
+    skipComments: true,
+    isCodeMatch: ({ source, sourceOffset }) => !isInsideJavaScriptNonCode(source, sourceOffset),
     severity: 'medium',
     cwe: 'CWE-307',
     owasp: 'A07:2021',

--- a/cli/agents/base-agent.js
+++ b/cli/agents/base-agent.js
@@ -117,6 +117,62 @@ export function languageOf(filePath) {
   return EXT_LANGUAGE[path.extname(String(filePath || '')).toLowerCase()] || null;
 }
 
+/**
+ * Whether an offset in JavaScript source is inside a string or comment.
+ *
+ * Regex rules often describe a runtime sink, but source code also contains
+ * snippets passed to another runtime (for example, a CDP expression). Treat
+ * those snippets as data for the outer file unless a rule explicitly opts in.
+ * This is intentionally a small lexer rather than a parser: it preserves the
+ * precision boundary needed by lexical rules without pretending to understand
+ * the whole JavaScript grammar.
+ */
+export function isInsideJavaScriptNonCode(source, offset) {
+  let quote = null;
+  let escaped = false;
+  let lineComment = false;
+  let blockComment = false;
+
+  for (let i = 0; i < offset; i += 1) {
+    const char = source[i];
+    const next = source[i + 1];
+
+    if (lineComment) {
+      if (char === '\n') lineComment = false;
+      continue;
+    }
+    if (blockComment) {
+      if (char === '*' && next === '/') {
+        blockComment = false;
+        i += 1;
+      }
+      continue;
+    }
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === '/' && next === '/') {
+      lineComment = true;
+      i += 1;
+    } else if (char === '/' && next === '*') {
+      blockComment = true;
+      i += 1;
+    } else if (char === "'" || char === '"' || char === '`') {
+      quote = char;
+    }
+  }
+
+  return Boolean(quote || lineComment || blockComment);
+}
+
 // =============================================================================
 // SUPPRESSION FLOOR
 // =============================================================================
@@ -336,6 +392,7 @@ export class BaseAgent {
     const lines = source.split('\n');
     const findings = [];
 
+    let lineStart = 0;
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
       // Suppression is decided per pattern, not per line: the floor depends on
@@ -369,9 +426,20 @@ export class BaseAgent {
           if (!p.regex.global) break;
         }
         if (matches.length === 0) continue;
+
+        const relevantMatches = typeof p.isCodeMatch === 'function'
+          ? matches.filter(match => p.isCodeMatch({
+            source,
+            line,
+            lineIndex: i,
+            sourceOffset: lineStart + match.index,
+            match,
+          }))
+          : matches;
+        if (relevantMatches.length === 0) continue;
         if (lineMarked && this.isSuppressed(line, severity)) continue;
 
-        for (const match of matches) {
+        for (const match of relevantMatches) {
           const finding = createFinding({
             file: filePath,
             line: i + 1,
@@ -402,6 +470,8 @@ export class BaseAgent {
           findings.push(finding);
         }
       }
+
+      lineStart += line.length + 1;
     }
 
     return findings;

--- a/cli/agents/html-reporter.js
+++ b/cli/agents/html-reporter.js
@@ -17,6 +17,7 @@
 import fs from 'fs';
 import path from 'path';
 import { getComplianceSummary } from '../utils/compliance-map.js';
+import { dependencyName } from '../commands/deps.js';
 
 export class HTMLReporter {
   /**
@@ -248,7 +249,7 @@ small{color:#64748b}
       const sev = d.severity === 'moderate' ? 'medium' : d.severity;
       return `<tr>
         <td><span class="sev sev-${sev}">${(d.severity || 'unknown').toUpperCase()}</span></td>
-        <td><code>${this.esc(d.package || d.id || 'unknown')}</code></td>
+        <td><code>${this.esc(dependencyName(d))}</code></td>
         <td>${this.esc((d.description || '').slice(0, 150))}</td>
       </tr>`;
     }).join('\n');

--- a/cli/agents/injection-tester.js
+++ b/cli/agents/injection-tester.js
@@ -12,7 +12,7 @@
  */
 
 import path from 'path';
-import { BaseAgent, createFinding } from './base-agent.js';
+import { BaseAgent, createFinding, isInsideJavaScriptNonCode } from './base-agent.js';
 
 // =============================================================================
 // INJECTION PATTERNS
@@ -193,6 +193,8 @@ const PATTERNS = [
     rule: 'XSS_DOCUMENT_WRITE',
     title: 'XSS via document.write()',
     regex: /\bdocument\.write(?:ln)?\s*\(/g,
+    skipComments: true,
+    isCodeMatch: ({ source, sourceOffset }) => !isInsideJavaScriptNonCode(source, sourceOffset),
     severity: 'medium',
     cwe: 'CWE-79',
     owasp: 'A03:2021',

--- a/cli/agents/sbom-generator.js
+++ b/cli/agents/sbom-generator.js
@@ -160,7 +160,7 @@ export class SBOMGenerator {
   attachVulnerabilities(bom, depVulns = []) {
     bom.vulnerabilities = depVulns.map((v, i) => ({
       'bom-ref': `vuln-${i}`,
-      id: v.id || v.package || `VULN-${i}`,
+      id: v.id || v.package || v.name || `VULN-${i}`,
       source: { name: 'ship-safe' },
       ratings: [{
         severity: v.severity || 'unknown',
@@ -168,7 +168,7 @@ export class SBOMGenerator {
       }],
       description: v.description || '',
       affects: [{
-        ref: v.package || 'unknown',
+        ref: v.package || v.name || v.id || 'unknown',
       }],
     }));
     return bom;

--- a/cli/agents/ssrf-prober.js
+++ b/cli/agents/ssrf-prober.js
@@ -10,14 +10,14 @@
  */
 
 import path from 'path';
-import { BaseAgent } from './base-agent.js';
+import { BaseAgent, isInsideJavaScriptNonCode } from './base-agent.js';
 
 const PATTERNS = [
   {
     rule: 'SSRF_USER_URL_FETCH',
     langs: ['js'],   // fetch() is a JS/TS API; the req./ctx. shapes are Express and Koa.
     title: 'SSRF: User Input in fetch()',
-    regex: /fetch\s*\(\s*(?:req\.|request\.|ctx\.|query|params|body|input|url|data)/g,
+    regex: /(?<![\w.])fetch\s*\(\s*(?:req\s*\.|request\s*\.|ctx\s*\.|(?:input|userInput|userUrl|untrustedUrl|suppliedUrl|targetUrl|destinationUrl)\b)/gi,
     severity: 'critical',
     cwe: 'CWE-918',
     owasp: 'A10:2021',
@@ -28,7 +28,7 @@ const PATTERNS = [
     rule: 'SSRF_USER_URL_AXIOS',
     langs: ['js'],   // axios, got, superagent, node-fetch and undici are all npm clients.
     title: 'SSRF: User Input in axios/got/http',
-    regex: /(?:axios|got|http|https|request|superagent|node-fetch|undici)(?:\.get|\.post|\.put|\.delete|\.request|\s*\()\s*\(\s*(?:req\.|request\.|ctx\.|query|params|body|input|url|data)/g,
+    regex: /(?<![\w.])(?:axios|got|http|https|request|superagent|node-fetch|undici)(?:\.(?:get|post|put|delete|request))?\s*\(\s*(?:req\s*\.|request\s*\.|ctx\s*\.|(?:input|userInput|userUrl|untrustedUrl|suppliedUrl|targetUrl|destinationUrl)\b)/gi,
     severity: 'critical',
     cwe: 'CWE-918',
     owasp: 'A10:2021',
@@ -39,7 +39,7 @@ const PATTERNS = [
     rule: 'SSRF_URL_TEMPLATE',
     langs: ['js'],   // backtick template literals only exist in JS/TS.
     title: 'SSRF: Template Literal in URL',
-    regex: /(?:fetch|axios|got|http\.get|https\.get)\s*\(\s*`[^`]*\$\{(?:req\.|request\.|ctx\.|query|params|body|input)/g,
+    regex: /(?<![\w.])(?:fetch|axios|got|http\.get|https\.get)\s*\(\s*`[^`]*\$\{(?:req\s*\.|request\s*\.|ctx\s*\.|(?:input|userInput|userUrl|untrustedUrl|suppliedUrl|targetUrl|destinationUrl)\b)/gi,
     severity: 'critical',
     cwe: 'CWE-918',
     owasp: 'A10:2021',
@@ -49,7 +49,7 @@ const PATTERNS = [
   {
     rule: 'SSRF_WEBHOOK_URL',
     title: 'SSRF: Unvalidated Webhook URL',
-    regex: /webhook[_-]?url\s*[:=]\s*(?:req\.|request\.|ctx\.|body|query|params|input)/gi,
+    regex: /webhook[_-]?url\s*[:=]\s*(?:req\s*\.|request\s*\.|ctx\s*\.)/gi,
     severity: 'high',
     cwe: 'CWE-918',
     owasp: 'A10:2021',
@@ -59,10 +59,13 @@ const PATTERNS = [
   {
     rule: 'SSRF_CLOUD_METADATA',
     title: 'SSRF: Cloud Metadata Endpoint Access',
-    regex: /169\.254\.169\.254|metadata\.google\.internal|100\.100\.100\.200/g,
-    // Every hit on hermes-agent was a comment explaining why the code takes
-    // care *not* to probe IMDS. Prose about an endpoint is not access to it.
+    // A blocklist must contain the metadata address, but that is defensive
+    // code, not an outbound request. Require the literal inside a network
+    // client call so `if (hostname === 'metadata.google.internal') return
+    // false` is not reported as credential theft.
+    regex: /\b(?:fetch|axios|got|request|superagent|node-fetch|undici|requests|httpx|http|https)(?:\.\w+)?\s*\([^)\n]*(?:169\.254\.169\.254|metadata\.google\.internal|100\.100\.100\.200)[^)\n]*\)/gi,
     skipComments: true,
+    isCodeMatch: ({ source, sourceOffset }) => !isInsideJavaScriptNonCode(source, sourceOffset),
     severity: 'critical',
     cwe: 'CWE-918',
     owasp: 'A10:2021',
@@ -83,6 +86,10 @@ const PATTERNS = [
     // native app, not an SSRF sink, so exclude the callback shape outright.
     regex: /(?<!(?:redirect_?uri|callback_?url|redirect_?url)\s*[:=]\s*f?["'`])(?:fetch|axios|got|request|urlopen|requests\.\w+|httpx?\.\w+|curl|https?:\/\/|url\s*[:=]|endpoint\s*[:=]|baseURL\s*[:=]|proxy\s*[:=])[^\n]{0,80}(?:127\.0\.0\.|0\.0\.0\.0|10\.\d+\.\d+\.\d+|172\.(?:1[6-9]|2\d|3[01])\.\d+\.\d+|192\.168\.)\d+/gi,
     skipComments: true,
+    // The local Chrome DevTools endpoint is a fixed loopback harness, not an
+    // attacker-selected internal destination. Keep other loopback requests
+    // visible, including the direct-request calibration case.
+    isCodeMatch: ({ line }) => !/127\.0\.0\.1(?::\$\{[^}]+\}|:\d+)?\/json\/list\b/.test(line),
     severity: 'medium',
     cwe: 'CWE-918',
     owasp: 'A10:2021',
@@ -94,7 +101,12 @@ const PATTERNS = [
     rule: 'SSRF_REDIRECT_FOLLOW',
     langs: ['js'],   // maxRedirects is an axios option, and `key: true` is JS object syntax. Still runs on .json and .yml, which carry no language.
     title: 'SSRF: HTTP Client Follows Redirects',
-    regex: /(?:follow|maxRedirects|redirect)\s*:\s*(?:true|\d{2,})/g,
+    // `follow: true` is also a common SEO robots option. Tie the option to an
+    // actual HTTP client call so page metadata and Next.js redirects do not
+    // become SSRF findings.
+    regex: /(?<![\w.])(?:fetch|axios|got|request|superagent|node-fetch|undici|http|https)(?:\.\w+)?\s*\([^)\n]*(?:follow|maxRedirects|redirect)\s*:\s*(?:true|['"]follow['"]|\d{2,})[^)\n]*\)/gi,
+    skipComments: true,
+    isCodeMatch: ({ source, sourceOffset }) => !isInsideJavaScriptNonCode(source, sourceOffset),
     severity: 'medium',
     cwe: 'CWE-918',
     owasp: 'A10:2021',
@@ -106,7 +118,7 @@ const PATTERNS = [
     rule: 'SSRF_PYTHON_REQUESTS',
     langs: ['python'],   // requests + flask.request is Python.
     title: 'SSRF: Python requests with User Input',
-    regex: /requests\.(?:get|post|put|delete|head|patch)\s*\(\s*(?:request\.|flask\.|data|args|form)/g,
+    regex: /requests\.(?:get|post|put|delete|head|patch)\s*\(\s*(?:request\s*\.|flask\s*\.)/g,
     severity: 'critical',
     cwe: 'CWE-918',
     owasp: 'A10:2021',

--- a/cli/agents/supply-chain-agent.js
+++ b/cli/agents/supply-chain-agent.js
@@ -53,9 +53,11 @@ const POPULAR_PACKAGES = [
   'next', 'nuxt', 'svelte', 'vue', 'angular',
 ];
 
-// Well-known packages that happen to be close to other popular names
-// (not typosquats — verified legitimate packages)
+// Exact names in the popular list are legitimate package names, not
+// typosquats of a neighbouring framework. Without this allowlist, `next` is
+// reported as a typo of `nuxt` in an otherwise normal Next.js application.
 const KNOWN_SAFE = new Set([
+  ...POPULAR_PACKAGES,
   'ora', 'got', 'ink', 'yup', 'joi', 'ava', 'tap', 'npm', 'nwb',
   'pug', 'koa', 'hap', 'ejs', 'csv', 'ws', 'pg', 'ms',
 ]);

--- a/cli/commands/audit.js
+++ b/cli/commands/audit.js
@@ -25,7 +25,7 @@ import { PolicyEngine } from '../agents/policy-engine.js';
 import { HTMLReporter } from '../agents/html-reporter.js';
 import { SBOMGenerator } from '../agents/sbom-generator.js';
 import { autoDetectProvider } from '../providers/llm-provider.js';
-import { runDepsAudit } from './deps.js';
+import { dependencyName, runDepsAudit } from './deps.js';
 import {
   SECRET_PATTERNS,
   SECURITY_PATTERNS,
@@ -715,7 +715,7 @@ function buildRemediationPlan(findings, depVulns, rootPath) {
         severity: sev,
         category: 'deps',
         categoryLabel: 'DEPENDENCIES',
-        title: `Vulnerable: ${d.package || d.id}`,
+        title: `Vulnerable: ${dependencyName(d)}`,
         file: 'package.json',
         action: d.description ? `${d.description.slice(0, 80)}` : 'Update to patched version',
         effort: 'medium',
@@ -859,7 +859,7 @@ function outputJSON(scoreResult, findings, depVulns, recon, agentResults, remedi
       cwe: f.cwe, owasp: f.owasp,
     })),
     depVulns: depVulns.map(d => ({
-      severity: d.severity, package: d.package || d.id, description: d.description,
+      severity: d.severity, package: dependencyName(d), description: d.description,
     })),
     remediationPlan,
     recon,
@@ -1089,8 +1089,8 @@ function outputCSV(findings, depVulns, scoreResult, rootPath) {
   }
   for (const d of depVulns) {
     console.log([
-      escape(d.severity), 'deps', escape(d.id || d.package),
-      'package.json', '', escape(`Vulnerable: ${d.package || d.id}`),
+      escape(d.severity), 'deps', escape(d.id || dependencyName(d)),
+      'package.json', '', escape(`Vulnerable: ${dependencyName(d)}`),
       escape(d.description), escape('Update to patched version'),
     ].join(','));
   }
@@ -1143,7 +1143,7 @@ function outputMarkdown(scoreResult, findings, depVulns, remediationPlan, rootPa
     lines.push('| Severity | Package | Description |');
     lines.push('|----------|---------|-------------|');
     for (const d of depVulns) {
-      lines.push(`| ${d.severity} | ${d.package || d.id} | ${(d.description || '').slice(0, 80)} |`);
+      lines.push(`| ${d.severity} | ${dependencyName(d)} | ${(d.description || '').slice(0, 80)} |`);
     }
     lines.push('');
   }

--- a/cli/commands/deps.js
+++ b/cli/commands/deps.js
@@ -278,7 +278,7 @@ function parseNpmAudit(jsonStr) {
   // Deduplicate by package name (transitive deps appear multiple times)
   const seen = new Set();
   return vulns.filter(v => {
-    const key = `${v.name}:${v.severity}`;
+    const key = `${dependencyName(v)}:${v.severity}`;
     if (seen.has(key)) return false;
     seen.add(key);
     return true;
@@ -429,6 +429,11 @@ async function fetchEPSS(cves) {
 // OUTPUT
 // =============================================================================
 
+/** Return the package identifier used by all audit report formats. */
+export function dependencyName(vulnerability) {
+  return vulnerability?.package || vulnerability?.name || vulnerability?.id || 'unknown';
+}
+
 const SEVERITY_ORDER = { critical: 0, high: 1, moderate: 2, medium: 2, low: 3, unknown: 4 };
 const SEVERITY_COLOR = {
   critical: chalk.red.bold,
@@ -460,7 +465,7 @@ function printDepFindings(vulns, pm) {
 
     console.log(
       `  ${sevColor(sevLabel.padEnd(12))}` +
-      chalk.white(`${v.name}`) +
+      chalk.white(dependencyName(v)) +
       chalk.gray(`@${v.range}`)
     );
     console.log(chalk.gray(`              ${v.title}`));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ship-safe",
-  "version": "9.7.5",
+  "version": "9.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ship-safe",
-      "version": "9.7.5",
+      "version": "9.7.6",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-safe",
-  "version": "9.7.5",
+  "version": "9.7.6",
   "description": "AI-powered multi-agent security platform. 29 agents scan 80+ attack classes including AI integration supply chain (Vercel-class attacks), Hermes Agent deployment scanning (ASI-01–ASI-10), tool registry poisoning, function-call injection, skill permission drift, and agent attestation.",
   "main": "cli/index.js",
   "bin": {


### PR DESCRIPTION
## Summary

- Scope authentication rate-limit, upload validation, `document.write` XSS,
  SSRF, and typosquat rules to actual code contexts.
- Normalize dependency names in reports.
- Add regression coverage for each calibrated false positive and its real
  counterpart.

## Verification

- 602 tests pass.
- `npm audit --audit-level=high` reports 0 vulnerabilities.
- `npm pack --dry-run` is clean.

No Kimi suppression or `.ship-safeignore` widening is included.
