### PR TITLE
docs: pin Hermes 10.0 coverage baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,10 +419,11 @@ they beat us: **[docs/comparison.md](docs/comparison.md)**
 
 ## What's Next
 
-**10.0 is Hermes Agent coverage.** Ship Safe already scans Hermes deployments,
-but against v0.13.0 while Hermes is on v0.20.0 — the ACP adapter, TUI gateway,
-serverless terminal backends, cron blueprints and plugin manifests all shipped
-in between with no coverage.
+**10.0 is verified Hermes Agent coverage.** The baseline is Hermes v0.21.0 at
+an immutable upstream commit. Existing plugin and adapter checks are partial;
+terminal posture, ACP/TUI, current cron lifecycle, and credential reachability
+remain explicit work rather than implied coverage. See the
+[coverage matrix](docs/hermes-coverage-matrix.md).
 
 See the [roadmap](./ROADMAP.md) for what is planned and what is deliberately
 not, and the [10.0 milestone](https://github.com/asamassekou10/ship-safe/milestone/1)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,9 +32,12 @@ Full detail in the [changelog](CHANGELOG.md) and the
 
 ## Now — 10.0, Hermes Agent coverage
 
-Ship Safe already scans Hermes Agent deployments, but the agent that does it
-was written against Hermes **v0.13.0**. Hermes is on **v0.20.0**. Everything
-below arrived in between and has no coverage today.
+Ship Safe 10.0 targets Hermes Agent **v0.21.0** at pinned commit
+[`29112bef099274229cadff79cdff7bf7b99c4b77`](https://github.com/NousResearch/hermes-agent/commit/29112bef099274229cadff79cdff7bf7b99c4b77).
+Some older rules overlap the current surface, but overlap is not verified
+coverage. The [coverage matrix](docs/hermes-coverage-matrix.md) records each
+surface as partial or uncovered until its current paths and safe counterpart
+are tested.
 
 **Note on scope.** This is coverage we build for our users who run Hermes. It
 is not coordinated with Nous Research, and nothing here should be read as an
@@ -42,14 +45,14 @@ endorsement by them.
 
 ### The surfaces
 
-| area | what is uncovered |
+| area | 10.0 status |
 |---|---|
-| plugin manifests | `plugins/*/plugin.yaml`, hook declarations, undeclared network listeners |
-| external surfaces | gateway platform adapters, allowlist handling, non-loopback binds |
-| terminal backends | seven of them, from local to Docker to cloud sandboxes |
-| ACP and TUI gateway | editor and local-IPC surfaces with their own permission models |
-| cron | blueprints and lifecycle guard |
-| credential scoping | environment passthrough to lower-trust components |
+| plugin manifests | partial: provenance, hook, and listener checks shipped; install/discovery review remains |
+| external surfaces | partial: adapter fail-open detection shipped; shared auth, relay, HTTP, and bind scope remain |
+| terminal backends | uncovered: seven backends from local to container, remote, and cloud sandboxes |
+| ACP and TUI gateway | uncovered: editor and local-IPC surfaces with their own permission models |
+| cron | partial: the older generic rule is not calibrated to the current Python lifecycle |
+| credential scoping | partial: generic exposure rules do not prove credential reachability or use |
 
 ### Two ideas shaping the work
 
@@ -72,9 +75,10 @@ matter how clever the regex.
   Rules can declare `langs: ['js']` and stop being applied to Ruby. The
   mechanism shipped in 9.7.0; nine agents still need converting, one per pull
   request. Good first issues.
-- **A2A agent cards** ([#103](https://github.com/asamassekou10/ship-safe/issues/103))
-  and **MCP OAuth** ([#104](https://github.com/asamassekou10/ship-safe/issues/104)).
-  Real 2026 attack surfaces with zero coverage.
+- **MCP OAuth** ([#104](https://github.com/asamassekou10/ship-safe/issues/104))
+  shipped in 9.7.5. **A2A agent cards**
+  ([#103](https://github.com/asamassekou10/ship-safe/issues/103)) moved to a
+  post-10.0 milestone so this release keeps one verifiable upstream target.
 
 ---
 
@@ -91,8 +95,9 @@ Saying this out loud so nobody builds it and gets turned away.
   not finished.
 - **Auto-fixing security findings without review.** `agent` and `fix` propose
   and require approval. That stays.
-- **Runtime or agent-side enforcement.** Ship Safe is a static scanner. It
-  reports; it does not block at runtime.
+- **Runtime or agent-side containment.** Ship Safe detects and investigates
+  repository and configuration evidence. CI can gate on its verdicts, but the
+  report itself is not an OS isolation boundary.
 
 ---
 

--- a/cli/__tests__/fixtures/hermes-v0.21.0-baseline.json
+++ b/cli/__tests__/fixtures/hermes-v0.21.0-baseline.json
@@ -1,0 +1,14 @@
+{
+  "release": "v0.21.0",
+  "tag": "v2026.8.31",
+  "commit": "29112bef099274229cadff79cdff7bf7b99c4b77",
+  "representativePaths": {
+    "plugin-manifests": "plugins/security-guidance/plugin.yaml",
+    "network-adapters": "gateway/platforms/api_server.py",
+    "terminal-backends": "tools/environments/docker.py",
+    "acp": "acp_adapter/server.py",
+    "tui-gateway": "tui_gateway/server.py",
+    "cron": "cron/lifecycle_guard.py",
+    "credential-scoping": "tools/environments/local.py"
+  }
+}

--- a/cli/__tests__/hermes-baseline.test.js
+++ b/cli/__tests__/hermes-baseline.test.js
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, '../..');
+const baselinePath = path.join(root, 'cli/data/hermes-baseline.json');
+const fixturePath = path.join(root, 'cli/__tests__/fixtures/hermes-v0.21.0-baseline.json');
+const matrixPath = path.join(root, 'docs/hermes-coverage-matrix.md');
+const agentPath = path.join(root, 'cli/agents/hermes-security-agent.js');
+
+const baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8'));
+const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+const matrix = fs.readFileSync(matrixPath, 'utf8');
+const agent = fs.readFileSync(agentPath, 'utf8');
+
+test('Hermes baseline pins an immutable upstream release', () => {
+  assert.equal(baseline.project, 'NousResearch/hermes-agent');
+  assert.equal(baseline.release, 'v0.21.0');
+  assert.equal(baseline.tag, 'v2026.8.31');
+  assert.match(baseline.commit, /^[a-f0-9]{40}$/);
+  assert.match(baseline.releasedAt, /^\d{4}-\d{2}-\d{2}T/);
+  assert.doesNotMatch(baseline.commit, /^(?:main|master|latest)$/);
+});
+
+test('coverage matrix accounts for every 10.0 Hermes surface', () => {
+  const expected = [
+    'plugin-manifests',
+    'network-adapters',
+    'terminal-backends',
+    'acp',
+    'tui-gateway',
+    'cron',
+    'credential-scoping',
+  ];
+  assert.deepEqual(baseline.surfaces.map((surface) => surface.id), expected);
+
+  for (const surface of baseline.surfaces) {
+    assert.match(surface.status, /^(?:covered|partial|uncovered)$/);
+    assert.ok(surface.upstreamPaths.length > 0, `${surface.id} needs upstream paths`);
+    assert.ok(surface.boundary.length > 0, `${surface.id} needs a boundary`);
+    assert.ok(surface.limitations.length > 0, `${surface.id} needs limitations`);
+  }
+});
+
+test('baseline only claims rules that exist and documentation pins the same snapshot', () => {
+  for (const rule of baseline.surfaces.flatMap((surface) => surface.rules)) {
+    assert.match(agent, new RegExp(`['\\"]${rule}['\\"]`), `${rule} must exist`);
+  }
+
+  for (const value of [baseline.release, baseline.tag, baseline.commit]) {
+    assert.ok(matrix.includes(value), `matrix must include ${value}`);
+  }
+  assert.match(matrix, /never automatic tag following/i);
+});
+
+test('the upstream fixture and published baseline cannot drift apart', () => {
+  for (const field of ['release', 'tag', 'commit']) {
+    assert.equal(fixture[field], baseline[field]);
+  }
+
+  assert.deepEqual(
+    Object.keys(fixture.representativePaths),
+    baseline.surfaces.map((surface) => surface.id),
+  );
+  for (const representativePath of Object.values(fixture.representativePaths)) {
+    assert.ok(representativePath.length > 0);
+    assert.doesNotMatch(representativePath, /^(?:main|latest)(?:\/|$)/);
+  }
+});

--- a/cli/data/hermes-baseline.json
+++ b/cli/data/hermes-baseline.json
@@ -1,0 +1,68 @@
+{
+  "schemaVersion": 1,
+  "project": "NousResearch/hermes-agent",
+  "release": "v0.21.0",
+  "tag": "v2026.8.31",
+  "commit": "29112bef099274229cadff79cdff7bf7b99c4b77",
+  "releasedAt": "2026-08-31T19:29:49Z",
+  "auditedAt": "2026-09-04",
+  "securityPolicyPath": "SECURITY.md",
+  "surfaces": [
+    {
+      "id": "plugin-manifests",
+      "status": "partial",
+      "upstreamPaths": ["plugins/**/plugin.yaml", "hermes_cli/plugins.py"],
+      "boundary": "operator review before in-process loading",
+      "rules": ["HERMES_PLUGIN_NO_PROVENANCE", "HERMES_PLUGIN_UNDECLARED_HOOK", "HERMES_PLUGIN_NETWORK_LISTENER_UNDECLARED"],
+      "limitations": "Manifest provenance, hook drift, and undeclared listeners are covered as hygiene. Install and discovery paths that hide code from operator review are not modeled."
+    },
+    {
+      "id": "network-adapters",
+      "status": "partial",
+      "upstreamPaths": ["gateway/platforms/**", "plugins/platforms/**", "gateway/platform_registry.py"],
+      "boundary": "operator-configured caller authorization at each network surface",
+      "rules": ["HERMES_ADAPTER_ALLOWLIST_FAIL_OPEN"],
+      "limitations": "Python adapter functions are checked for fail-open dispatch. Shared authorization, relay, HTTP plugin, and non-loopback exposure paths are not comprehensively modeled."
+    },
+    {
+      "id": "terminal-backends",
+      "status": "uncovered",
+      "upstreamPaths": ["tools/environments/**", "tools/terminal_tool.py", "hermes_cli/setup.py"],
+      "boundary": "OS isolation for shell and file operations only",
+      "rules": [],
+      "limitations": "Ship Safe does not yet parse backend posture or verify which operations remain in the host process across local, Docker, Modal, SSH, Daytona, Vercel Sandbox, and Singularity."
+    },
+    {
+      "id": "acp",
+      "status": "uncovered",
+      "upstreamPaths": ["acp_adapter/**"],
+      "boundary": "host-user access control for local editor IPC",
+      "rules": [],
+      "limitations": "ACP is deliberately excluded from the network-adapter rule and has no dedicated local-IPC exposure analysis."
+    },
+    {
+      "id": "tui-gateway",
+      "status": "uncovered",
+      "upstreamPaths": ["tui_gateway/**", "ui-tui/**"],
+      "boundary": "host-user access control for local JSON-RPC IPC",
+      "rules": [],
+      "limitations": "Ship Safe does not yet model TUI gateway transport, bind scope, session routing, or reachable tool capabilities."
+    },
+    {
+      "id": "cron",
+      "status": "partial",
+      "upstreamPaths": ["cron/**", "tools/cronjob_tools.py"],
+      "boundary": "job identity, lifecycle, subprocess environment, and reachable effects",
+      "rules": ["HERMES_CRON_SKILL_INJECTION"],
+      "limitations": "The existing detector covers a generic scheduled skill-to-prompt shape but is not calibrated to Hermes v0.21.0's Python cron lifecycle, scripts, retries, or retained permissions."
+    },
+    {
+      "id": "credential-scoping",
+      "status": "partial",
+      "upstreamPaths": ["tools/environments/local.py", "tools/code_execution_tool.py", "tools/credential_files.py", "cron/scheduler.py"],
+      "boundary": "filtered credential flow into lower-trust subprocesses and external effects",
+      "rules": ["HERMES_SUB_AGENT_CREDENTIAL_FORWARD", "HERMES_XURL_TOKEN_STORE_EXPOSURE"],
+      "limitations": "Generic forwarding and credential-store exposure are covered. Ship Safe does not yet prove that a configured credential reaches and is consumed by a lower-trust component."
+    }
+  ]
+}

--- a/docs/hermes-coverage-matrix.md
+++ b/docs/hermes-coverage-matrix.md
@@ -1,0 +1,73 @@
+# Hermes Agent coverage baseline
+
+Ship Safe 10.0 targets one immutable upstream snapshot:
+
+- release: **Hermes Agent v0.21.0**
+- tag: [`v2026.8.31`](https://github.com/NousResearch/hermes-agent/releases/tag/v2026.8.31)
+- commit: [`29112bef099274229cadff79cdff7bf7b99c4b77`](https://github.com/NousResearch/hermes-agent/commit/29112bef099274229cadff79cdff7bf7b99c4b77)
+- release published: **2026-08-31 19:29:49 UTC**
+- baseline audited: **2026-09-04**
+
+The tag and commit were resolved through the GitHub API. GitHub reports both
+the annotated tag object and its commit as unsigned, so the commit SHA is the
+identity Ship Safe pins. We do not follow `main` or a mutable release label.
+
+The machine-readable copy is
+[`cli/data/hermes-baseline.json`](../cli/data/hermes-baseline.json). Hermes's
+policy at the pinned commit remains authoritative:
+[`SECURITY.md`](https://github.com/NousResearch/hermes-agent/blob/29112bef099274229cadff79cdff7bf7b99c4b77/SECURITY.md).
+The test fixture
+[`hermes-v0.21.0-baseline.json`](../cli/__tests__/fixtures/hermes-v0.21.0-baseline.json)
+pins representative paths from the same snapshot.
+
+## Status definitions
+
+- **Covered** means a detector is calibrated to this pinned surface and has a
+  vulnerable fixture plus a safely constrained counterpart.
+- **Partial** means Ship Safe has relevant detection, but it does not model the
+  complete current surface or cannot support every implied verdict.
+- **Uncovered** means there is no dedicated detector for the surface.
+
+These labels describe Ship Safe's coverage, not Hermes Agent's security.
+
+## Coverage matrix
+
+| Surface | Upstream implementation | Boundary in the upstream model | Ship Safe status | Current detection | Known limitation / next issue |
+|---|---|---|---|---|---|
+| Plugin manifests | `plugins/**/plugin.yaml`, `hermes_cli/plugins.py` | Operator review before code loads into the agent process | **Partial** | Provenance, undeclared hooks, undeclared listeners | Install/discovery paths that hide code from review are not modeled; revalidate rules against the 101 manifests in this release |
+| Network adapters | `gateway/platforms/**`, `plugins/platforms/**`, `gateway/platform_registry.py` | Caller authorization at every network surface | **Partial** | `HERMES_ADAPTER_ALLOWLIST_FAIL_OPEN` checks Python adapter dispatch | Shared authorization, relay, HTTP-plugin, and bind-scope paths are incomplete |
+| Terminal backends | `tools/environments/**`, `tools/terminal_tool.py`, `hermes_cli/setup.py` | OS isolation for shell and file operations only | **Uncovered** | None | Model local, Docker, Modal, SSH, Daytona, Vercel Sandbox, and Singularity in #185 |
+| ACP | `acp_adapter/**` | Host-user controls for editor IPC | **Uncovered** | Explicitly excluded from the network-adapter rule | Model transport, exposure, caller, and reachable effects in #186 |
+| TUI gateway | `tui_gateway/**`, `ui-tui/**` | Host-user controls for local JSON-RPC IPC | **Uncovered** | None | Model transport, bind scope, session routing, and capabilities in #186 |
+| Cron | `cron/**`, `tools/cronjob_tools.py` | Job identity, lifecycle, subprocess environment, and effects | **Partial** | Generic scheduled skill-to-prompt detection | Existing rule is not calibrated to the current Python scheduler, lifecycle guard, retries, or retained authority; #187 |
+| Credential scoping | `tools/environments/local.py`, `tools/code_execution_tool.py`, `tools/credential_files.py`, `cron/scheduler.py` | Filtered flow into lower-trust subprocesses; not containment | **Partial** | Generic sub-agent forwarding and credential-store exposure | Environment presence does not prove reachability or use; build the source-to-consumer-to-effect chain in #188 |
+
+No surface is marked fully covered at this baseline. That is deliberate: the
+matrix records what the current implementation can prove, not what its rule
+names suggest.
+
+## Boundary interpretation
+
+Hermes's only containment boundary against an adversarial model is the OS.
+Terminal-backend isolation confines shell and file operations, but not Python
+code execution, MCP subprocesses, plugins, hooks, or skills running in the
+agent process. Whole-process wrapping can contain the complete process tree.
+
+For local IPC, loopback binds and OS file permissions are the authorization
+boundary. For network adapters, an operator-configured allowlist must fail
+closed. A documented break-glass setting or an explicitly selected local
+backend is not a vulnerability on its own.
+
+## Maintaining the baseline
+
+Baseline updates are reviewed changes, never automatic tag following:
+
+1. Query the latest GitHub release and resolve its tag to a full commit SHA.
+2. Review the release notes, `SECURITY.md`, and the seven surface groups above.
+3. Update the JSON baseline and this document in the same pull request.
+4. Re-run the baseline contract test and relevant positive/safe fixtures.
+5. Change a matrix status only when the detector is calibrated to the new
+   snapshot and its evidence supports the advertised verdict.
+
+Version drift is therefore visible as a code review. A newer Hermes release
+does not silently expand Ship Safe's coverage claim.

--- a/docs/hermes-security-model.md
+++ b/docs/hermes-security-model.md
@@ -18,8 +18,10 @@ two disagree, theirs wins and this file needs updating.
 That is a direct quote, and the emphasis is theirs. It has two consequences for
 us.
 
-**We are not containment either.** Ship Safe is a static scanner. Framing a
-finding as if it prevents an attack contradicts their model and ours.
+**We are not containment either.** Ship Safe investigates repository and
+configuration evidence; it does not create an isolation boundary. Framing a
+finding as if the report itself prevents an attack contradicts their model and
+ours.
 
 **In-process heuristics are not boundaries.** Their approval gate, output
 redaction, and Skills Guard are review aids by design. A finding that says "the
@@ -90,8 +92,12 @@ Hermes operator trusts and one they close.
 
 ## Version drift
 
-Rules should note the Hermes version they were written against. `HermesSecurityAgent`
-targeted v0.13.0 for seven minor versions, during which the ACP adapter, the TUI
-gateway, serverless terminal backends, cron blueprints and the `plugin.yaml`
-manifest format all shipped uncovered. Hermes moves weekly. Pin your fixtures to
-a commit and say which one.
+Ship Safe 10.0 is baselined against Hermes Agent v0.21.0 at commit
+`29112bef099274229cadff79cdff7bf7b99c4b77`. The exact surface-by-surface claim
+and its limitations live in
+[hermes-coverage-matrix.md](hermes-coverage-matrix.md).
+
+Hermes moves quickly. Baseline changes must pin a release tag to a full commit,
+review upstream's security policy and affected surfaces, and update the
+machine-readable baseline and matrix together. Never make a coverage claim
+follow `main` or `latest` automatically.


### PR DESCRIPTION
## Summary

- pin Ship Safe 10.0 to Hermes Agent v0.21.0 at commit `29112bef099274229cadff79cdff7bf7b99c4b77`
- add a machine-readable baseline and matching test fixture
- publish a surface-by-surface coverage matrix with partial and uncovered states
- update the security model, roadmap, and README to stop implying coverage from rule overlap
- document a reviewed version-drift process that never follows `main` or `latest`

The audit covers plugin manifests, network adapters, seven terminal backends, ACP, the TUI gateway, cron, and credential scoping. No surface is marked fully covered yet.

## Verification

- `npm test`: 872 passed
- `npm run lint`: 0 errors (86 existing warnings)
- focused Hermes and baseline tests: 236 passed
- `npm pack --dry-run`: clean; includes `cli/data/hermes-baseline.json`
- `git diff --check`: clean

During a real scan of the pinned Hermes tree, large `audit --json` output was truncated before the stdout buffer drained. That pre-existing release-output problem is recorded on #189 rather than treated as valid audit evidence here.

Closes #184
