### PR TITLE
feat: trace through an inline arrow handed to an iterator

### DIFF
--- a/cli/__tests__/dataflow-investigator.test.js
+++ b/cli/__tests__/dataflow-investigator.test.js
@@ -471,6 +471,96 @@ describe('functions handed to an iterator', () => {
   });
 });
 
+describe('inline arrow callbacks', () => {
+  // `arr.forEach(x => f(x))` and `arr.forEach(f)` describe the same flow. One
+  // was traceable and the other was not, purely because of how it was written.
+  it('traces through an arrow into a named function', () => {
+    const file = source('arrow-call.js', [
+      'function renderRow(user, cell) {',
+      '  cell.innerHTML = "<b>" + user + "</b>";',
+      '}',
+      '',
+      'export function populate(cell) {',
+      '  const users = location.hash.slice(1).split(",");',
+      '  users.forEach((user) => renderRow(user, cell));',
+      '}',
+    ]);
+
+    const finding = createFinding({
+      file, line: 2, rule: 'XSS_INNERHTML', title: 'XSS',
+      category: 'vulnerability', severity: 'high',
+    });
+    new DataflowInvestigator().investigate([finding], { rootPath: ROOT, files: [file] });
+
+    const claim = finding.evidence.claims.find((c) => c.source === 'dataflow');
+    assert.equal(claim.verdict, 'confirmed');
+    assert.ok(claim.attackPath.some((s) => s.includes('is each users in turn')));
+  });
+
+  it('traces when the sink sits directly inside the arrow', () => {
+    const file = source('arrow-inline.js', [
+      'export function populate(cell) {',
+      '  const users = location.hash.slice(1).split(",");',
+      '  users.forEach((user) => {',
+      '    cell.innerHTML = user;',
+      '  });',
+      '}',
+    ]);
+    assert.equal(trace(file, 4, { rule: 'XSS_INNERHTML' }).claim.verdict, 'confirmed');
+  });
+
+  it('refutes when the collection was sanitized', () => {
+    const file = source('arrow-safe.js', [
+      'export function populate(cell) {',
+      '  const users = escapeHtml(location.hash.slice(1)).split(",");',
+      '  users.forEach((user) => {',
+      '    cell.innerHTML = user;',
+      '  });',
+      '}',
+    ]);
+    assert.equal(trace(file, 4, { rule: 'XSS_INNERHTML' }).claim.verdict, 'refuted');
+  });
+
+  it('does not borrow a receiver from an unrelated arrow', () => {
+    const file = source('arrow-sibling.js', [
+      'export function populate(cell, safe) {',
+      '  const tainted = location.hash.slice(1).split(",");',
+      '  tainted.forEach((other) => track(other));',
+      '  safe.forEach((user) => {',
+      '    cell.innerHTML = user;',
+      '  });',
+      '}',
+    ]);
+    const claim = trace(file, 5, { rule: 'XSS_INNERHTML' }).claim;
+    assert.notEqual(claim?.verdict, 'confirmed', 'the tainted collection belongs to a different callback');
+  });
+
+  it('does not apply the arrow shim to Python lambdas', () => {
+    // The sink's value is a lambda parameter. Resolving it would need the same
+    // reasoning as a JavaScript arrow, and guessing at Python's shapes with a
+    // JavaScript-shaped rule is how a trace ends up in the wrong collection.
+    const dao = source('render.py', [
+      'def render(user, db):',
+      '    return db.execute(f"SELECT * FROM t WHERE n = {user}")',
+    ]);
+    const routes = source('routes.py', [
+      'from flask import request',
+      'from render import render',
+      '',
+      'def populate(db):',
+      '    users = request.args.get("u").split(",")',
+      '    list(map(lambda u: render(u, db), users))',
+    ]);
+
+    const finding = createFinding({
+      file: dao, line: 2, rule: 'PYTHON_SQL_FSTRING', title: 'x',
+      category: 'injection', severity: 'critical',
+    });
+    new DataflowInvestigator().investigate([finding], { rootPath: ROOT, files: [dao, routes] });
+    assert.equal(finding.evidence.verdict, 'unknown', 'abstains rather than guessing');
+  });
+});
+
 describe('crossing the function boundary', () => {
   // The dominant shape in real handler code: the sink is in a helper, the value
   // arrives as a parameter, and the caller lives in another file. Found against

--- a/cli/agents/dataflow-investigator.js
+++ b/cli/agents/dataflow-investigator.js
@@ -402,6 +402,24 @@ export class DataflowInvestigator {
       return null;
     }
 
+    // An inline arrow handed straight to an iterator is not a function
+    // boundary worth spending the one hop on. `arr.forEach(x => f(x))` and
+    // `arr.forEach(f)` describe the same flow, and one of them was traceable
+    // while the other was not purely because of how it was written.
+    const shimmed = iteratorArrowReceiver(lines, fromLine, name, lang);
+    if (shimmed) {
+      const hop = {
+        line: shimmed.line,
+        excerpt: (lines[shimmed.line - 1] || '').trim().slice(0, 120),
+        text: `${name} is each ${truncate(shimmed.receiver, 40)} in turn`,
+        file,
+      };
+      const [next] = identifiersIn(shimmed.receiver, lang);
+      if (next && next !== name) {
+        return this._walk(next, shimmed.line, lines, [...hops, hop], depth, file, lang);
+      }
+    }
+
     // Not defined in this file. If it is a parameter of the enclosing function,
     // the value was handed in from somewhere, and that somewhere is knowable.
     return this._walkIntoCallers(name, fromLine, lines, hops, depth, file, lang);
@@ -511,6 +529,34 @@ export class DataflowInvestigator {
 // =============================================================================
 // SYNTAX HELPERS
 // =============================================================================
+
+/**
+ * An inline arrow passed to an iterator, whose parameter list contains `name`.
+ *
+ * The receiver stands in for the parameter: each element of it is what the
+ * arrow is called with. Only JavaScript has this shape; Python's comprehensions
+ * and lambdas are a separate question and get no answer here rather than a
+ * JavaScript-shaped guess.
+ *
+ * The search window is deliberately short. An arrow more than a few lines above
+ * the value is as likely to be a sibling callback as an enclosing one, and a
+ * wrong receiver is a trace into unrelated code.
+ */
+const ITERATOR_ARROW = /([\w$.[\]'"]+)\s*\.\s*(?:forEach|map|flatMap|filter|find|some|every|sort|reduce)\s*\(\s*(?:async\s*)?\(?\s*([^)=]*?)\s*\)?\s*=>/;
+
+const ARROW_WINDOW = 10;
+
+function iteratorArrowReceiver(lines, fromLine, name, lang) {
+  if (lang.id !== 'js') return null;
+
+  for (let i = fromLine - 1; i >= 0 && i >= fromLine - 1 - ARROW_WINDOW; i--) {
+    const match = (lines[i] || '').match(ITERATOR_ARROW);
+    if (!match) continue;
+    if (!splitParams(match[2], lang).includes(name)) continue;
+    return { receiver: match[1], line: i + 1 };
+  }
+  return null;
+}
 
 /** Merge hop lists from several seeds, keeping each line once and in order. */
 /** Say why a traced flow stops short of confirmed. */


### PR DESCRIPTION
`users.forEach(updateTable)` traced and `users.forEach((user) => render(user))` did not, and the difference was how the code was written rather than what it did.

## Approach

The arrow is not treated as a second function boundary, because it is not one in any sense that matters. An inline arrow passed straight to an iterator is a shim around the element, and the receiver stands in for its parameter. Spending the one-boundary budget on it would mean the named form and the inline form cost different amounts to trace — exactly the arbitrariness this removes.

```
1. value reaches XSS_INNERHTML here          :2
2. renderRow is called here with user        :7
3. user is each users in turn                :7
4. users is assigned here                    :6
```

## Guards

- **A ten-line window.** An arrow further away is as likely to be a sibling callback as an enclosing one, and a wrong receiver traces into unrelated code. There is a test for a sibling `forEach` that must not lend its receiver.
- **JavaScript only.** A test pins that a Python lambda abstains rather than receiving a JavaScript-shaped guess about Python's shapes.

## Scope

Corpus shows no regressions — DVWA, NodeGoat, and express unchanged. DVWA's `innerHTML` findings were already handled; theirs is a named callback. This covers the form that appears in most front-end code written since arrow functions became ordinary.

Based on `codex/release-9.8.0` (#177) so the diff shows only this change. GitHub will retarget to `main` when that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)