### PR TITLE
Detect unpinned AI actions with broad CI access

### DIFF
--- a/cli/__tests__/ai-action-unpinned.test.js
+++ b/cli/__tests__/ai-action-unpinned.test.js
@@ -1,0 +1,191 @@
+/**
+ * cli/__tests__/ai-action-unpinned.test.js
+ * =========================================
+ *
+ * Tests for the CICD_AI_ACTION_UNPINNED check in CICDScanner: an AI/agent
+ * GitHub Action that floats on a mutable ref (@main, @v1, etc.) combined
+ * with either broad write permissions or an unguarded pull_request_target
+ * trigger.
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { CICDScanner } from '../agents/cicd-scanner.js';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+
+// UNSAFE: unpinned AI review action, job grants contents/pull-requests write.
+const UNSAFE_BROAD_WRITE = `
+name: AI PR Review
+on:
+  pull_request:
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: some-org/ai-pr-reviewer@main
+        env:
+          ANTHROPIC_API_KEY: \${{ secrets.ANTHROPIC_API_KEY }}
+`;
+
+// UNSAFE: unpinned AI action, pull_request_target trigger with no
+// permissions block at all narrowing the default token.
+const UNSAFE_PR_TARGET_UNGUARDED = `
+name: AI Autofix
+on:
+  pull_request_target:
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: some-org/autofix-agent@v1
+`;
+
+// SAFE: same AI action, but pinned to a full commit SHA.
+const SAFE_PINNED_SHA = `
+name: AI PR Review
+on:
+  pull_request:
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: some-org/ai-pr-reviewer@a1b2c3d4e5f60718293a4b5c6d7e8f9012345678
+        env:
+          ANTHROPIC_API_KEY: \${{ secrets.ANTHROPIC_API_KEY }}
+`;
+
+// SAFE: unpinned AI action, but permissions are read-only and there is no
+// pull_request_target trigger.
+const SAFE_READ_ONLY = `
+name: AI PR Review
+on:
+  pull_request:
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: some-org/ai-pr-reviewer@main
+`;
+
+// SAFE: unpinned AI action on pull_request_target, but the job explicitly
+// scopes the token down to contents: read.
+const SAFE_PR_TARGET_SCOPED = `
+name: AI Autofix
+on:
+  pull_request_target:
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: some-org/autofix-agent@v1
+`;
+
+// SAFE: unpinned action with broad write, but nothing AI/agent related.
+const SAFE_NON_AI_ACTION = `
+name: Deploy
+on:
+  push:
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: some-org/deploy-tool@main
+`;
+
+// ── Test harness ─────────────────────────────────────────────────────────
+
+function writeFixture(dir, filename, content) {
+  const workflowsDir = path.join(dir, '.github', 'workflows');
+  fs.mkdirSync(workflowsDir, { recursive: true });
+  const filePath = path.join(workflowsDir, filename);
+  fs.writeFileSync(filePath, content, 'utf-8');
+  return filePath;
+}
+
+async function scanFixture(content, filename = 'ai-review.yml') {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ship-safe-ai-action-'));
+  try {
+    fs.mkdirSync(path.join(tmpDir, '.git'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.git', 'config'),
+      '[remote "origin"]\n\turl = https://github.com/example-org/example-repo.git\n',
+      'utf-8'
+    );
+
+    const filePath = writeFixture(tmpDir, filename, content);
+    const scanner = new CICDScanner();
+    const findings = await scanner.analyze({ rootPath: tmpDir, files: [filePath] });
+    return findings;
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('CICDScanner: unpinned AI action with broad access', () => {
+  test('flags an unpinned AI action with broad write permissions', async () => {
+    const findings = await scanFixture(UNSAFE_BROAD_WRITE);
+    const rule = findings.find(f => f.rule === 'CICD_AI_ACTION_UNPINNED');
+
+    assert.ok(rule, 'expected CICD_AI_ACTION_UNPINNED to fire');
+    assert.strictEqual(rule.severity, 'critical');
+  });
+
+  test('flags an unpinned AI action on unguarded pull_request_target', async () => {
+    const findings = await scanFixture(UNSAFE_PR_TARGET_UNGUARDED);
+    const rule = findings.find(f => f.rule === 'CICD_AI_ACTION_UNPINNED');
+
+    assert.ok(rule, 'expected CICD_AI_ACTION_UNPINNED to fire');
+  });
+
+  test('does not flag a pinned AI action even with broad write permissions', async () => {
+    const findings = await scanFixture(SAFE_PINNED_SHA);
+    const rule = findings.find(f => f.rule === 'CICD_AI_ACTION_UNPINNED');
+
+    assert.strictEqual(rule, undefined);
+  });
+
+  test('does not flag an unpinned AI action with read-only permissions', async () => {
+    const findings = await scanFixture(SAFE_READ_ONLY);
+    const rule = findings.find(f => f.rule === 'CICD_AI_ACTION_UNPINNED');
+
+    assert.strictEqual(rule, undefined);
+  });
+
+  test('does not flag pull_request_target when permissions are explicitly scoped to read', async () => {
+    const findings = await scanFixture(SAFE_PR_TARGET_SCOPED);
+    const rule = findings.find(f => f.rule === 'CICD_AI_ACTION_UNPINNED');
+
+    assert.strictEqual(rule, undefined);
+  });
+
+  test('does not flag a non-AI action even when unpinned with broad write', async () => {
+    const findings = await scanFixture(SAFE_NON_AI_ACTION);
+    const rule = findings.find(f => f.rule === 'CICD_AI_ACTION_UNPINNED');
+
+    assert.strictEqual(rule, undefined);
+  });
+});

--- a/cli/agents/cicd-scanner.js
+++ b/cli/agents/cicd-scanner.js
@@ -455,6 +455,21 @@ const NPM_TOKEN_ENV_RE = /\bNPM_TOKEN\b/;
 const PROVENANCE_DISABLED_RE = /--provenance(?:=|\s+)false\b|provenance\s*:\s*false\b/i;
 const PROVENANCE_INTENDED_RE = /--provenance\b|trusted\s+publish(?:ing)?\b/i;
 const ID_TOKEN_WRITE_RE = /id-token\s*:\s*write\b/i;
+
+// An AI/agent action that floats on a mutable tag is an ordinary supply-chain
+// risk on its own (see CICD_UNPINNED_ACTION above). It becomes a distinct,
+// higher-stakes finding once the workflow running it also hands out broad
+// write scope, or runs it on pull_request_target with nothing narrowing the
+// default token — either way a hijacked tag on the action executes with
+// that access on every run, and the action itself can read PR diffs,
+// comments, and repository contents.
+const AI_ACTION_STEP_RE =
+  /uses\s*:\s*([\w.-]+\/[\w.-]*(?:ai|agent|llm|review|autofix|copilot|claude|openai|anthropic|chatgpt|gpt|gemini|cursor|codeium|tabnine|codex|devin)[\w.-]*)@((?![\da-f]{40}\b)[\w./-]+)/gi;
+const BROAD_WRITE_PERMISSION_RE =
+  /permissions\s*:\s*(?:write-all\b|[\s\S]{0,280}\b(?:contents|pull-requests|actions)\s*:\s*write\b)/i;
+const READ_SCOPED_PERMISSION_RE =
+  /permissions\s*:\s*(?:read-all\b|[\s\S]{0,280}\bcontents\s*:\s*read\b)/i;
+
 function firstMatchLine(rawContent, patterns) {
   for (const re of patterns) {
     re.lastIndex = 0;
@@ -647,6 +662,54 @@ export class CICDScanner extends BaseAgent {
 
     return findings;
   }
+
+  /**
+   * An unpinned AI/agent action is CICD_UNPINNED_ACTION territory on its
+   * own. It becomes CICD_AI_ACTION_UNPINNED once the workflow running it
+   * also grants broad write permissions, or runs it on pull_request_target
+   * with no permissions block narrowing the default token down.
+   */
+  scanAiActionUnpinned(file) {
+    const content = this.readFile(file);
+    if (!content) return [];
+
+    const hasBroadWrite = BROAD_WRITE_PERMISSION_RE.test(content);
+    const prTargetUnguarded =
+      PR_TARGET_EVENT_RE.test(content) &&
+      !hasBroadWrite &&
+      !READ_SCOPED_PERMISSION_RE.test(content);
+
+    if (!hasBroadWrite && !prTargetUnguarded) return [];
+
+    const findings = [];
+    AI_ACTION_STEP_RE.lastIndex = 0;
+    let m;
+    while ((m = AI_ACTION_STEP_RE.exec(content)) !== null) {
+      const [, action, ref] = m;
+      findings.push(createFinding({
+        file,
+        line: content.slice(0, m.index).split('\n').length,
+        column: m.index + 1,
+        severity: 'critical',
+        category: this.category,
+        rule: 'CICD_AI_ACTION_UNPINNED',
+        title: `CI/CD: Unpinned AI Action With Broad Access (${action})`,
+        description:
+          `The AI/agent action "${action}" is referenced by a mutable ref ("${ref}") rather than a commit SHA, and ` +
+          (hasBroadWrite
+            ? 'this workflow grants broad write permissions (contents, pull-requests, or actions).'
+            : 'this workflow runs it on pull_request_target with no permissions block narrowing the default token.') +
+          ' A hijacked tag on this action executes with that access on every run, and the action itself can read PR diffs, comments, and repository contents.',
+        matched: m[0].trim().slice(0, 180),
+        confidence: 'medium',
+        cwe: 'CWE-829',
+        owasp: 'CICD-SEC-8',
+        fix: 'Pin the action to a full 40-character commit SHA, and scope permissions to read-only unless the action genuinely needs to write.',
+      }));
+    }
+
+    return findings;
+  }
 /**
    * npm publish workflows should prefer provenance/trusted publishing over
    * a long-lived NPM_TOKEN, and if provenance is intended, id-token: write
@@ -756,6 +819,7 @@ export class CICDScanner extends BaseAgent {
       // cannot see (see UNGOVERNED CONTINUOUS INGESTION above).
       findings = findings.concat(this.scanIngestionChain(file, rootPath, self));
       findings = findings.concat(this.scanPrivilegedHandoffs(file));
+      findings = findings.concat(this.scanAiActionUnpinned(file));
       findings = findings.concat(this.scanNpmPublishProvenance(file));
     }
     return findings;


### PR DESCRIPTION
CICDScanner had no way to flag AI or agent GitHub Actions that combine a floating version with elevated access, even though these are prime supply-chain and prompt-injection targets. I added a CICD_AI_ACTION_UNPINNED check that fires when a step referencing an AI/agent-named action (matched by common keywords and provider names) is pinned to a mutable ref instead of a commit SHA, and the workflow either grants broad write permissions (contents, pull-requests, or actions) or runs the step under pull_request_target with no permissions block narrowing the default token. Pinned actions and read-only-scoped workflows are left alone, and I added fixture-based tests covering both the vulnerable and safe cases.

Fixes #55.

The repo's own CI runs green on this branch; I ran it on my fork before opening this.
