### PR TITLE
feat: let absence rules follow a call one hop into a wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- **Absence rules can follow a call one hop** — `AGENT_NO_COST_LIMIT` and
+  `AGENT_NO_AUDIT_LOG` are answerable again. Both say the file sets no ceiling or
+  writes no log *anywhere in it*, which a project-wide search contradicts rather
+  than tests: `max_tokens` is a per-call argument and does not propagate. But it
+  is normally set once, in whatever wraps the provider client, and every call
+  site inherits it by calling that. The search now covers the file and the
+  bodies of the functions it calls, and stops there — a control two hops away
+  costs an unresolved finding rather than a wrong one.
+
 ## [9.8.0] - 2026-09-01
 
 ### Added

--- a/cli/__tests__/absence-investigator.test.js
+++ b/cli/__tests__/absence-investigator.test.js
@@ -200,16 +200,105 @@ describe('absences that are local to a handler', () => {
     assert.equal(investigate('AGENT_TOOL_CALL_REPLAY_MISSING_ASSISTANT', [file], { file, line: 2 }).claim.verdict, 'refuted');
   });
 
-  it('leaves a rule alone when a project-wide search would contradict its own claim', () => {
-    // AGENT_NO_COST_LIMIT says the file sets no ceiling anywhere in it.
-    // max_tokens is a per-call argument, so one in another module refutes
-    // nothing -- and registering it refuted 25 findings against a single line.
-    const caller = write('runner.py', ['def run(client):', '    return client.messages.create(model="x")']);
-    const other = write('batch.py', ['def batch(client):', '    return client.messages.create(model="x", max_tokens=100)']);
+  it('is still not refuted by an unrelated module that sets the control', () => {
+    // The property the earlier version of this rule got wrong: max_tokens is a
+    // per-call argument, so one in a batch runner this file never calls says
+    // nothing about it. Registered against the whole project it refuted
+    // twenty-five findings against a single line.
+    const caller = write('runner.py', [
+      'def run(client):',
+      '    return client.messages.create(model="x")',
+    ]);
+    const unrelated = write('batch.py', [
+      'def batch(client):',
+      '    return client.messages.create(model="x", max_tokens=100)',
+    ]);
 
-    assert.equal(investigate('AGENT_NO_COST_LIMIT', [caller, other], { file: caller, line: 2 }).claim, null);
-    assert.equal(isAbsenceRule('AGENT_NO_COST_LIMIT'), false);
-    assert.equal(isAbsenceRule('AGENT_NO_AUDIT_LOG'), false);
+    const { claim } = investigate('AGENT_NO_COST_LIMIT', [caller, unrelated], { file: caller, line: 2 });
+    assert.equal(claim.verdict, 'likely', 'a module this file never calls is not evidence about it');
+  });
+
+  it('refutes when a wrapper the file calls sets the control', () => {
+    const caller = write('runner.py', [
+      'from llm import complete',
+      '',
+      'def run(prompt):',
+      '    return complete(prompt)',
+      '',
+      'def other(client):',
+      '    return client.messages.create(model="x")',
+    ]);
+    const wrapper = write('llm.py', [
+      'def complete(prompt):',
+      '    return client.messages.create(model="x", prompt=prompt, max_tokens=512)',
+    ]);
+
+    const { claim } = investigate('AGENT_NO_COST_LIMIT', [caller, wrapper], { file: caller, line: 7 });
+    assert.equal(claim.verdict, 'refuted');
+    assert.match(claim.rationale, /is set in complete, which this file calls/);
+    assert.equal(claim.citations[0].line, 2, 'cites the line in the wrapper that sets it');
+  });
+
+  it('refutes when the control is in the file itself', () => {
+    const file = write('direct.py', [
+      'def run(client):',
+      '    return client.messages.create(model="x", max_tokens=256)',
+    ]);
+    assert.equal(investigate('AGENT_NO_COST_LIMIT', [file], { file, line: 2 }).claim.verdict, 'refuted');
+  });
+
+  it('never refutes without pointing at the control it found', () => {
+    // The first version re-derived the rule's own precondition with a narrower
+    // pattern and refuted when the two disagreed. That is not evidence about
+    // the control; it is this pass overruling the detector on the detector's
+    // own question, and it refuted twenty-four findings with no citation at all.
+    const file = write('plain.py', ['def add(a, b):', '    return a + b']);
+    const { claim } = investigate('AGENT_NO_COST_LIMIT', [file], { file, line: 2 });
+
+    assert.equal(claim.verdict, 'likely', 'finding nothing is not the same as finding it safe');
+    assert.ok(claim.citations.length > 0 || claim.verdict !== 'refuted');
+  });
+
+  it('cites a real line on every refutation it makes', () => {
+    const caller = write('runner.py', ['from llm import complete', '', 'def run(p):', '    return complete(p)']);
+    const wrapper = write('llm.py', ['def complete(prompt):', '    return client.create(prompt=prompt, max_tokens=512)']);
+    const direct = write('direct.py', ['def run(client):', '    return client.create(model="x", max_tokens=256)']);
+
+    for (const file of [caller, direct]) {
+      const { claim } = investigate('AGENT_NO_COST_LIMIT', [caller, wrapper, direct], { file, line: 2 });
+      assert.equal(claim.verdict, 'refuted');
+      assert.ok(claim.citations.length > 0, `${file} refuted with no citation`);
+    }
+  });
+
+  it('follows a call for audit logging too', () => {
+    const caller = write('dispatch.js', [
+      "import { record } from './audit.js';",
+      'export function dispatch(tool) {',
+      '  record(tool);',
+      '  return tool.run();',
+      '}',
+    ]);
+    const wrapper = write('audit.js', [
+      'export function record(tool) {',
+      '  logger.info("tool dispatched", { tool });',
+      '}',
+    ]);
+
+    const { claim } = investigate('AGENT_NO_AUDIT_LOG', [caller, wrapper], { file: caller, line: 3 });
+    assert.equal(claim.verdict, 'refuted');
+    assert.match(claim.rationale, /which this file calls/);
+  });
+
+  it('stops at one hop rather than chasing a chain', () => {
+    const caller = write('a.js', ["import { b } from './b.js';", 'export function run() { return b(); }']);
+    const middle = write('b.js', ["import { c } from './c.js';", 'export function b() { return c(); }']);
+    const deep = write('c.js', ['export function c() { return client.messages.create({ max_tokens: 10 }); }']);
+    const app = write('app.js', ['export function go(client) { return client.messages.create({ model: "x" }); }']);
+
+    const { claim } = investigate('AGENT_NO_COST_LIMIT', [caller, middle, deep, app], { file: app, line: 1 });
+    assert.equal(claim.verdict, 'likely', 'app.js calls nothing that sets it; two hops away is out of reach');
+    assert.match(claim.rationale, /further down the call chain than this pass follows/);
   });
 
   it('answers without a project file list, because the question is local', () => {

--- a/cli/agents/absence-investigator.js
+++ b/cli/agents/absence-investigator.js
@@ -31,6 +31,8 @@
 import fs from 'fs';
 import path from 'path';
 import { attachEvidence, createClaim } from '../utils/evidence.js';
+import { buildDefinitionIndex, functionBody, calledNames } from '../utils/function-bodies.js';
+import { commentMask } from '../utils/source-context.js';
 
 // =============================================================================
 // WHAT EACH ABSENCE RULE IS ACTUALLY CLAIMING
@@ -58,19 +60,51 @@ const FRAMEWORK_CONSUMER = /(?:require\s*\(\s*['"`]|from\s+['"`])(?:express|fast
  * exactly the silent-loss error this layer exists to prevent.
  */
 /**
- * Two rules are deliberately absent from this table: AGENT_NO_COST_LIMIT and
- * AGENT_NO_AUDIT_LOG. Both say, in their own text, that the file issuing
- * completions or dispatching tools sets no ceiling or writes no log *anywhere
- * in it*. A project-wide search contradicts the claim rather than testing it:
- * max_tokens is a per-call argument and does not propagate, and a logger in
- * another module does not record this dispatcher's calls.
- *
- * Registering them refuted 25 and 7 findings against a single unrelated line in
- * one batch runner. Answering a question wrongly is worse than leaving it open,
- * so they stay unanswered until there is a pass that can follow a call into a
- * shared wrapper and see what it sets.
+ * How far a search follows a call before giving up. One hop: the file's own
+ * callees, and no further. A ceiling set two wrappers deep is real and this
+ * pass will miss it, which costs an unresolved finding rather than a wrong one.
  */
+const WRAPPER_HOPS = 1;
+
 const ABSENCE_RULES = {
+  /**
+   * A token ceiling is a per-call argument, so a project-wide search answers
+   * the wrong question: max_tokens in an unrelated batch runner says nothing
+   * about this file. But the ceiling is normally set once, in whatever wraps
+   * the provider client, and every call site inherits it by calling that.
+   *
+   * So the search follows the calls this file makes. Registered naively against
+   * the whole project it refuted twenty-five findings against a single line;
+   * scoped to the file's own callees it answers the question the rule asks.
+   */
+  AGENT_NO_COST_LIMIT: {
+    what: 'a token ceiling or cost budget',
+    scope: 'callees',
+    control: [
+      /\bmax_?(?:output_?|completion_?)?tokens\b\s*[:=]/i,
+      /\b(?:budget|cost|spend)_?(?:limit|cap|ceiling|cents|usd)\b\s*[:=]/i,
+      /\bmaxTokens\b\s*[:=]/,
+    ],
+    // Unused at this scope: the finding's existence is the precondition.
+    precondition: [/./],
+  },
+
+  /**
+   * Same shape. A dispatcher that calls a shared logger is recorded even though
+   * nothing at the call site says so, and a logger in an unrelated module is
+   * not evidence about this dispatcher.
+   */
+  AGENT_NO_AUDIT_LOG: {
+    what: 'logging or telemetry around tool dispatch',
+    scope: 'callees',
+    control: [
+      /\b(?:logger|log|audit|telemetry|tracer)\.(?:info|debug|warn|error|event|record|span)\s*\(/i,
+      /\b(?:console\.(?:log|info|warn|error)|print)\s*\(/,
+      /\b(?:structlog|winston|pino|bunyan|opentelemetry)\b/i,
+    ],
+    precondition: [/./],
+  },
+
   API_NO_SECURITY_HEADERS: {
     what: 'security headers middleware',
     control: [
@@ -254,6 +288,22 @@ const MAX_SEARCHED_FILES = 4000;
 /** How far past a finding a local guard clause may reasonably sit. */
 const LOCAL_WINDOW = 15;
 
+/** Callees examined per finding, and definitions examined per name. */
+const MAX_CALLEES = 40;
+const MAX_DEFINITIONS = 3;
+
+/** First line matching any control pattern, skipping prose. */
+function findControl(lines, patterns, file) {
+  const prose = commentMask(lines, { file });
+  for (let i = 0; i < lines.length; i++) {
+    if (prose[i]) continue;
+    if (patterns.some((pattern) => pattern.test(lines[i]))) {
+      return { line: i + 1, excerpt: lines[i].trim().slice(0, 120) };
+    }
+  }
+  return null;
+}
+
 // =============================================================================
 // PASS
 // =============================================================================
@@ -279,6 +329,11 @@ export class AbsenceInvestigator {
 
       if (spec.scope === 'local') {
         this._investigateLocally(finding, spec, cache);
+        continue;
+      }
+
+      if (spec.scope === 'callees') {
+        this._investigateCallees(finding, spec, cache, corpus, rootPath);
         continue;
       }
 
@@ -319,6 +374,94 @@ export class AbsenceInvestigator {
     }
 
     return findings;
+  }
+
+  /** Read a file once per run, cached with everything else this pass reads. */
+  _read(file, cache) {
+    if (cache.has(file)) return cache.get(file);
+    let lines;
+    try { lines = fs.readFileSync(file, 'utf-8').split('\n'); } catch { lines = null; }
+    cache.set(file, lines);
+    return lines;
+  }
+
+  /**
+   * Look in this file, then one hop into what it calls.
+   *
+   * The rule's own claim is about the file, and the file is where the answer
+   * usually is not: a wrapper sets the ceiling and the call site inherits it.
+   * Following the calls answers what the rule meant rather than what it said,
+   * without letting an unrelated module in another directory speak for this one.
+   */
+  _investigateCallees(finding, spec, cache, corpus, rootPath) {
+    const lines = this._read(finding.file, cache);
+    if (!lines) return;
+
+    // No precondition check here, deliberately. The detector already decided
+    // this file does the thing the control would protect -- that is why the
+    // finding exists. Re-deriving it with a second, narrower pattern and
+    // refuting when the two disagree is not evidence about the control; it is
+    // this pass overruling the detector on the detector's own question. Written
+    // that way it refuted twenty-four findings with no citation at all, which
+    // is the shape of every refutation that turned out to be wrong.
+    const local = findControl(lines, spec.control, finding.file);
+    if (local) {
+      attachEvidence(finding, createClaim({
+        source: 'presence',
+        verdict: 'refuted',
+        rationale: `${capitalize(spec.what)} is set in this file.`,
+        citations: [{ file: finding.file, line: local.line, excerpt: local.excerpt }],
+      }));
+      return;
+    }
+
+    const wrapper = this._searchCallees(finding, spec, cache, corpus);
+    if (wrapper) {
+      attachEvidence(finding, createClaim({
+        source: 'presence',
+        verdict: 'refuted',
+        rationale: `${capitalize(spec.what)} is set in ${wrapper.name}, which this file calls. The call site inherits it without saying so.`,
+        citations: [{ file: wrapper.file, line: wrapper.line, excerpt: wrapper.excerpt }],
+        attackPath: [`${finding.file.split('/').pop()} calls ${wrapper.name}`, `${wrapper.name} sets ${spec.what}`],
+      }));
+      return;
+    }
+
+    attachEvidence(finding, createClaim({
+      source: 'presence',
+      verdict: 'likely',
+      rationale: `No ${spec.what} was found in this file or in what it calls. It may still be set further down the call chain than this pass follows.`,
+      citations: [{ file: finding.file, line: finding.line }],
+    }));
+  }
+
+  /** One hop: the definitions of the names this file calls. */
+  _searchCallees(finding, spec, cache, corpus) {
+    if (!corpus.length) return null;
+
+    if (!this._definitions) this._definitions = buildDefinitionIndex(corpus);
+    const lines = this._read(finding.file, cache);
+
+    for (const name of calledNames(lines).slice(0, MAX_CALLEES)) {
+      for (const def of (this._definitions.get(name) || []).slice(0, MAX_DEFINITIONS)) {
+        if (def.file === finding.file) continue;         // already searched above
+
+        const defLines = this._read(def.file, cache);
+        if (!defLines) continue;
+
+        // functionBody returns each line with its own absolute number, which
+        // differs by language: a Python body starts below its `def` and a
+        // braced one starts on the signature. Recomputing the offset here got
+        // that wrong; carrying the line the body already knows cannot.
+        const body = functionBody(defLines, def.line, def.file);
+        const hit = findControl(body.map((b) => b.text), spec.control, def.file);
+        if (hit) {
+          return { name, file: def.file, line: body[hit.line - 1].line, excerpt: hit.excerpt };
+        }
+      }
+    }
+
+    return null;
   }
 
   /**

--- a/cli/utils/function-bodies.js
+++ b/cli/utils/function-bodies.js
@@ -1,0 +1,145 @@
+/**
+ * Finding a named function and reading its body
+ * ==============================================
+ *
+ * Some questions are only answerable one call away. "This file issues LLM
+ * completions and sets no token ceiling" is true of most files that issue
+ * completions, because the ceiling is set once in whatever wraps the provider
+ * client and every call site inherits it by calling that wrapper.
+ *
+ * Answering those needs two things a line-based scan does not have: where a
+ * name is defined, and where its body ends. Both are approximations here —
+ * braces for C-like languages, indentation for Python — and both are wrong on
+ * code that a parser would handle. That is the trade this file makes: it is
+ * cheap, it has no dependencies, and it is used only to look for something,
+ * never to conclude that a thing is absent from a body it may have measured
+ * badly.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const JS_EXT = new Set(['.js', '.jsx', '.mjs', '.cjs', '.ts', '.tsx', '.mts', '.cts']);
+const PY_EXT = new Set(['.py', '.pyi']);
+
+/** Definitions worth indexing: a name, and a line its body starts on. */
+const JS_DEFINITION = [
+  /(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(/,
+  /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>/,
+  /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s+)?function\b/,
+  /^\s*(?:async\s+)?([A-Za-z_$][\w$]*)\s*\([^)]*\)\s*\{/,
+];
+
+const PY_DEFINITION = [/^\s*(?:async\s+)?def\s+([A-Za-z_][\w]*)\s*\(/];
+
+/** Keywords that look like definitions to the shorthand-method pattern. */
+const NOT_A_NAME = new Set([
+  'if', 'for', 'while', 'switch', 'catch', 'with', 'do', 'else', 'return',
+  'function', 'class', 'constructor', 'super', 'typeof', 'await', 'new',
+]);
+
+const MAX_INDEXED_FILES = 4000;
+const MAX_BODY_LINES = 400;
+
+/**
+ * Build name → definitions across the given files.
+ *
+ * A name may be defined more than once in a project, and every definition is
+ * kept. A caller searching for a control checks all of them and takes any hit:
+ * looking in one too many bodies costs a false refutation only if the control
+ * is genuinely there, in which case the code does have it somewhere.
+ */
+export function buildDefinitionIndex(files = []) {
+  const index = new Map();
+
+  for (const file of files.slice(0, MAX_INDEXED_FILES)) {
+    const patterns = definitionPatterns(file);
+    if (!patterns) continue;
+
+    let lines;
+    try { lines = fs.readFileSync(file, 'utf-8').split('\n'); } catch { continue; }
+
+    lines.forEach((line, i) => {
+      for (const pattern of patterns) {
+        const match = line.match(pattern);
+        if (!match || NOT_A_NAME.has(match[1])) continue;
+        if (!index.has(match[1])) index.set(match[1], []);
+        index.get(match[1]).push({ file, line: i + 1 });
+        break;
+      }
+    });
+  }
+
+  return index;
+}
+
+function definitionPatterns(file) {
+  const ext = path.extname(String(file)).toLowerCase();
+  if (JS_EXT.has(ext)) return JS_DEFINITION;
+  if (PY_EXT.has(ext)) return PY_DEFINITION;
+  return null;
+}
+
+/**
+ * The lines belonging to the definition starting at `startLine` (1-based).
+ *
+ * Braces for C-like languages, indentation for Python. Capped, because a body
+ * this long is either generated or not a function, and either way reading all
+ * of it to look for one call is not worth the pages.
+ */
+export function functionBody(lines, startLine, file) {
+  const ext = path.extname(String(file)).toLowerCase();
+  const limit = Math.min(lines.length, startLine - 1 + MAX_BODY_LINES);
+
+  if (PY_EXT.has(ext)) {
+    const indent = indentOf(lines[startLine - 1] || '');
+    const body = [];
+    for (let i = startLine; i < limit; i++) {
+      const line = lines[i];
+      if (line.trim() && indentOf(line) <= indent) break;
+      body.push({ line: i + 1, text: line });
+    }
+    return body;
+  }
+
+  let depth = 0;
+  let opened = false;
+  const body = [];
+
+  for (let i = startLine - 1; i < limit; i++) {
+    const line = lines[i];
+    for (const char of line) {
+      if (char === '{') { depth += 1; opened = true; }
+      else if (char === '}') depth -= 1;
+    }
+    if (i >= startLine - 1) body.push({ line: i + 1, text: line });
+    if (opened && depth <= 0) break;
+  }
+
+  return body;
+}
+
+function indentOf(line) {
+  const match = String(line).match(/^[ \t]*/);
+  return match ? match[0].replace(/\t/g, '    ').length : 0;
+}
+
+/** Names this file calls, so a search can follow them one hop. */
+export function calledNames(lines) {
+  const names = new Set();
+
+  for (const line of lines) {
+    if (/^\s*(?:\/\/|#|\*)/.test(line)) continue;
+    for (const match of line.matchAll(/(?:\b|\.)([A-Za-z_$][\w$]*)\s*\(/g)) {
+      const name = match[1];
+      if (NOT_A_NAME.has(name)) continue;
+
+      // A definition is not a call to itself.
+      const before = line.slice(0, match.index).trimEnd();
+      if (/\b(?:function|class|def)$/.test(before)) continue;
+      names.add(name);
+    }
+  }
+
+  return [...names];
+}


### PR DESCRIPTION
`AGENT_NO_COST_LIMIT` and `AGENT_NO_AUDIT_LOG` were removed from the absence registry during 9.8.0 because no scope answered them correctly. This adds the scope that does.

## The problem

Both rules say the file sets no ceiling, or writes no log, *anywhere in it*.

- A **project-wide** search contradicts that claim rather than testing it. `max_tokens` is a per-call argument and does not propagate; a logger in another module does not record this dispatcher's calls.
- A **file-local** search re-derives what the detector already established, and adds nothing.

## The scope that works

One hop. A ceiling is normally set once, in whatever wraps the provider client, and every call site inherits it by calling that wrapper. So the search covers the file and the bodies of the functions it calls, and stops there.

A control two hops away yields `likely`, with *"may still be set further down the call chain than this pass follows"* — an unresolved finding rather than a wrong one.

New `cli/utils/function-bodies.js` provides the definition index and body extraction: braces for C-like languages, indentation for Python. Deliberately approximate, and used only to **find** something, never to conclude absence from a body it may have measured badly.

## The invariant this rule kept teaching

Three implementations before one that was right, each refuting by something other than finding the control:

| refuted by | count |
|---|---|
| an unrelated module's `max_tokens` | 25 |
| the line the rule itself fired on | 30 |
| disagreeing with the detector's own precondition, citing nothing | 24 |

That last one is the subtlest: it re-checked the rule's precondition with a narrower pattern and refuted when the two disagreed — the pass overruling the detector on the detector's own question.

There is now a test for the invariant: **every refutation carries a citation to a real line.** A pass that cannot point at what it found has not found anything. The audit that catches a breach is one command — count distinct citations. When they are all `undefined`, the pass is producing reasons rather than evidence.

## Result

On hermes-agent: **6 findings resolved, citing 6 distinct wrappers.** The broken versions claimed 29.

843 tests, both benchmark gates green, `settled` holds at 11 with 0 false refutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)