### PR TITLE
fix: two false confirmations, found by auditing real applications

### DIFF
--- a/benchmarks/applications/README.md
+++ b/benchmarks/applications/README.md
@@ -1,0 +1,40 @@
+# Application corpus
+
+The false-positive corpus is five libraries and two teaching fixtures. A library
+has no request handlers, so the investigation layer barely engages with it:
+scanning express produced twenty findings and no traced paths at all.
+
+These are the shapes users actually scan — HTTP services, an auth-heavy web app —
+pinned by commit.
+
+The question here is different from the other benchmarks. Not how much noise
+there is, and not whether known vulnerabilities are still found, but **whether
+the confirmations are right**. A confirmation is the strongest thing this tool
+says, and the only way to check one is to read the code it cites.
+
+So this corpus has no pass/fail gate. It produces confirmations for a person to
+audit, and the audit is the output.
+
+```bash
+node benchmarks/applications/run.mjs --clone   # fetch the pinned checkouts
+node benchmarks/applications/run.mjs           # list confirmations for review
+```
+
+## What the first audit found
+
+Two confirmations across three applications.
+
+- `API_SPREAD_BODY` in an Express controller: `createUser({ ...req.body.user })`.
+  Genuine mass assignment. Correct.
+- `API_EXCESSIVE_DATA` in another: `const result = await getArticles(req.query, id)`.
+  The rationale claimed `result` came from the HTTP request. It came from the
+  database; the request was an argument to the call.
+
+The second was a general defect — an untrusted source anywhere in a right-hand
+side was read as the origin of the assigned value, so every
+`const x = await something(req...)` confirmed. That is one of the most common
+lines in any web application.
+
+One audit of two confirmations, on three repositories, found a fault that six
+scans of the other corpora had not. That is the argument for this corpus
+existing.

--- a/benchmarks/applications/corpus.json
+++ b/benchmarks/applications/corpus.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.0",
+  "description": "Real applications, pinned by commit. The false-positive corpus is five libraries and two teaching fixtures; a library has no request handlers, so the investigation layer barely engages with it. These are the shapes users actually scan: HTTP services, an auth-heavy web app, an AI agent. The question here is not how much noise there is but whether the confirmations are right, which only reading them can answer.",
+  "applications": [
+    {
+      "id": "express-realworld",
+      "repo": "gothinkster/node-express-realworld-example-app",
+      "commit": "30b68e1e881462b2f4164ea09ab4c4f5699c7b0b",
+      "language": "typescript",
+      "shape": "Express + Prisma REST API"
+    },
+    {
+      "id": "hackathon-starter",
+      "repo": "sahat/hackathon-starter",
+      "commit": "73faf8c249d050da6d3ec6c7779fd2b6d3d88159",
+      "language": "javascript",
+      "shape": "Express web app, OAuth and many third-party integrations"
+    },
+    {
+      "id": "fastapi-fullstack",
+      "repo": "fastapi/full-stack-fastapi-template",
+      "commit": "486f054cc8d1aead59ec96cc0a16933d06c10e0d",
+      "language": "python",
+      "shape": "FastAPI + SQLModel service with auth"
+    }
+  ]
+}

