### PR TITLE
feat(cicd): detect unpinned AI actions

### DIFF
--- a/cli/__tests__/ai-action-pinning.test.js
+++ b/cli/__tests__/ai-action-pinning.test.js
@@ -1,0 +1,123 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, test } from 'node:test';
+
+import { CICDScanner } from '../agents/cicd-scanner.js';
+
+const FIXTURES = new URL('./fixtures/ai-actions/', import.meta.url);
+
+function fixture(name) {
+  return fs.readFileSync(new URL(name, FIXTURES), 'utf8');
+}
+
+async function scanWorkflow(content) {
+  const rootPath = fs.mkdtempSync(path.join(os.tmpdir(), 'ship-safe-ai-action-'));
+  try {
+    const workflowDir = path.join(rootPath, '.github', 'workflows');
+    fs.mkdirSync(workflowDir, { recursive: true });
+    const file = path.join(workflowDir, 'ai-review.yml');
+    fs.writeFileSync(file, content, 'utf8');
+
+    const scanner = new CICDScanner();
+    return await scanner.analyze({ rootPath, files: [file] });
+  } finally {
+    fs.rmSync(rootPath, { recursive: true, force: true });
+  }
+}
+
+function aiActionFindings(findings) {
+  return findings.filter(finding => finding.rule === 'CICD_AI_ACTION_UNPINNED');
+}
+
+describe('CICDScanner: AI action pinning', () => {
+  test('flags an unpinned AI action with broad permissions as critical', async () => {
+    const findings = await scanWorkflow(fixture('unsafe-unpinned.yml'));
+
+    const [finding] = aiActionFindings(findings);
+    assert.ok(finding, 'expected the AI-specific pinning rule to fire');
+    assert.strictEqual(finding.severity, 'critical');
+    assert.strictEqual(finding.line, 9);
+    assert.strictEqual(finding.matched, 'vendor/ai-review@main');
+  });
+
+  test('uses the step name to recognize an AI action on pull_request_target', async () => {
+    const findings = await scanWorkflow(`
+on: pull_request_target
+permissions:
+  contents: read
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: AI review
+        uses: vendor/general-action@master
+`);
+
+    const [finding] = aiActionFindings(findings);
+    assert.ok(finding, 'expected an AI-named step to be recognized');
+    assert.strictEqual(finding.severity, 'critical');
+  });
+
+  test('flags an unpinned AI action even with read-only permissions', async () => {
+    const findings = await scanWorkflow(`
+on: [push]
+permissions:
+  contents: read
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: vendor/agent-review@v1
+`);
+
+    const [finding] = aiActionFindings(findings);
+    assert.ok(finding, 'an unpinned AI action is still a supply-chain risk');
+    assert.strictEqual(finding.severity, 'high');
+  });
+
+  test('stays quiet for a pinned AI action with read-only permissions', async () => {
+    const findings = await scanWorkflow(fixture('safe-pinned.yml'));
+
+    assert.strictEqual(aiActionFindings(findings).length, 0);
+  });
+
+  test('does not inherit broad permissions from a different job', async () => {
+    const findings = await scanWorkflow(`
+on: [push]
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm publish
+  review:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: vendor/ai-review@main
+`);
+
+    const [finding] = aiActionFindings(findings);
+    assert.ok(finding);
+    assert.strictEqual(finding.severity, 'high');
+  });
+
+  test('does not classify a non-AI action or a comment as an AI step', async () => {
+    const findings = await scanWorkflow(`
+on: [push]
+permissions: write-all
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # AI review uses: vendor/ai-review@main
+      - uses: actions/checkout@v4
+`);
+
+    assert.strictEqual(aiActionFindings(findings).length, 0);
+  });
+});

--- a/cli/__tests__/fixtures/ai-actions/safe-pinned.yml
+++ b/cli/__tests__/fixtures/ai-actions/safe-pinned.yml
@@ -1,0 +1,8 @@
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: vendor/ai-review@0123456789abcdef0123456789abcdef01234567

