### PR TITLE
test: record benchmark results against the released 9.8.0

### DIFF
--- a/benchmarks/false-positives/results/latest.json
+++ b/benchmarks/false-positives/results/latest.json
@@ -7,16 +7,16 @@
       "id": "express",
       "repo": "expressjs/express",
       "commit": "a3714473feb3d2908add734d340e7755fd85e0a3",
-      "findings": 20,
+      "findings": 18,
       "critical": 0,
       "high": 4,
-      "score": 80.1,
+      "score": 81.4,
       "grade": "B",
       "verdicts": {
         "confirmed": 0,
         "likely": 2,
         "unknown": 7,
-        "refuted": 11
+        "refuted": 9
       }
     },
     {
@@ -71,16 +71,16 @@
       "id": "hermes-agent",
       "repo": "NousResearch/hermes-agent",
       "commit": "743dc94ab90adb0529bb233b8498c6fd6ee0e020",
-      "findings": 738,
-      "critical": 100,
-      "high": 224,
-      "score": 19.9,
+      "findings": 695,
+      "critical": 66,
+      "high": 223,
+      "score": 20.1,
       "grade": "F",
       "verdicts": {
         "confirmed": 3,
-        "likely": 81,
-        "unknown": 372,
-        "refuted": 244
+        "likely": 95,
+        "unknown": 352,
+        "refuted": 223
       }
     }
   ],
@@ -89,15 +89,21 @@
       "id": "NodeGoat",
       "repo": "OWASP/NodeGoat",
       "commit": "c5cb68a7084e4ae7dcc60e6a98768720a81841e8",
-      "findings": 73,
+      "findings": 67,
       "critical": 9,
       "high": 18,
       "verdicts": {
         "confirmed": 7,
-        "likely": 19,
+        "likely": 13,
         "unknown": 27,
         "refuted": 5
-      }
+      },
+      "mustDetect": [
+        "CODE_INJECTION_EVAL",
+        "NOSQL_INJECTION_WHERE",
+        "MASS_ASSIGNMENT"
+      ],
+      "missingFromFloor": []
     },
     {
       "id": "DVWA",
@@ -111,17 +117,22 @@
         "likely": 4,
         "unknown": 51,
         "refuted": 1
-      }
+      },
+      "mustDetect": [
+        "XSS_DOCUMENT_WRITE",
+        "XSS_INNERHTML"
+      ],
+      "missingFromFloor": []
     }
   ],
   "summary": {
     "cleanProjects": 5,
-    "cleanFindings": 787,
-    "cleanCriticalFindings": 100,
+    "cleanFindings": 742,
+    "cleanCriticalFindings": 66,
     "vulnerableProjects": 2,
-    "vulnerableFindings": 144,
+    "vulnerableFindings": 138,
     "cleanConfirmed": 3,
-    "cleanRefuted": 259,
+    "cleanRefuted": 236,
     "vulnerableConfirmed": 7
   }
 }

--- a/benchmarks/results/latest.json
+++ b/benchmarks/results/latest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "corpusVersion": "1.0.0",
-  "shipSafeVersion": "9.5.2",
+  "shipSafeVersion": "9.8.0",
   "methodology": "First-party paired synthetic scenarios; one vulnerable and one safe control per target rule.",
   "limitations": [
     "This corpus measures deterministic scenario detection, not prevalence or performance on arbitrary production repositories.",
@@ -9,11 +9,11 @@
     "The evaluation is maintained by the Ship Safe project and is not independent validation."
   ],
   "metrics": {
-    "scenarios": 12,
-    "detected": 12,
+    "scenarios": 13,
+    "detected": 13,
     "scenarioRecall": 1,
-    "targetRuleCleanControls": 12,
-    "targetRuleCleanControlsPassed": 12,
+    "targetRuleCleanControls": 13,
+    "targetRuleCleanControlsPassed": 13,
     "targetRuleCleanControlPassRate": 1
   },
   "scenarios": [
@@ -88,10 +88,12 @@
       "detected": true,
       "cleanControlPassed": true,
       "vulnerableFindingRules": [
+        "MCP_SERVER_NO_AUTH",
         "MCP_SHADOW_CONFIG",
         "MCP_TOOL_SHELL_EXEC"
       ],
       "safeFindingRules": [
+        "MCP_SERVER_NO_AUTH",
         "MCP_SHADOW_CONFIG"
       ]
     },
@@ -169,6 +171,18 @@
       "cleanControlPassed": true,
       "vulnerableFindingRules": [
         "CLICKFIX_PASTE_RUN"
+      ],
+      "safeFindingRules": []
+    },
+    {
+      "id": "embedded-script-xss",
+      "category": "XSS",
+      "agent": "InjectionTester",
+      "expectedRule": "XSS_DOCUMENT_WRITE",
+      "detected": true,
+      "cleanControlPassed": true,
+      "vulnerableFindingRules": [
+        "XSS_DOCUMENT_WRITE"
       ],
       "safeFindingRules": []
     }


### PR DESCRIPTION
The deterministic corpus results on `main` were recorded at **9.5.2** — three minor versions and an entire investigation layer ago. Anyone reading the published numbers was reading a description of a tool that no longer exists.

All three result files now come from one run against `d2033dd`, the commit that was released and published to npm.

## What they say

```
deterministic corpus   13 scenarios, all detected, every clean control passed
verdicts               11 settled of 20 · 10 noise refuted · 0 false refutations
false positives        742 findings across five mature projects, 66 critical
```

## What moved with 9.8.0

| | before | after |
|---|---|---|
| clean findings | 787 | 742 |
| clean criticals | 100 | 66 |
| clean confirmed | 3 | 3 |
| vulnerable confirmed | 7 | 7 |

**34 fewer criticals on well-reviewed code, with confirmations unchanged on both corpora.** Less noise where noise was the problem; the same detection where the code is deliberately broken.

That second clause is the part worth checking rather than assuming, and it is now checkable. The detection floor added in #178 fails the run if NodeGoat or DVWA stops reporting the rules they are known to contain. Without it, "45 fewer findings" and "we broke something" produce the same summary — which is exactly how a false negative shipped here eight days ago and went unnoticed.

Data only. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)