--- a/benchmarks/applications/run.mjs
+++ b/benchmarks/applications/run.mjs
@@ -1,0 +1,127 @@
+/**
+ * Application corpus — list confirmations for a person to read
+ * =============================================================
+ *
+ * The other two benchmarks gate. This one does not, deliberately.
+ *
+ * A confirmation is the strongest thing this tool says: traced end to end,
+ * ranked above everything a model or a heuristic concluded. There is no
+ * automatic way to check one. Either someone opens the cited lines and agrees,
+ * or the claim stands unexamined.
+ *
+ * So the output here is a list of confirmations with their paths and citations,
+ * shaped for reading. The audit is the product; the exit code is always zero.
+ *
+ *   node benchmarks/applications/run.mjs --clone   fetch the pinned checkouts
+ *   node benchmarks/applications/run.mjs           list confirmations
+ *   node benchmarks/applications/run.mjs --json    the same, machine-readable
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..', '..');
+const corpus = JSON.parse(fs.readFileSync(path.join(here, 'corpus.json'), 'utf8'));
+const srcDir = path.join(here, 'corpus-src');
+const cli = path.join(repoRoot, 'cli', 'bin', 'ship-safe.js');
+
+const asJson = process.argv.includes('--json');
+const clone = process.argv.includes('--clone');
+
+function cloneCorpus() {
+  fs.mkdirSync(srcDir, { recursive: true });
+  for (const entry of corpus.applications) {
+    const dest = path.join(srcDir, entry.id);
+    if (fs.existsSync(dest)) continue;
+    process.stderr.write(`cloning ${entry.repo}\n`);
+    // The single pinned commit, so the corpus does not drift when upstream moves.
+    fs.mkdirSync(dest, { recursive: true });
+    execFileSync('git', ['init', '-q'], { cwd: dest });
+    execFileSync('git', ['remote', 'add', 'origin', `https://github.com/${entry.repo}.git`], { cwd: dest });
+    execFileSync('git', ['fetch', '-q', '--depth', '1', 'origin', entry.commit], { cwd: dest });
+    execFileSync('git', ['checkout', '-q', 'FETCH_HEAD'], { cwd: dest });
+  }
+}
+
+/** `investigate` exits 1 when anything is confirmed, which is the normal case here. */
+function investigate(dir) {
+  try {
+    return JSON.parse(execFileSync(process.execPath, [cli, 'investigate', dir, '--json'], {
+      encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, env: { ...process.env, NO_COLOR: '1' },
+    }));
+  } catch (error) {
+    if (error.stdout) {
+      try { return JSON.parse(error.stdout); } catch { /* fall through */ }
+    }
+    return null;
+  }
+}
+
+if (clone) cloneCorpus();
+
+const missing = corpus.applications
+  .filter((e) => !fs.existsSync(path.join(srcDir, e.id)))
+  .map((e) => e.id);
+
+if (missing.length > 0) {
+  process.stderr.write(`missing checkouts: ${missing.join(', ')}\nrun with --clone to fetch them\n`);
+  process.exit(1);
+}
+
+const applications = corpus.applications.map((entry) => {
+  const result = investigate(path.join(srcDir, entry.id));
+  if (!result) return { ...entry, error: 'investigate produced no output' };
+
+  const confirmed = result.findings
+    .filter((f) => f.verdict === 'confirmed')
+    .map((f) => ({
+      rule: f.rule,
+      file: f.file,
+      line: f.line,
+      severity: f.severity,
+      why: f.evidence?.claims?.at(-1)?.rationale || null,
+      decidedBy: f.evidence?.decidedBy || null,
+      path: (f.evidence?.claims?.at(-1)?.attackPath || []).map((step, i) => {
+        const citation = f.evidence.claims.at(-1).citations[i];
+        return citation ? `${step} — ${citation.file}:${citation.line}` : step;
+      }),
+    }));
+
+  return {
+    id: entry.id, repo: entry.repo, commit: entry.commit, shape: entry.shape,
+    counts: result.locationCounts,
+    findings: result.findingCount,
+    confirmed,
+  };
+});
+
+const report = {
+  schemaVersion: 1,
+  corpusVersion: corpus.version,
+  methodology: 'Confirmations from `ship-safe investigate` against pinned real applications. There is no gate: a confirmation can only be checked by reading the code it cites, so this lists them for that purpose.',
+  applications,
+};
+
+if (asJson) {
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+} else {
+  for (const app of applications) {
+    process.stdout.write(`\n${app.id}  (${app.shape})\n`);
+    process.stdout.write(`  ${app.findings} findings  ${JSON.stringify(app.counts)}\n`);
+    if (!app.confirmed?.length) {
+      process.stdout.write('  no confirmations to audit\n');
+      continue;
+    }
+    for (const c of app.confirmed) {
+      process.stdout.write(`\n  CONFIRMED  ${c.rule}  [${c.severity}]\n`);
+      process.stdout.write(`    ${c.file}:${c.line}   decided by ${c.decidedBy?.join(', ')}\n`);
+      process.stdout.write(`    why: ${c.why}\n`);
+      for (const step of c.path) process.stdout.write(`      - ${step}\n`);
+    }
+  }
+  process.stdout.write('\nRead the cited lines. A confirmation nobody has checked is a claim, not a finding.\n');
+}

--- a/cli/__tests__/absence-investigator.test.js
+++ b/cli/__tests__/absence-investigator.test.js
@@ -173,6 +173,38 @@ describe('absences that are local to a handler', () => {
     assert.equal(investigate('API_NO_VALIDATION', [file], { file, line: 4 }).claim.verdict, 'likely');
   });
 
