### PR TITLE
release: 9.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,52 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [9.9.0] - 2026-09-01
+
+### Added
+- **`CICD_AI_ACTION_UNPINNED`** — flags an AI or agent action in a workflow that
+  is not pinned to a full commit SHA. Severity rises to critical when the
+  workflow also carries broad write permissions or runs on
+  `pull_request_target`; permissions are read per job, so a write grant in one
+  job does not implicate an action in another. Thanks to **@xianjianlf2**.
+- **Three Hermes plugin manifest rules** — a plugin with no author or source, a
+  `register()` that wires a hook the manifest does not declare, and a plugin
+  that binds a network listener without saying so. A Hermes plugin loads with
+  full agent privileges, and the boundary is an operator reading the manifest
+  before install. Thanks to **@AlvaroBalbin**.
+- **Application corpus** — three real applications pinned by commit: an Express
+  API, an auth-heavy Express app, a FastAPI service. The false-positive corpus
+  is five libraries and two teaching fixtures, and a library has no request
+  handlers, so the investigation layer barely engages with it. This corpus has
+  no gate: it prints confirmations with their citations for a person to read,
+  because a confirmation can only be checked by reading the code it cites.
+- **Documentation for custom agent plugins.** Thanks to **@AlvaroBalbin**.
+
+### Fixed
+- **A call's return value read as its tainted argument** — `const result = await
+  getArticles(req.query, id)` was confirmed on the grounds that `result` came
+  from the HTTP request. It came from the database; the request was an argument.
+  Every `const x = await something(req...)` confirmed, which is one of the most
+  common lines in any web application. Transforms that hand their argument back,
+  such as `JSON.parse`, still trace; an unknown call is a barrier, and a barrier
+  this pass cannot see through is not a path it may confirm.
+- **A rule about configuration answered by the tracer** —
+  `RAG_NO_RELEVANCE_THRESHOLD` was confirmed because the query came from the
+  request. True, and unrelated: whether a minimum similarity score is set is not
+  a property of where the query came from. The line is whether the absent
+  control sits on the path the value takes.
+- **Markdown examples scanned as deployed source** — documentation is both prose
+  and a container for code examples, and treating every token in it as shipped
+  code made ordinary security guidance look like a vulnerability. Fenced blocks
+  are now recognised by the CommonMark rules rather than by looking for a bare
+  fence substring.
+
+Both confirmation defects were found by auditing what the tool said about real
+applications, one at a time, by hand. Six runs of the existing corpora had not
+surfaced either: they measure how much the tool says, not whether it is true.
+
+## [9.8.0] - 2026-09-01
+
 ### Added
 - **Absence rules can follow a call one hop** — `AGENT_NO_COST_LIMIT` and
   `AGENT_NO_AUDIT_LOG` are answerable again. Both say the file sets no ceiling or
@@ -17,10 +63,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   site inherits it by calling that. The search now covers the file and the
   bodies of the functions it calls, and stops there — a control two hops away
   costs an unresolved finding rather than a wrong one.
-
-## [9.8.0] - 2026-09-01
-
-### Added
 - **Evidence schema on every finding** — each investigation pass now records a
   claim (source, verdict, rationale, citations) instead of writing its own
   ad-hoc field, and the finding's verdict is derived from those claims by fixed

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: asamassekou10/ship-safe@v9.8.0
+      - uses: asamassekou10/ship-safe@v9.9.0
         with:
           fail-on: high
           inline: true

--- a/cli/__tests__/ai-action-pinning.test.js
+++ b/cli/__tests__/ai-action-pinning.test.js
@@ -74,7 +74,11 @@ jobs:
 
     const [finding] = aiActionFindings(findings);
     assert.ok(finding, 'an unpinned AI action is still a supply-chain risk');
-    assert.strictEqual(finding.severity, 'high');
+    // Read scoping lowers this to medium rather than silencing it. The rule as
+    // first written called it high; an independent implementation of the same
+    // rule declined to report it at all. Neither is unreasonable, and severity
+    // is the mechanism for "real but less urgent".
+    assert.strictEqual(finding.severity, 'medium');
   });
 
   test('stays quiet for a pinned AI action with read-only permissions', async () => {
@@ -103,7 +107,10 @@ jobs:
 
     const [finding] = aiActionFindings(findings);
     assert.ok(finding);
-    assert.strictEqual(finding.severity, 'high');
+    // What this test is about is that the release job's write permission does
+    // not reach the review job. Medium rather than critical demonstrates that
+    // as well as high did; the review job is itself read-scoped.
+    assert.strictEqual(finding.severity, 'medium');
   });
 
   test('does not classify a non-AI action or a comment as an AI step', async () => {

--- a/cli/agents/cicd-scanner.js
+++ b/cli/agents/cicd-scanner.js
@@ -439,6 +439,21 @@ const FULL_COMMIT_SHA_RE = /^[a-f0-9]{40}$/i;
 const BROAD_AI_ACTION_PERMISSION_RE =
   /permissions\s*:\s*write-all\b|(?:contents|pull-requests|actions)\s*:\s*write\b/i;
 
+/**
+ * Permissions narrowed to read. From AlvaroBalbin's independent implementation
+ * of this rule (#176), which treated read scoping as reason not to report at
+ * all.
+ *
+ * That goes further than this rule is willing to: an unpinned action still runs
+ * attacker-changeable code inside the workflow, and can read repository content
+ * and every secret in scope even with no write access. But it is genuinely less
+ * exposed than one that can push, and saying so is what severity is for. The
+ * disagreement between the two implementations was about whether to suppress;
+ * expressing it as a rung keeps both positions.
+ */
+const READ_SCOPED_AI_ACTION_PERMISSION_RE =
+  /permissions\s*:\s*(?:read-all\b|[\s\S]{0,280}\bcontents\s*:\s*read\b)/i;
+
 function workflowAndJobScopes(lines, lineIndex) {
   const jobsIndex = lines.findIndex(line => /^\s*jobs\s*:\s*(?:#.*)?$/.test(line));
   const workflow = jobsIndex >= 0 ? lines.slice(0, jobsIndex).join('\n') : lines.join('\n');
@@ -788,6 +803,10 @@ export class CICDScanner extends BaseAgent {
         BROAD_AI_ACTION_PERMISSION_RE.test(scopes.workflow) ||
         BROAD_AI_ACTION_PERMISSION_RE.test(scopes.job);
       const elevated = broadPermissions || privilegedEvent;
+      const readScoped = !elevated && (
+        READ_SCOPED_AI_ACTION_PERMISSION_RE.test(scopes.job) ||
+        READ_SCOPED_AI_ACTION_PERMISSION_RE.test(scopes.workflow)
+      );
       const riskContext = [
         broadPermissions ? 'broad write permissions' : null,
         privilegedEvent ? '`pull_request_target`' : null,
@@ -796,14 +815,15 @@ export class CICDScanner extends BaseAgent {
       findings.push(createFinding({
         file,
         line: index + 1,
-        severity: elevated ? 'critical' : 'high',
+        severity: elevated ? 'critical' : readScoped ? 'medium' : 'high',
         category: this.category,
         rule: 'CICD_AI_ACTION_UNPINNED',
         title: 'CI/CD: AI action uses an unpinned reference',
         description:
           `The AI/agent workflow step uses \`${action}\`, which is not pinned to a full commit SHA. ` +
           'These actions can read prompts, repository content, and pull-request diffs; an upstream ref change can therefore alter code that runs inside this workflow without a reviewed repository change.' +
