### PR TITLE
fix: drain audit machine output before exit

### DIFF
--- a/cli/__tests__/audit-json-output.test.js
+++ b/cli/__tests__/audit-json-output.test.js
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, test } from 'node:test';
+
+const directories = [];
+
+afterEach(() => {
+  for (const dir of directories.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function largeAudit(format) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-audit-json-'));
+  directories.push(dir);
+  const cli = path.resolve('cli/bin/ship-safe.js');
+  const source = Array.from(
+    { length: 800 },
+    (_, index) => `const key${index} = "AKIA${String(index).padStart(16, '0')}";`,
+  ).join('\n');
+  fs.writeFileSync(path.join(dir, 'secrets.js'), source);
+
+  return spawnSync(process.execPath, [
+    cli,
+    'audit',
+    dir,
+    '--hermes-only',
+    '--no-deps',
+    '--no-ai',
+    '--no-cache',
+    format,
+  ], {
+    cwd: path.resolve('.'),
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+    env: { ...process.env, NO_COLOR: '1' },
+  });
+}
+
+test('audit emits complete JSON when the report exceeds a pipe buffer', () => {
+  const result = largeAudit('--json');
+  assert.equal(result.error, undefined, result.error?.message);
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(result.stdout.length > 64 * 1024, `expected more than 64 KiB, got ${result.stdout.length}`);
+
+  let report;
+  assert.doesNotThrow(() => { report = JSON.parse(result.stdout); });
+  assert.equal(report.findings.length, 800);
+});
+
+test('audit emits complete SARIF when the report exceeds a pipe buffer', () => {
+  const result = largeAudit('--sarif');
+  assert.equal(result.error, undefined, result.error?.message);
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(result.stdout.length > 64 * 1024, `expected more than 64 KiB, got ${result.stdout.length}`);
+
+  let report;
+  assert.doesNotThrow(() => { report = JSON.parse(result.stdout); });
+  assert.equal(report.version, '2.1.0');
+  assert.equal(report.runs[0].results.length, 800);
+});

--- a/cli/commands/audit.js
+++ b/cli/commands/audit.js
@@ -47,6 +47,7 @@ import { generatePDF, generatePrintHTML, isChromeAvailable } from '../utils/pdf-
 import { SecretsVerifier } from '../utils/secrets-verifier.js';
 import { applyInlineAnnotations } from './autofix.js';
 import { hasEvidence, summarizeEvidence } from '../utils/evidence.js';
+import { STDOUT_WRITE_TIMEOUT_MS, writeStdout } from '../utils/stdout.js';
 
 // =============================================================================
 // CONSTANTS
@@ -457,9 +458,9 @@ export async function auditCommand(targetPath = '.', options = {}) {
   } else if (options.md) {
     outputMarkdown(scoreResult, emittedFindings, depVulns, remediationPlan, absolutePath);
   } else if (options.json) {
-    outputJSON(scoreResult, emittedFindings, depVulns, recon, agentResults, remediationPlan, suppressions, options.compare ? scoringEngine.loadHistory(absolutePath) : null, absolutePath);
+    await outputJSON(scoreResult, emittedFindings, depVulns, recon, agentResults, remediationPlan, suppressions, options.compare ? scoringEngine.loadHistory(absolutePath) : null, absolutePath);
   } else if (options.sarif) {
-    outputSARIF(emittedFindings, absolutePath);
+    await outputSARIF(emittedFindings, absolutePath);
   } else {
     printReport(scoreResult, filteredFindings, depVulns, recon, remediationPlan, absolutePath, filesScanned);
   }
@@ -845,7 +846,7 @@ function printReport(scoreResult, findings, depVulns, recon, plan, rootPath, fil
 // JSON OUTPUT
 // =============================================================================
 
-function outputJSON(scoreResult, findings, depVulns, recon, agentResults, remediationPlan, suppressions, history, rootPath = process.cwd()) {
+async function outputJSON(scoreResult, findings, depVulns, recon, agentResults, remediationPlan, suppressions, history, rootPath = process.cwd()) {
   const output = {
     scoreVersion: scoreResult.scoreVersion,
     score: scoreResult.score,
@@ -905,14 +906,14 @@ function outputJSON(scoreResult, findings, depVulns, recon, agentResults, remedi
       ),
     };
   }
-  console.log(JSON.stringify(output, null, 2));
+  await writeMachineOutput(`${JSON.stringify(output, null, 2)}\n`);
 }
 
 // =============================================================================
 // SARIF OUTPUT
 // =============================================================================
 
-function outputSARIF(findings, rootPath) {
+async function outputSARIF(findings, rootPath) {
   const rules = {};
   for (const f of findings) {
     if (!rules[f.rule]) {
@@ -928,7 +929,7 @@ function outputSARIF(findings, rootPath) {
     }
   }
 
-  console.log(JSON.stringify({
+  await writeMachineOutput(`${JSON.stringify({
     version: '2.1.0',
     $schema: 'https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json',
     runs: [{
@@ -952,7 +953,19 @@ function outputSARIF(findings, rootPath) {
         }],
       })),
     }],
-  }, null, 2));
+  }, null, 2)}\n`);
+}
+
+async function writeMachineOutput(value) {
+  try {
+    await writeStdout(value);
+  } catch (error) {
+    const message = error.code === 'SHIP_SAFE_STDOUT_TIMEOUT'
+      ? `Timed out writing machine output to stdout after ${STDOUT_WRITE_TIMEOUT_MS}ms; the downstream consumer may not be reading.`
+      : `Could not write machine output to stdout: ${error.message}`;
+    console.error(`[ship-safe] ${message}`);
+    process.exit(1);
+  }
 }
 
 // =============================================================================

--- a/cli/commands/ci.js
+++ b/cli/commands/ci.js
@@ -52,12 +52,7 @@ import { isHighEntropyMatch, getConfidence } from '../utils/entropy.js';
 import { postPRComments } from './watch.js';
 import { compareFindingSets, snapshotFinding } from '../utils/finding-delta.js';
 import fg from 'fast-glob';
-
-const DEFAULT_STDOUT_WRITE_TIMEOUT_MS = 10_000;
-const configuredStdoutWriteTimeout = Number.parseInt(process.env.SHIP_SAFE_STDOUT_TIMEOUT_MS, 10);
-const STDOUT_WRITE_TIMEOUT_MS = Number.isInteger(configuredStdoutWriteTimeout) && configuredStdoutWriteTimeout > 0
-  ? configuredStdoutWriteTimeout
-  : DEFAULT_STDOUT_WRITE_TIMEOUT_MS;
+import { STDOUT_WRITE_TIMEOUT_MS, writeStdout } from '../utils/stdout.js';
 
 // =============================================================================
 // MAIN COMMAND
@@ -334,33 +329,6 @@ export async function ciCommand(targetPath = '.', options = {}) {
     }
     process.exit(0);
   }
-}
-
-function writeStdout(value) {
-  return new Promise((resolve, reject) => {
-    let settled = false;
-    function finish(error) {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      error ? reject(error) : resolve();
-    }
-
-    const timer = setTimeout(() => {
-      const error = new Error('stdout write timed out');
-      error.code = 'SHIP_SAFE_STDOUT_TIMEOUT';
-      finish(error);
-      // A live pipe that is no longer being read can keep the write callback
-      // pending forever. Close it after the bound so CI can fail cleanly.
-      process.stdout.destroy();
-    }, STDOUT_WRITE_TIMEOUT_MS);
-
-    try {
-      process.stdout.write(value, finish);
-    } catch (error) {
-      finish(error);
-    }
-  });
 }
 
 // =============================================================================

--- a/cli/utils/stdout.js
+++ b/cli/utils/stdout.js
@@ -1,0 +1,39 @@
+const DEFAULT_STDOUT_WRITE_TIMEOUT_MS = 10_000;
+const configuredStdoutWriteTimeout = Number.parseInt(process.env.SHIP_SAFE_STDOUT_TIMEOUT_MS, 10);
+
+export const STDOUT_WRITE_TIMEOUT_MS =
+  Number.isInteger(configuredStdoutWriteTimeout) && configuredStdoutWriteTimeout > 0
+    ? configuredStdoutWriteTimeout
+    : DEFAULT_STDOUT_WRITE_TIMEOUT_MS;
+
+/**
+ * Write a complete machine-readable report before a command exits.
+ *
+ * `console.log()` may return while a pipe still has buffered bytes. A direct
+ * `process.exit()` can then truncate JSON or SARIF. The timeout keeps a stalled
+ * downstream consumer from holding the process open forever.
+ */
+export function writeStdout(value) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    function finish(error) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      error ? reject(error) : resolve();
+    }
+
+    const timer = setTimeout(() => {
+      const error = new Error('stdout write timed out');
+      error.code = 'SHIP_SAFE_STDOUT_TIMEOUT';
+      finish(error);
+      process.stdout.destroy();
+    }, STDOUT_WRITE_TIMEOUT_MS);
+
+    try {
+      process.stdout.write(value, finish);
+    } catch (error) {
+      finish(error);
+    }
+  });
+}


### PR DESCRIPTION
## Summary

- wait for `audit --json` and `audit --sarif` stdout writes to finish before applying the score exit code
- share the bounded stdout writer already used by `ci --json`
- preserve the stalled-consumer timeout so an unread pipe fails instead of hanging
- add large-report regressions for both audit JSON and SARIF

## Reproduction and result

Before this change, a Hermes v0.21.0 audit exited after exactly 65,537 stdout bytes and left JSON incomplete. After the change, the same scan emitted 547,209 bytes, parsed successfully, and contained all 328 findings.

## Verification

- `npm test`: 875 passed
- `npm run lint`: 0 errors (86 existing warnings)
- focused large-output tests: 10 passed
- `npm pack --dry-run`: clean and includes `cli/utils/stdout.js`
- `git diff --check`: clean

Related to #189