+  it('does not let the tracer answer a rule about a configuration argument', () => {
+    // RAG_NO_RELEVANCE_THRESHOLD was confirmed against a real application on the
+    // grounds that the question came from the HTTP request — true, and unrelated.
+    // Whether a minimum similarity score is set is not a property of where the
+    // query came from. The line between what the tracer can settle and what it
+    // cannot is whether the absent control sits on the data path.
+    const file = write('rag.js', [
+      'exports.ask = async (req, res, vectorStore) => {',
+      "  const question = (req.body.question || '').slice(0, 500);",
+      '  const docs = await vectorStore.similaritySearch(question, 8);',
+      '  return res.json(docs);',
+      '};',
+    ]);
+
+    const { claim } = investigate('RAG_NO_RELEVANCE_THRESHOLD', [file], { file, line: 3 });
+    assert.equal(claim.verdict, 'likely', 'absent threshold is a gap, not a traced path');
+    assert.match(claim.rationale, /^A relevance threshold/, 'reads as a sentence, not "No a threshold"');
+  });
+
+  it('refutes when a threshold is set at the call', () => {
+    const file = write('rag-ok.js', [
+      'exports.ask = async (req, res, vectorStore) => {',
+      '  const question = req.body.question;',
+      '  const docs = await vectorStore.similaritySearch(question, 8, {',
+      '    scoreThreshold: 0.75,',
+      '  });',
+      '  return res.json(docs);',
+      '};',
+    ]);
+    assert.equal(investigate('RAG_NO_RELEVANCE_THRESHOLD', [file], { file, line: 3 }).claim.verdict, 'refuted');
+  });
+
   it('does not refute a finding with the line the finding is on', () => {
     // AGENT_TOOL_CALL_REPLAY matched `tool_calls` on the very line whose
     // handling of tool_calls it objected to, refuting itself 30 times on

--- a/cli/__tests__/dataflow-investigator.test.js
+++ b/cli/__tests__/dataflow-investigator.test.js
@@ -398,6 +398,54 @@ describe('assignment sinks', () => {
   });
 });
 