-          (riskContext ? ` The exposure is critical because the workflow also has ${riskContext}.` : ''),
+          (riskContext ? ` The exposure is critical because the workflow also has ${riskContext}.` : '') +
+          (readScoped ? ' Permissions here are scoped to read, which limits the damage without removing it: the action still runs inside the workflow and can read repository content and any secret in scope.' : ''),
         matched: action.slice(0, 180),
         confidence: 'high',
         cwe: 'CWE-829',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ship-safe",
-  "version": "9.8.0",
+  "version": "9.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ship-safe",
-      "version": "9.8.0",
+      "version": "9.9.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-safe",
-  "version": "9.8.0",
+  "version": "9.9.0",
   "description": "AI-powered multi-agent security platform. 29 agents scan 80+ attack classes including AI integration supply chain (Vercel-class attacks), Hermes Agent deployment scanning (ASI-01–ASI-10), tool registry poisoning, function-call injection, skill permission drift, and agent attestation.",
   "main": "cli/index.js",
   "bin": {


### PR DESCRIPTION
A minor rather than a patch. I had called this 9.8.1 in conversation, which was wrong: #160 and #175 each add detection rules, and new rules are a feature.

## Added

- **`CICD_AI_ACTION_UNPINNED`** (@xianjianlf2) — an AI or agent action not pinned to a full commit SHA. Critical when the workflow also carries broad write permissions or runs on `pull_request_target`; permissions are read per job, so a write grant in one job does not implicate an action in another.
- **Three Hermes plugin manifest rules** (@AlvaroBalbin) — no author or source, a `register()` wiring a hook the manifest does not declare, a plugin binding a network listener without saying so.
- **Application corpus** — three real applications pinned by commit. No gate: it prints confirmations with their citations for a person to read.
- **Custom agent plugins documentation** (@AlvaroBalbin).

## Fixed

- **A call's return value read as its tainted argument.** `const result = await getArticles(req.query, id)` was confirmed because `result` supposedly came from the HTTP request. It came from the database. Every `const x = await something(req...)` confirmed — one of the most common lines in any web application.
- **A rule about configuration answered by the tracer.** `RAG_NO_RELEVANCE_THRESHOLD` was confirmed because the query came from the request. Whether a minimum similarity score is set is not a property of where the query came from.
- **Markdown examples scanned as deployed source.** Fenced blocks are now recognised by the CommonMark rules rather than a bare fence substring.

## How the two confirmation defects were found

By auditing what the tool said about three real applications, one confirmation at a time, by hand. **One of four survived.**

Six runs of the existing corpora had surfaced neither, because they measure how much the tool says rather than whether it is true. That gap is why the application corpus exists and why it has no pass/fail gate.

## Also

Corrects the 9.8.0 changelog: the absence-wrapper entry sat under `[Unreleased]` while shipping inside 9.8.0, since the release was cut after it merged.

869 tests, lint clean, all three benchmark gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)