--- a/cli/__tests__/fixtures/ai-actions/unsafe-unpinned.yml
+++ b/cli/__tests__/fixtures/ai-actions/unsafe-unpinned.yml
@@ -1,0 +1,9 @@
+on: [pull_request]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: vendor/ai-review@main

--- a/cli/agents/cicd-scanner.js
+++ b/cli/agents/cicd-scanner.js
@@ -455,6 +455,39 @@ const NPM_TOKEN_ENV_RE = /\bNPM_TOKEN\b/;
 const PROVENANCE_DISABLED_RE = /--provenance(?:=|\s+)false\b|provenance\s*:\s*false\b/i;
 const PROVENANCE_INTENDED_RE = /--provenance\b|trusted\s+publish(?:ing)?\b/i;
 const ID_TOKEN_WRITE_RE = /id-token\s*:\s*write\b/i;
+const AI_ACTION_SIGNAL_RE =
+  /(?:^|[/_.\s-])(?:ai|agent|llm|openai|anthropic|claude|gemini|copilot|codex|kimi|mistral|bedrock|autofix|review)(?:$|[/_.@\s-])/i;
+const ACTION_USES_RE = /^\s*(?:-\s*)?uses\s*:\s*["']?([^\s"'#]+)["']?/;
+const FULL_COMMIT_SHA_RE = /^[a-f0-9]{40}$/i;
+const BROAD_AI_ACTION_PERMISSION_RE =
+  /permissions\s*:\s*write-all\b|(?:contents|pull-requests|actions)\s*:\s*write\b/i;
+
+function workflowAndJobScopes(lines, lineIndex) {
+  const jobsIndex = lines.findIndex(line => /^\s*jobs\s*:\s*(?:#.*)?$/.test(line));
+  const workflow = jobsIndex >= 0 ? lines.slice(0, jobsIndex).join('\n') : lines.join('\n');
+  if (jobsIndex < 0 || lineIndex <= jobsIndex) return { workflow, job: '' };
+
+  const jobsIndent = lines[jobsIndex].match(/^\s*/)[0].length;
+  let jobStart = jobsIndex + 1;
+  let jobEnd = lines.length;
+
+  for (let index = jobsIndex + 1; index < lines.length; index += 1) {
+    const uncommented = lines[index].replace(/(^|\s)#.*$/, '');
+    if (!uncommented.trim()) continue;
+    const indent = uncommented.match(/^\s*/)[0].length;
+    if (indent <= jobsIndent) break;
+    if (indent === jobsIndent + 2 && /^\s*[\w.-]+\s*:/.test(uncommented)) {
+      if (index <= lineIndex) jobStart = index;
+      else {
+        jobEnd = index;
+        break;
+      }
+    }
+  }
+
+  return { workflow, job: lines.slice(jobStart, jobEnd).join('\n') };
+}
+
 function firstMatchLine(rawContent, patterns) {
   for (const re of patterns) {
     re.lastIndex = 0;
@@ -728,6 +761,81 @@ export class CICDScanner extends BaseAgent {
 
     return findings;
   }
+
+  /**
+   * AI review and autofix actions routinely receive repository and PR context.
+   * A mutable action ref lets an upstream change turn that access into code
+   * execution without any change to the consuming repository.
+   */
+  scanUnpinnedAiActions(file) {
+    const rawContent = this.readFile(file);
+    if (!rawContent) return [];
+
+    const lines = rawContent.split('\n');
+    const contentWithoutComments = lines
+      .map(line => line.replace(/(^|\s)#.*$/, ''))
+      .join('\n');
+    const privilegedEvent = PR_TARGET_EVENT_RE.test(contentWithoutComments);
+    const findings = [];
+
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index].replace(/(^|\s)#.*$/, '');
+      const uses = ACTION_USES_RE.exec(line);
+      if (!uses) continue;
+
+      const action = uses[1];
+      if (action.startsWith('./') || action.startsWith('docker://')) continue;
+
+      let stepName = '';
+      for (let previous = index - 1; previous >= 0; previous -= 1) {
+        const candidate = lines[previous].replace(/(^|\s)#.*$/, '');
+        const name = /^\s*-\s*name\s*:\s*["']?(.+?)["']?\s*$/.exec(candidate);
+        if (name) {
+          stepName = name[1];
+          break;
+        }
+        if (/^\s*-\s*(?:uses|run)\s*:/.test(candidate)) break;
+      }
+
+      if (!AI_ACTION_SIGNAL_RE.test(action) && !AI_ACTION_SIGNAL_RE.test(stepName)) continue;
+
+      const at = action.lastIndexOf('@');
+      const ref = at >= 0 ? action.slice(at + 1) : '';
+      if (FULL_COMMIT_SHA_RE.test(ref)) continue;
+
+      const scopes = workflowAndJobScopes(lines, index);
+      const broadPermissions =
+        BROAD_AI_ACTION_PERMISSION_RE.test(scopes.workflow) ||
+        BROAD_AI_ACTION_PERMISSION_RE.test(scopes.job);
+      const elevated = broadPermissions || privilegedEvent;
+      const riskContext = [
+        broadPermissions ? 'broad write permissions' : null,
+        privilegedEvent ? '`pull_request_target`' : null,
+      ].filter(Boolean).join(' and ');
+
+      findings.push(createFinding({
+        file,
+        line: index + 1,
+        severity: elevated ? 'critical' : 'high',
+        category: this.category,
+        rule: 'CICD_AI_ACTION_UNPINNED',
+        title: 'CI/CD: AI action uses an unpinned reference',
+        description:
+          `The AI/agent workflow step uses \`${action}\`, which is not pinned to a full commit SHA. ` +
+          'These actions can read prompts, repository content, and pull-request diffs; an upstream ref change can therefore alter code that runs inside this workflow without a reviewed repository change.' +
+          (riskContext ? ` The exposure is critical because the workflow also has ${riskContext}.` : ''),
+        matched: action.slice(0, 180),
+        confidence: 'high',
+        cwe: 'CWE-829',
+        owasp: 'CICD-SEC-8',
+        fix:
+          'Pin the action to a reviewed 40-character commit SHA. Keep `contents` read-only, grant write permissions only to the job that needs them, and avoid running AI actions with `pull_request_target` on untrusted input.',
+      }));
+    }
+
+    return findings;
+  }
+
   async analyze(context) {
     const { rootPath, files } = context;
 
@@ -757,6 +865,7 @@ export class CICDScanner extends BaseAgent {
       findings = findings.concat(this.scanIngestionChain(file, rootPath, self));
       findings = findings.concat(this.scanPrivilegedHandoffs(file));
       findings = findings.concat(this.scanNpmPublishProvenance(file));
+      findings = findings.concat(this.scanUnpinnedAiActions(file));
     }
     return findings;
   }


### PR DESCRIPTION
## Summary
- add `CICD_AI_ACTION_UNPINNED` for AI/agent GitHub Action steps that are not pinned to a full commit SHA
- recognize AI intent from either the action identifier or its step name
- raise severity from high to critical for `pull_request_target` or broad write permissions, scoped to the workflow and containing job
- add vulnerable and safe workflow fixtures plus regression coverage for comments, non-AI actions, and cross-job permissions

Closes #55

## Verification
- `node --test cli/__tests__/ai-action-pinning.test.js cli/__tests__/npm-publish-provenance.test.js cli/__tests__/upstream-ingestion.test.js cli/__tests__/canonical-detection.test.js` (47 passed)
- `npm test` (616 passed)
- `npm run lint` (0 errors; 86 existing warnings)
- `node benchmarks/false-positives/run.mjs`
- `git diff --check`

## False-positive benchmark
The new rule produced no findings in the pinned corpus. Current totals versus the checked-in baseline:

| Corpus | Baseline | This branch |
| --- | ---: | ---: |
| Clean findings | 844 | 798 |
| Clean critical | 102 | 68 |
| NodeGoat findings | 74 | 68 |
| DVWA findings | 71 | 65 |

The lower totals come from current `main` relative to the repository’s saved benchmark baseline; this rule adds zero corpus hits.