+describe('a call is not its arguments', () => {
+  // `const rows = await db.query(sql, req.params.id)` assigns what the database
+  // gave back. Reading the request inside the parentheses as the origin of
+  // `rows` confirms a finding about data the caller never controlled — and that
+  // shape is one of the most common lines in any web application. Found by
+  // auditing a confirmation against a real Express API.
+  it('does not treat a return value as its tainted argument', () => {
+    const file = source('opaque.js', [
+      'export async function handler(req, res, db) {',
+      '  const rows = await db.query("SELECT 1", req.params.id);',
+      '  res.json(rows);',
+      '}',
+    ]);
+    assert.equal(trace(file, 3, { rule: 'API_EXCESSIVE_DATA', category: 'api' }).claim, null,
+      'what the database returned is not what the caller sent');
+  });
+
+  it('still follows a transform that hands its argument back', () => {
+    const file = source('transform.js', [
+      'export function handler(req, res) {',
+      '  const parsed = JSON.parse(req.body.raw);',
+      '  res.json(parsed);',
+      '}',
+    ]);
+    assert.equal(trace(file, 3, { rule: 'API_EXCESSIVE_DATA', category: 'api' }).claim.verdict, 'confirmed');
+  });
+
+  it('still confirms when the source is the receiver, not an argument', () => {
+    const file = source('receiver.js', [
+      'export function handler(req, res) {',
+      '  const id = req.query.get("id");',
+      '  res.json(id);',
+      '}',
+    ]);
+    assert.equal(trace(file, 3, { rule: 'API_EXCESSIVE_DATA', category: 'api' }).claim.verdict, 'confirmed');
+  });
+
+  it('is unaffected for a plain member access', () => {
+    const file = source('member.js', [
+      'export function handler(req, res) {',
+      '  const id = req.params.id;',
+      '  res.json(id);',
+      '}',
+    ]);
+    assert.equal(trace(file, 3, { rule: 'API_EXCESSIVE_DATA', category: 'api' }).claim.verdict, 'confirmed');
+  });
+});
+
 describe('client-side sources', () => {
   it('confirms a value from the page URL', () => {
     const file = source('dom.js', [

--- a/cli/agents/absence-investigator.js
+++ b/cli/agents/absence-investigator.js
@@ -238,6 +238,29 @@ const ABSENCE_RULES = {
     precondition: [/\b(?:completions?|messages|chat)\.create\s*\(|\bgenerate_content\s*\(/i],
   },
 
+  /**
+   * Local. A relevance threshold is an argument to the retrieval call, so the
+   * answer is at the call site or nowhere.
+   *
+   * The data-flow tracer must not answer this one. It confirmed the rule against
+   * a real application on the grounds that the question came from the HTTP
+   * request -- true, and unrelated: whether a minimum similarity score is set is
+   * not a property of where the query came from. The absent control here is a
+   * configuration parameter, not a sanitizer on the path, which is the line
+   * between what the tracer can settle and what it cannot.
+   */
+  RAG_NO_RELEVANCE_THRESHOLD: {
+    what: 'a relevance threshold on the retrieval',
+    scope: 'local',
+    control: [
+      /\b(?:score|similarity|relevance|distance)_?[Tt]hreshold\b\s*[:=]/,
+      /\bmin(?:_|)(?:score|similarity|relevance)\b\s*[:=]/i,
+      /\bfilter\s*[:=]/,
+      /\.filter\s*\(/,
+    ],
+    precondition: [/./],
+  },
+
   /** Local: the confirmation gate sits at the dispatch it gates. */
   AGENT_TOOL_NO_CONFIRMATION: {
     what: 'a confirmation step before the tool runs',
@@ -367,7 +390,7 @@ export class AbsenceInvestigator {
       attachEvidence(finding, createClaim({
         source: 'presence',
         verdict: 'likely',
-        rationale: `No ${spec.what} was found anywhere in this project, so the gap is not local to this file. It may still be provided outside the codebase — a proxy, gateway, or platform control this pass cannot see.`,
+        rationale: `${capitalize(spec.what)} was not found anywhere in this project, so the gap is not local to this file. It may still be provided outside the codebase — a proxy, gateway, or platform control this pass cannot see.`,
         citations: [{ file: precondition.file, line: precondition.line, excerpt: precondition.excerpt }],
         attackPath: [`the code this protects is at ${path.relative(rootPath, precondition.file)}:${precondition.line}`],
       }));
@@ -430,7 +453,7 @@ export class AbsenceInvestigator {
     attachEvidence(finding, createClaim({
       source: 'presence',
       verdict: 'likely',
-      rationale: `No ${spec.what} was found in this file or in what it calls. It may still be set further down the call chain than this pass follows.`,
+      rationale: `${capitalize(spec.what)} was not found in this file or in what it calls. It may still be set further down the call chain than this pass follows.`,
       citations: [{ file: finding.file, line: finding.line }],
     }));
   }
@@ -502,7 +525,7 @@ export class AbsenceInvestigator {
     attachEvidence(finding, createClaim({
       source: 'presence',
       verdict: 'likely',
-      rationale: `No ${spec.what} was found in the ${LOCAL_WINDOW} lines that follow, where it would be.`,
+      rationale: `${capitalize(spec.what)} was not found in the ${LOCAL_WINDOW} lines that follow, where it would be.`,
       citations: [{ file: finding.file, line: finding.line }],
     }));
   }

--- a/cli/agents/dataflow-investigator.js
+++ b/cli/agents/dataflow-investigator.js
@@ -378,7 +378,19 @@ export class DataflowInvestigator {
         };
       }
 
+      // A call's return value is not its arguments. `const rows = await
+      // db.query(sql, req.params.id)` assigns what the database gave back, and
+      // reading the request inside the parentheses as the origin of `rows`
+      // confirms a finding about data the caller never controlled. That shape
+      // -- `const x = await something(req...)` -- is one of the most common
+      // lines in any web application.
+      //
+      // Transforms are the exception: JSON.parse and its neighbours return
+      // their input in another form, so taint really does pass through them.
       const source = matchAny(lang.sources, rhs);
+      if (source && sourceOnlyInsideOpaqueCall(rhs, source.re)) {
+        return null;
+      }
       if (source) {
         return {
           verdict: source.ceiling || 'confirmed',
@@ -569,6 +581,35 @@ function dedupeHops(hops) {
   return hops
     .filter((hop) => (seen.has(hop.line) ? false : seen.add(hop.line)))
     .sort((a, b) => a.line - b.line);
+}
+
+/**
+ * Calls whose return value derives from their arguments. Everything else is a
+ * barrier this pass cannot see through, and a barrier it cannot see through is
+ * not a path it may confirm.
+ */
+const PASSTHROUGH_CALL = /\b(?:JSON\.parse|decodeURI(?:Component)?|unescape|atob|Buffer\.from|String|toString|trim|slice|substring|substr|split|join|concat|replace|toLowerCase|toUpperCase|normalize|json|loads|str)\s*$/;
+
+/**
+ * True when the only place an untrusted source appears is inside the arguments
+ * of a call whose return value is what gets assigned.
+ *
+ * The source in `req.query.get('id')` is the receiver, and the call returns
+ * part of it, so that still counts as a path. The source in
+ * `db.query(sql, req.params.id)` is an argument, and what comes back is the
+ * database's answer.
+ */
+function sourceOnlyInsideOpaqueCall(rhs, sourceRe) {
+  const call = String(rhs).match(/^\s*(?:await\s+)?([\w$.[\]'"]+)\s*\(/);
+  if (!call) return false;
+
+  const callee = call[1];
+  // The source is part of what is being called, not what is passed to it.
+  if (sourceRe.test(callee)) return false;
+  // A transform hands its argument back in another shape.
+  if (PASSTHROUGH_CALL.test(callee)) return false;
+
+  return true;
 }
 
 function matchAny(patterns, text) {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "benchmark:verdicts": "node benchmarks/verdicts.mjs",
     "benchmark:verdicts:write": "node benchmarks/verdicts.mjs --write",
     "benchmark:fp": "node benchmarks/false-positives/run.mjs",
+    "benchmark:apps": "node benchmarks/applications/run.mjs",
     "benchmark:fp:write": "node benchmarks/false-positives/run.mjs --write",
     "benchmark:corpus:write": "node benchmarks/run.mjs --write",
     "benchmark:fp": "node benchmarks/false-positives/run.mjs",


### PR DESCRIPTION
The false-positive corpus is five libraries and two teaching fixtures. A library has no request handlers, so the investigation layer barely engages with it — scanning express produces twenty findings and no traced paths at all.

This adds three real applications, pinned by commit, and audits what the tool says about them. The first audit found two defects.

## Audit

| application | confirmation | verdict |
|---|---|---|
| express-realworld | `API_SPREAD_BODY` | **correct** — `createUser({ ...req.body.user })` |
| express-realworld | `API_EXCESSIVE_DATA` | **false** |
| hackathon-starter | `RAG_NO_RELEVANCE_THRESHOLD` | **false** |
| fastapi-fullstack | none | — |

One of four survived.

## Fix 1 — a call's return value is not its arguments

```js
const result = await getArticles(req.query, req.auth?.user?.id);
```

The rationale said *"result is assigned from the HTTP request."* It was assigned what the database returned; the request was an argument.

An untrusted source appearing anywhere in a right-hand side was read as the origin of the assigned value, so every `const x = await something(req...)` confirmed — one of the most common lines in any web application.

A blanket fix would cost real detections: `JSON.parse(xhr.responseText)` genuinely does return its argument in another form. The distinction is whether the call passes its argument through. Transforms still trace; an unknown call is a barrier, and a barrier this pass cannot see through is not a path it may confirm. A source that is the *receiver* rather than an argument — `req.query.get('id')` — still counts.

## Fix 2 — the tracer does not answer rules about configuration

```js
const question = (req.body.question || '').slice(0, 500);
const docs = await vectorStore.similaritySearch(question, 8);
```

`RAG_NO_RELEVANCE_THRESHOLD` was confirmed because the question came from the request. True, and unrelated: whether a minimum similarity score is set is not a property of where the query came from. The rule's premise was being reported as evidence for it — the third instance of a pattern already fixed twice.

Surveying every absence-named rule the tracer confirms found exactly two, and they are not the same case. `LLM_PROMPT_INJECTION_NO_SANITIZE` is missing a sanitizer **on the data path**, which is the taint question. `RAG_NO_RELEVANCE_THRESHOLD` is missing **an argument to a call**.

So the line is not the rule's name — `VIBE_NO_PARAMETERIZED_QUERY` is absence-named and genuinely taint-shaped — but whether the absent control sits on the path the value takes. That criterion is now stated rather than applied case by case.

## No regressions

NodeGoat holds at 7 confirmations, hermes-agent at 3, express at 0. Only the false ones went away.

## The corpus has no gate

The other benchmarks pass or fail. This one prints confirmations with their paths and citations and exits zero, because a confirmation can only be checked by a person reading the cited lines. The audit is the output.

849 tests, both gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)