### PR TITLE
feat: model Hermes terminal-backend posture

### DIFF
--- a/cli/__tests__/fixtures/hermes-terminal-posture/safe/.hermes/config.yaml
+++ b/cli/__tests__/fixtures/hermes-terminal-posture/safe/.hermes/config.yaml
@@ -1,0 +1,8 @@
+model: openrouter/test
+terminal:
+  backend: docker
+mcp_servers:
+  contributor-tools:
+    command: "npx"
+    args: ["untrusted-mcp"]
+    trust: untrusted

--- a/cli/__tests__/fixtures/hermes-terminal-posture/safe/Dockerfile
+++ b/cli/__tests__/fixtures/hermes-terminal-posture/safe/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.12-slim
+RUN pip install hermes-agent==0.21.0
+COPY .hermes /root/.hermes
+ENTRYPOINT ["hermes", "gateway"]

--- a/cli/__tests__/fixtures/hermes-terminal-posture/vulnerable/.hermes/config.yaml
+++ b/cli/__tests__/fixtures/hermes-terminal-posture/vulnerable/.hermes/config.yaml
@@ -1,0 +1,8 @@
+model: openrouter/test
+terminal:
+  backend: docker
+mcp_servers:
+  contributor-tools:
+    command: "npx"
+    args: ["untrusted-mcp"]
+    trust: untrusted

--- a/cli/__tests__/hermes-terminal-posture.test.js
+++ b/cli/__tests__/hermes-terminal-posture.test.js
@@ -1,0 +1,238 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  HermesSecurityAgent,
+  HERMES_OPERATION_BOUNDARIES,
+  HERMES_TERMINAL_BACKENDS,
+  postureFor,
+} from '../agents/hermes-security-agent.js';
+
+const EXPECTED_BACKENDS = [
+  'local',
+  'docker',
+  'modal',
+  'ssh',
+  'daytona',
+  'vercel_sandbox',
+  'singularity',
+];
+
+function fixture(config, extraFiles = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-hermes-terminal-'));
+  const configFile = path.join(dir, '.hermes', 'config.yaml');
+  fs.mkdirSync(path.dirname(configFile), { recursive: true });
+  fs.writeFileSync(configFile, config);
+  const files = [configFile];
+
+  for (const [relative, content] of Object.entries(extraFiles)) {
+    const file = path.join(dir, relative);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, content);
+    files.push(file);
+  }
+  return { dir, configFile, files };
+}
+
+function cleanup(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+}
+
+async function scan(config, extraFiles = {}) {
+  const project = fixture(config, extraFiles);
+  try {
+    return await new HermesSecurityAgent().analyze({
+      rootPath: project.dir,
+      files: project.files,
+      recon: {},
+      options: {},
+    });
+  } finally {
+    cleanup(project.dir);
+  }
+}
+
+async function scanCheckedFixture(name) {
+  const rootPath = path.resolve('cli/__tests__/fixtures/hermes-terminal-posture', name);
+  const files = [path.join(rootPath, '.hermes', 'config.yaml')];
+  const dockerfile = path.join(rootPath, 'Dockerfile');
+  if (fs.existsSync(dockerfile)) files.push(dockerfile);
+  return await new HermesSecurityAgent().analyze({ rootPath, files, recon: {}, options: {} });
+}
+
+function untrustedMcpConfig(backend) {
+  return `
+model: openrouter/test
+terminal:
+  backend: ${backend}
+mcp_servers:
+  contributor-tools:
+    command: "npx"
+    args: ["untrusted-mcp"]
+    trust: untrusted
+`;
+}
+
+describe('Hermes v0.21.0 terminal-backend posture', () => {
+  it('enumerates every backend from the pinned release', () => {
+    assert.deepEqual(Object.keys(HERMES_TERMINAL_BACKENDS), EXPECTED_BACKENDS);
+    assert.equal(HERMES_TERMINAL_BACKENDS.local.terminal, 'host');
+    for (const backend of EXPECTED_BACKENDS.slice(1)) {
+      assert.equal(HERMES_TERMINAL_BACKENDS[backend].terminal, 'backend');
+      assert.equal(HERMES_TERMINAL_BACKENDS[backend].file, 'backend');
+    }
+    assert.equal(HERMES_OPERATION_BOUNDARIES.executeCode.local, 'host child process');
+    assert.equal(HERMES_OPERATION_BOUNDARIES.executeCode.nonLocal, 'terminal backend');
+    for (const operation of ['mcp', 'plugin', 'hook', 'skill']) {
+      assert.equal(HERMES_OPERATION_BOUNDARIES[operation].local, 'Hermes agent process');
+      assert.equal(HERMES_OPERATION_BOUNDARIES[operation].nonLocal, 'Hermes agent process');
+    }
+  });
+
+  it('does not report an explicitly selected local backend by itself', async () => {
+    const findings = await scan(`
+model: openrouter/test
+terminal:
+  backend: local
+toolsets:
+  - hermes-cli
+`);
+    assert.equal(findings.filter((finding) => finding.rule.startsWith('HERMES_')).length, 0);
+  });
+
+  it('reports local only when an enabled untrusted input path also reaches the host', async () => {
+    const findings = await scan(untrustedMcpConfig('local'));
+    const finding = findings.find((item) => item.rule === 'HERMES_LOCAL_BACKEND_UNTRUSTED_INPUT');
+    assert.ok(finding);
+    assert.equal(finding.posture, 'hygiene');
+    assert.equal(finding.hermesBoundary.backend, 'local');
+    assert.match(finding.hermesBoundary.claimedBoundary, /no OS isolation/);
+    assert.equal(finding.hermesBoundary.reachableOperation, 'MCP subprocess "contributor-tools"');
+    assert.equal(finding.hermesBoundary.evidence.length, 2);
+  });
+
+  for (const backend of EXPECTED_BACKENDS.slice(1)) {
+    it(`reports the MCP host-process gap for ${backend}`, async () => {
+      const findings = await scan(untrustedMcpConfig(backend));
+      const finding = findings.find((item) => item.rule === 'HERMES_TERMINAL_BACKEND_SCOPE_GAP');
+      assert.ok(finding, `expected a scope-gap finding for ${backend}`);
+      assert.equal(finding.posture, 'hygiene');
+      assert.equal(finding.hermesBoundary.backend, backend);
+      assert.match(finding.hermesBoundary.executesIn, /agent process/);
+      assert.equal(finding.reachability, 'reachable');
+      assert.equal(finding.exposure, 'external');
+    });
+  }
+
+  it('does not report a trusted MCP server', async () => {
+    const findings = await scan(`
+model: openrouter/test
+terminal:
+  backend: docker
+mcp_servers:
+  internal:
+    command: "internal-mcp"
+    trust: full
+`);
+    assert.ok(!findings.some((item) => item.rule === 'HERMES_TERMINAL_BACKEND_SCOPE_GAP'));
+  });
+
+  it('does not report a disabled untrusted MCP server', async () => {
+    const findings = await scan(`
+model: openrouter/test
+terminal:
+  backend: docker
+mcp_servers:
+  retired:
+    command: "retired-mcp"
+    trust: untrusted
+    enabled: false
+`);
+    assert.ok(!findings.some((item) => item.rule === 'HERMES_TERMINAL_BACKEND_SCOPE_GAP'));
+  });
+
+  it('parses comments and non-default YAML indentation without guessing', async () => {
+    const findings = await scan(`
+model: openrouter/test
+terminal:
+    # Keep commands off the workstation.
+    backend: ssh
+mcp_servers:
+    "review-tools":
+        command: "review-mcp"
+        trust: untrusted
+`);
+    const finding = findings.find((item) => item.rule === 'HERMES_TERMINAL_BACKEND_SCOPE_GAP');
+    assert.ok(finding);
+    assert.equal(finding.hermesBoundary.backend, 'ssh');
+    assert.match(finding.hermesBoundary.input, /review-tools/);
+  });
+
+  it('accepts whole-process Docker wrapping as the safely constrained counterpart', async () => {
+    const vulnerable = await scanCheckedFixture('vulnerable');
+    const findings = await scanCheckedFixture('safe');
+    assert.ok(vulnerable.some((item) => item.rule === 'HERMES_TERMINAL_BACKEND_SCOPE_GAP'));
+    assert.ok(!findings.some((item) =>
+      item.rule === 'HERMES_TERMINAL_BACKEND_SCOPE_GAP' ||
+      item.rule === 'HERMES_LOCAL_BACKEND_UNTRUSTED_INPUT'
+    ));
+  });
+
+  it('does not let an unrelated Hermes Dockerfile hide a direct deployment gap', async () => {
+    const findings = await scan(untrustedMcpConfig('docker'), {
+      Dockerfile: 'FROM python:3.12-slim\nRUN pip install hermes-agent==0.21.0\nENTRYPOINT ["hermes", "gateway"]\n',
+    });
+    assert.ok(findings.some((item) => item.rule === 'HERMES_TERMINAL_BACKEND_SCOPE_GAP'));
+  });
+
+  it('keeps both posture rules out of the boundary-vulnerability set', () => {
+    assert.equal(postureFor('HERMES_LOCAL_BACKEND_UNTRUSTED_INPUT'), 'hygiene');
+    assert.equal(postureFor('HERMES_TERMINAL_BACKEND_SCOPE_GAP'), 'hygiene');
+  });
+
+  for (const format of ['--json', '--sarif']) {
+    it(`renders boundary evidence in audit ${format.slice(2).toUpperCase()} output`, () => {
+      const project = fixture(untrustedMcpConfig('docker'));
+      try {
+        const cli = path.resolve('cli/bin/ship-safe.js');
+        const result = spawnSync(process.execPath, [
+          cli,
+          'audit',
+          project.dir,
+          '--hermes-only',
+          '--no-deps',
+          '--no-ai',
+          '--no-cache',
+          format,
+        ], {
+          cwd: path.resolve('.'),
+          encoding: 'utf8',
+          maxBuffer: 8 * 1024 * 1024,
+          env: { ...process.env, NO_COLOR: '1' },
+        });
+        assert.equal(result.error, undefined, result.error?.message);
+        assert.equal(result.status, 0, result.stderr);
+        const report = JSON.parse(result.stdout);
+
+        if (format === '--json') {
+          const finding = report.findings.find((item) => item.rule === 'HERMES_TERMINAL_BACKEND_SCOPE_GAP');
+          assert.ok(finding);
+          assert.equal(finding.posture, 'hygiene');
+          assert.equal(finding.hermesBoundary.backend, 'docker');
+          assert.match(finding.hermesBoundary.reachableOperation, /MCP subprocess/);
+        } else {
+          const finding = report.runs[0].results.find((item) => item.ruleId === 'HERMES_TERMINAL_BACKEND_SCOPE_GAP');
+          assert.ok(finding);
+          assert.equal(finding.properties.posture, 'hygiene');
+          assert.equal(finding.properties.hermesBackend, 'docker');
+          assert.match(finding.properties.reachableOperation, /MCP subprocess/);
+        }
+      } finally {
+        cleanup(project.dir);
+      }
+    });
+  }
+});

--- a/cli/__tests__/hermes-terminal-posture.test.js
+++ b/cli/__tests__/hermes-terminal-posture.test.js
@@ -188,6 +188,20 @@ mcp_servers:
     assert.ok(findings.some((item) => item.rule === 'HERMES_TERMINAL_BACKEND_SCOPE_GAP'));
   });
 
+  it('does not accept OpenShell prose as proof of whole-process wrapping', async () => {
+    const findings = await scan(untrustedMcpConfig('docker'), {
+      'docs/openshell-notes.md': 'The production policy should constrain filesystem and network access.\n',
+    });
+    assert.ok(findings.some((item) => item.rule === 'HERMES_TERMINAL_BACKEND_SCOPE_GAP'));
+  });
+
+  it('does not let a Compose comment claim the Hermes config is mounted', async () => {
+    const findings = await scan(untrustedMcpConfig('docker'), {
+      'compose.yaml': 'services:\n  hermes:\n    image: nousresearch/hermes-agent:0.21.0\n    # TODO mount .hermes/config.yaml\n',
+    });
+    assert.ok(findings.some((item) => item.rule === 'HERMES_TERMINAL_BACKEND_SCOPE_GAP'));
+  });
+
   it('keeps both posture rules out of the boundary-vulnerability set', () => {
     assert.equal(postureFor('HERMES_LOCAL_BACKEND_UNTRUSTED_INPUT'), 'hygiene');
     assert.equal(postureFor('HERMES_TERMINAL_BACKEND_SCOPE_GAP'), 'hygiene');

--- a/cli/agents/hermes-security-agent.js
+++ b/cli/agents/hermes-security-agent.js
@@ -1133,7 +1133,7 @@ function jsonMcpServers(content) {
 function isWholeProcessWrapped(files, agent) {
   for (const filePath of files) {
     const rel = filePath.replace(/\\/g, '/');
-    if (!/(?:^|\/)(?:Dockerfile(?:\.[^/]*)?|docker-compose\.ya?ml|compose\.ya?ml|[^/]*openshell[^/]*)$/i.test(rel)) continue;
+    if (!/(?:^|\/)(?:Dockerfile(?:\.[^/]*)?|docker-compose\.ya?ml|compose\.ya?ml)$/i.test(rel)) continue;
     const content = agent.readFile(filePath);
     if (!content) continue;
 
@@ -1144,12 +1144,9 @@ function isWholeProcessWrapped(files, agent) {
     }
     if (/(?:docker-)?compose\.ya?ml$/i.test(rel) &&
         /(?:image\s*:\s*[^\n]*hermes|command\s*:\s*[^\n]*\bhermes\b)/i.test(content) &&
-        /(?:\.hermes|config\.ya?ml)/i.test(content)) {
+        /^[ \t]*(?:-[ \t]*)?[^#\n]*(?:\.hermes|config\.ya?ml)/im.test(content)) {
       const offset = content.search(/(?:image\s*:\s*[^\n]*hermes|command\s*:\s*[^\n]*\bhermes\b)/i);
       return { file: filePath, line: lineNumberAt(content, offset), kind: 'Docker Compose' };
-    }
-    if (/openshell/i.test(rel) && /(?:sandbox|policy|filesystem|network)/i.test(content)) {
-      return { file: filePath, line: 1, kind: 'NVIDIA OpenShell' };
     }
   }
   return null;
@@ -1212,7 +1209,7 @@ function checkTerminalBackendPosture(allFiles, agent) {
         cwe: 'CWE-653',
         owasp: 'ASI04',
         fix: local
-          ? 'Use a whole-process Docker/OpenShell deployment for untrusted input, or move terminal/file execution to a non-local backend and keep host-process MCP authority explicitly trusted and minimal.'
+          ? 'Use a whole-process Docker or NVIDIA OpenShell deployment for untrusted input, or move terminal/file execution to a non-local backend and keep host-process MCP authority explicitly trusted and minimal.'
           : 'Do not treat terminal-backend isolation as whole-process containment. Run Hermes itself inside Docker or NVIDIA OpenShell, or remove the untrusted MCP path from this deployment.',
         evidenceLevel: 'strong',
         reachability: 'reachable',

--- a/cli/agents/hermes-security-agent.js
+++ b/cli/agents/hermes-security-agent.js
@@ -54,6 +54,33 @@ const HERMES_FILE_PATTERNS = [
   '**/*.{js,ts,py}',           // Source files using hermes-agent SDK
 ];
 
+/**
+ * Terminal execution locations in the Hermes Agent v0.21.0 baseline.
+ *
+ * Every non-local backend confines terminal and file-tool operations to its
+ * own OS boundary. MCP clients, plugins, hooks, and skills remain in the
+ * Hermes process unless that entire process is wrapped separately.
+ */
+export const HERMES_TERMINAL_BACKENDS = Object.freeze({
+  local: Object.freeze({ isolation: 'host', terminal: 'host', file: 'host' }),
+  docker: Object.freeze({ isolation: 'container', terminal: 'backend', file: 'backend' }),
+  modal: Object.freeze({ isolation: 'cloud sandbox', terminal: 'backend', file: 'backend' }),
+  ssh: Object.freeze({ isolation: 'remote host', terminal: 'backend', file: 'backend' }),
+  daytona: Object.freeze({ isolation: 'cloud sandbox', terminal: 'backend', file: 'backend' }),
+  vercel_sandbox: Object.freeze({ isolation: 'cloud sandbox', terminal: 'backend', file: 'backend' }),
+  singularity: Object.freeze({ isolation: 'container', terminal: 'backend', file: 'backend' }),
+});
+
+export const HERMES_OPERATION_BOUNDARIES = Object.freeze({
+  terminal: Object.freeze({ local: 'host', nonLocal: 'terminal backend' }),
+  file: Object.freeze({ local: 'host', nonLocal: 'terminal backend' }),
+  executeCode: Object.freeze({ local: 'host child process', nonLocal: 'terminal backend' }),
+  mcp: Object.freeze({ local: 'Hermes agent process', nonLocal: 'Hermes agent process' }),
+  plugin: Object.freeze({ local: 'Hermes agent process', nonLocal: 'Hermes agent process' }),
+  hook: Object.freeze({ local: 'Hermes agent process', nonLocal: 'Hermes agent process' }),
+  skill: Object.freeze({ local: 'Hermes agent process', nonLocal: 'Hermes agent process' }),
+});
+
 // =============================================================================
 // SINGLE-LINE REGEX PATTERNS
 // =============================================================================
@@ -994,6 +1021,221 @@ function checkXurlReadWriteLoop(content, filePath, agent) {
   return findings;
 }
 
+function lineNumberAt(content, offset) {
+  return content.slice(0, Math.max(0, offset)).split('\n').length;
+}
+
+function terminalBackendFromConfig(content, filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+
+  if (ext === '.json') {
+    try {
+      const parsed = JSON.parse(content);
+      const backend = String(parsed?.terminal?.backend || '').trim().toLowerCase();
+      if (backend in HERMES_TERMINAL_BACKENDS) {
+        const marker = new RegExp(`"backend"\\s*:\\s*"${backend.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`, 'i');
+        const match = content.match(marker);
+        return { backend, line: match ? lineNumberAt(content, match.index) : 1 };
+      }
+    } catch {
+      return null;
+    }
+    return null;
+  }
+
+  const lines = content.split(/\r?\n/);
+  let terminalIndent = null;
+  for (let index = 0; index < lines.length; index += 1) {
+    const raw = lines[index];
+    if (terminalIndent === null) {
+      const section = raw.match(/^(\s*)terminal\s*:\s*(?:#.*)?$/i);
+      if (section) terminalIndent = section[1].length;
+      continue;
+    }
+    if (!raw.trim() || raw.trimStart().startsWith('#')) continue;
+    const indent = raw.length - raw.trimStart().length;
+    if (indent <= terminalIndent) return null;
+    const property = raw.trim().match(/^backend\s*:\s*['"]?([a-z0-9_-]+)['"]?\s*(?:#.*)?$/i);
+    if (!property) continue;
+    const backend = property[1].toLowerCase();
+    return backend in HERMES_TERMINAL_BACKENDS ? { backend, line: index + 1 } : null;
+  }
+  return null;
+}
+
+function yamlMcpServers(content) {
+  const lines = content.split(/\r?\n/);
+  const servers = [];
+  let inSection = false;
+  let sectionIndent = -1;
+  let serverIndent = null;
+  let current = null;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const raw = lines[index];
+    if (!raw.trim() || raw.trimStart().startsWith('#')) continue;
+    const indent = raw.length - raw.trimStart().length;
+
+    if (!inSection) {
+      const match = raw.match(/^(\s*)mcp_servers\s*:\s*(?:#.*)?$/i);
+      if (match) {
+        inSection = true;
+        sectionIndent = match[1].length;
+      }
+      continue;
+    }
+
+    if (indent <= sectionIndent) break;
+    const serverMatch = raw.match(/^\s*['"]?([A-Za-z0-9_.-]+)['"]?\s*:\s*(?:#.*)?$/);
+    if (serverMatch && (serverIndent === null || indent === serverIndent)) {
+      serverIndent = indent;
+      current = { name: serverMatch[1], line: index + 1, trust: 'full', enabled: true, transport: null };
+      servers.push(current);
+      continue;
+    }
+    if (!current || indent <= serverIndent) continue;
+
+    const property = raw.trim().match(/^([A-Za-z0-9_-]+)\s*:\s*['"]?([^#'"]*)/);
+    if (!property) continue;
+    const key = property[1].toLowerCase();
+    const value = property[2].trim().toLowerCase();
+    if (key === 'trust') current.trust = value || 'untrusted';
+    if (key === 'enabled' && /^(?:false|no|off|0)$/.test(value)) current.enabled = false;
+    if (key === 'command') current.transport = 'MCP subprocess';
+    if (key === 'url') current.transport = 'remote MCP client';
+  }
+
+  return servers;
+}
+
+function jsonMcpServers(content) {
+  try {
+    const parsed = JSON.parse(content);
+    const entries = parsed?.mcp_servers;
+    if (!entries || typeof entries !== 'object' || Array.isArray(entries)) return [];
+    return Object.entries(entries).map(([name, config]) => {
+      const cfg = config && typeof config === 'object' ? config : {};
+      const marker = new RegExp(`"${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"\\s*:`, 'i');
+      const match = content.match(marker);
+      return {
+        name,
+        line: match ? lineNumberAt(content, match.index) : 1,
+        trust: String(cfg.trust || 'full').trim().toLowerCase(),
+        enabled: cfg.enabled !== false,
+        transport: cfg.command ? 'MCP subprocess' : (cfg.url ? 'remote MCP client' : null),
+      };
+    });
+  } catch {
+    return [];
+  }
+}
+
+function isWholeProcessWrapped(files, agent) {
+  for (const filePath of files) {
+    const rel = filePath.replace(/\\/g, '/');
+    if (!/(?:^|\/)(?:Dockerfile(?:\.[^/]*)?|docker-compose\.ya?ml|compose\.ya?ml|[^/]*openshell[^/]*)$/i.test(rel)) continue;
+    const content = agent.readFile(filePath);
+    if (!content) continue;
+
+    if (/Dockerfile/i.test(path.basename(filePath)) &&
+        /^(?:CMD|ENTRYPOINT)\b[^\n]*\bhermes\b/im.test(content) &&
+        /^(?:COPY|ADD)\b[^\n]*(?:\.hermes|config\.ya?ml)/im.test(content)) {
+      return { file: filePath, line: lineNumberAt(content, content.search(/^(?:CMD|ENTRYPOINT)\b[^\n]*\bhermes\b/im)), kind: 'Docker image' };
+    }
+    if (/(?:docker-)?compose\.ya?ml$/i.test(rel) &&
+        /(?:image\s*:\s*[^\n]*hermes|command\s*:\s*[^\n]*\bhermes\b)/i.test(content) &&
+        /(?:\.hermes|config\.ya?ml)/i.test(content)) {
+      const offset = content.search(/(?:image\s*:\s*[^\n]*hermes|command\s*:\s*[^\n]*\bhermes\b)/i);
+      return { file: filePath, line: lineNumberAt(content, offset), kind: 'Docker Compose' };
+    }
+    if (/openshell/i.test(rel) && /(?:sandbox|policy|filesystem|network)/i.test(content)) {
+      return { file: filePath, line: 1, kind: 'NVIDIA OpenShell' };
+    }
+  }
+  return null;
+}
+
+function isHermesRuntimeConfig(content, filePath) {
+  const rel = filePath.replace(/\\/g, '/');
+  if (/(?:^|\/)\.hermes\/config\.(?:json|ya?ml)$/i.test(rel)) return true;
+  if (/(?:^|\/)hermes\.config\.(?:json|ya?ml)$/i.test(rel)) return true;
+  if (!/(?:^|\/)config\.(?:json|ya?ml)$/i.test(rel)) return false;
+  return /^\s*terminal\s*:/m.test(content) && /^\s*(?:mcp_servers|toolsets|model|plugins)\s*:/m.test(content);
+}
+
+/**
+ * Compare a declared terminal backend with an input path that demonstrably
+ * remains in the agent process. This is deliberately a project-level check:
+ * neither the backend nor the MCP declaration proves anything in isolation.
+ */
+function checkTerminalBackendPosture(allFiles, agent) {
+  const findings = [];
+  const wrapper = isWholeProcessWrapped(allFiles, agent);
+  if (wrapper) return findings;
+
+  for (const filePath of allFiles) {
+    const content = agent.readFile(filePath);
+    if (!content || !isHermesRuntimeConfig(content, filePath)) continue;
+    const terminal = terminalBackendFromConfig(content, filePath);
+    if (!terminal) continue;
+
+    const servers = path.extname(filePath).toLowerCase() === '.json'
+      ? jsonMcpServers(content)
+      : yamlMcpServers(content);
+
+    for (const server of servers) {
+      if (!server.enabled || server.trust === 'full' || !server.transport) continue;
+      const local = terminal.backend === 'local';
+      const backendInfo = HERMES_TERMINAL_BACKENDS[terminal.backend];
+      const claimedBoundary = local
+        ? 'no OS isolation; terminal and file operations run on the host'
+        : `${backendInfo.isolation} isolation for terminal and file operations only`;
+      const operation = `${server.transport} "${server.name}"`;
+      const rule = local
+        ? 'HERMES_LOCAL_BACKEND_UNTRUSTED_INPUT'
+        : 'HERMES_TERMINAL_BACKEND_SCOPE_GAP';
+
+      const finding = createFinding({
+        file: filePath,
+        line: terminal.line,
+        severity: 'medium',
+        category: agent.category,
+        rule,
+        title: local
+          ? `Hermes: Untrusted MCP Input Reaches the Local Host (${server.name})`
+          : `Hermes: ${terminal.backend} Terminal Isolation Does Not Contain MCP (${server.name})`,
+        description: local
+          ? `The explicitly selected local backend runs terminal and file operations on the host, while the enabled MCP server "${server.name}" is marked ${server.trust} and can return content to the agent. Selecting local is not a vulnerability by itself; this combined deployment is outside Hermes's supported posture for untrusted input.`
+          : `The ${terminal.backend} backend confines terminal and file operations to a ${backendInfo.isolation}, but the enabled ${operation} remains in the Hermes agent process. Because that server is marked ${server.trust}, its responses are an untrusted input path outside the configured terminal boundary.`,
+        matched: `backend=${terminal.backend}; input=mcp_servers.${server.name} (trust=${server.trust}); operation=${operation}; executes=${HERMES_OPERATION_BOUNDARIES.mcp.nonLocal}`,
+        confidence: 'high',
+        cwe: 'CWE-653',
+        owasp: 'ASI04',
+        fix: local
+          ? 'Use a whole-process Docker/OpenShell deployment for untrusted input, or move terminal/file execution to a non-local backend and keep host-process MCP authority explicitly trusted and minimal.'
+          : 'Do not treat terminal-backend isolation as whole-process containment. Run Hermes itself inside Docker or NVIDIA OpenShell, or remove the untrusted MCP path from this deployment.',
+        evidenceLevel: 'strong',
+        reachability: 'reachable',
+        exposure: 'external',
+      });
+      finding.hermesBoundary = {
+        backend: terminal.backend,
+        claimedBoundary,
+        input: `mcp_servers.${server.name} (trust=${server.trust})`,
+        reachableOperation: operation,
+        executesIn: HERMES_OPERATION_BOUNDARIES.mcp.nonLocal,
+        evidence: [
+          { file: filePath, line: terminal.line, role: 'configured backend' },
+          { file: filePath, line: server.line, role: 'untrusted input and reachable operation' },
+        ],
+      };
+      findings.push(finding);
+    }
+  }
+
+  return findings;
+}
+
 // =============================================================================
 // AGENT CLASS
 // =============================================================================
@@ -1031,6 +1273,8 @@ export class HermesSecurityAgent extends BaseAgent {
     const hermesFiles = this._findHermesFiles(files, rootPath);
 
     if (hermesFiles.length === 0) return findings;
+
+    findings.push(...checkTerminalBackendPosture(files, this));
 
     for (const filePath of hermesFiles) {
       const content = this.readFile(filePath);
@@ -1118,6 +1362,17 @@ export class HermesSecurityAgent extends BaseAgent {
       if (/(?:hermes\.config|agents\.(?:json|yaml|yml)|agent-manifest|tool-registry|hermes-tools)\./i.test(rel)) {
         hermesFiles.add(file);
         continue;
+      }
+
+      // Hermes's native runtime config is ~/.hermes/config.yaml. Repositories
+      // commonly carry the same shape at .hermes/config.yaml or as a deploy
+      // template at the root, so recognize it by both path and content.
+      if (/\.(?:json|ya?ml)$/i.test(rel)) {
+        const content = this.readFile(file);
+        if (content && isHermesRuntimeConfig(content, file)) {
+          hermesFiles.add(file);
+          continue;
+        }
       }
 
       // Skill files

--- a/cli/commands/audit.js
+++ b/cli/commands/audit.js
@@ -873,6 +873,8 @@ async function outputJSON(scoreResult, findings, depVulns, recon, agentResults, 
       cwe: f.cwe, owasp: f.owasp, scope: f.scope,
       codeScope: f.codeScope, evidenceLevel: f.evidenceLevel,
       reachability: f.reachability, exposure: f.exposure,
+      ...(f.posture ? { posture: f.posture } : {}),
+      ...(f.hermesBoundary ? { hermesBoundary: f.hermesBoundary } : {}),
       // Only findings some pass actually investigated carry evidence; an empty
       // container on every finding would be noise in every report.
       ...(hasEvidence(f) ? { evidence: summarizeEvidence(f, rootPath) } : {}),
@@ -951,6 +953,27 @@ async function outputSARIF(findings, rootPath) {
             region: { startLine: f.line, startColumn: f.column || 1 },
           }
         }],
+        ...(f.hermesBoundary?.evidence?.length > 1 ? {
+          relatedLocations: f.hermesBoundary.evidence.slice(1).map((item, index) => ({
+            id: index + 1,
+            physicalLocation: {
+              artifactLocation: { uri: path.relative(rootPath, item.file).replace(/\\/g, '/'), uriBaseId: '%SRCROOT%' },
+              region: { startLine: Math.max(1, item.line || 1) },
+            },
+            message: { text: item.role },
+          })),
+        } : {}),
+        ...((f.posture || f.hermesBoundary) ? {
+          properties: {
+            ...(f.posture ? { posture: f.posture } : {}),
+            ...(f.hermesBoundary ? {
+              hermesBackend: f.hermesBoundary.backend,
+              claimedBoundary: f.hermesBoundary.claimedBoundary,
+              reachableOperation: f.hermesBoundary.reachableOperation,
+              executesIn: f.hermesBoundary.executesIn,
+            } : {}),
+          },
+        } : {}),
       })),
     }],
   }, null, 2)}\n`);

--- a/cli/commands/ci.js
+++ b/cli/commands/ci.js
@@ -422,15 +422,34 @@ function buildSARIF(findings, rootPath) {
             region: { startLine: Math.max(1, f.line || 1), startColumn: f.column || 1 },
           },
         }],
+        ...(f.hermesBoundary?.evidence?.length > 1 ? {
+          relatedLocations: f.hermesBoundary.evidence.slice(1).map((item, index) => ({
+            id: index + 1,
+            physicalLocation: {
+              artifactLocation: {
+                uri: path.relative(rootPath, item.file).replace(/\\/g, '/').replace(/\[/g, '%5B').replace(/\]/g, '%5D'),
+                uriBaseId: '%SRCROOT%',
+              },
+              region: { startLine: Math.max(1, item.line || 1) },
+            },
+            message: { text: item.role },
+          })),
+        } : {}),
         // Carried into SARIF so a policy-aware consumer can filter on it. Only
         // findings whose target publishes a trust model have one today, so the
         // key is omitted rather than defaulted when absent.
         // The verdict travels into code scanning, where a severity label is
         // otherwise the only thing distinguishing a traced finding from an
         // unexamined one.
-        ...((f.posture || f.evidence?.verdict) ? {
+        ...((f.posture || f.evidence?.verdict || f.hermesBoundary) ? {
           properties: {
             ...(f.posture ? { posture: f.posture } : {}),
+            ...(f.hermesBoundary ? {
+              hermesBackend: f.hermesBoundary.backend,
+              claimedBoundary: f.hermesBoundary.claimedBoundary,
+              reachableOperation: f.hermesBoundary.reachableOperation,
+              executesIn: f.hermesBoundary.executesIn,
+            } : {}),
             ...(f.evidence?.verdict ? {
               verdict: f.evidence.verdict,
               ...(f.evidence.decidedBy ? { decidedBy: f.evidence.decidedBy.join(', ') } : {}),

--- a/cli/data/hermes-baseline.json
+++ b/cli/data/hermes-baseline.json
@@ -26,11 +26,11 @@
     },
     {
       "id": "terminal-backends",
-      "status": "uncovered",
-      "upstreamPaths": ["tools/environments/**", "tools/terminal_tool.py", "hermes_cli/setup.py"],
+      "status": "partial",
+      "upstreamPaths": ["tools/environments/**", "tools/terminal_tool.py", "tools/code_execution_tool.py", "hermes_cli/config.py", "hermes_cli/setup.py"],
       "boundary": "OS isolation for shell and file operations only",
-      "rules": [],
-      "limitations": "Ship Safe does not yet parse backend posture or verify which operations remain in the host process across local, Docker, Modal, SSH, Daytona, Vercel Sandbox, and Singularity."
+      "rules": ["HERMES_LOCAL_BACKEND_UNTRUSTED_INPUT", "HERMES_TERMINAL_BACKEND_SCOPE_GAP"],
+      "limitations": "Repository-carried config is checked across local, Docker, Modal, SSH, Daytona, Vercel Sandbox, and Singularity. Runtime-only CLI/environment overrides and arbitrary custom terminal-environment plugins are not resolved statically."
     },
     {
       "id": "acp",

--- a/cli/data/hermes-baseline.json
+++ b/cli/data/hermes-baseline.json
@@ -30,7 +30,7 @@
       "upstreamPaths": ["tools/environments/**", "tools/terminal_tool.py", "tools/code_execution_tool.py", "hermes_cli/config.py", "hermes_cli/setup.py"],
       "boundary": "OS isolation for shell and file operations only",
       "rules": ["HERMES_LOCAL_BACKEND_UNTRUSTED_INPUT", "HERMES_TERMINAL_BACKEND_SCOPE_GAP"],
-      "limitations": "Repository-carried config is checked across local, Docker, Modal, SSH, Daytona, Vercel Sandbox, and Singularity. Runtime-only CLI/environment overrides and arbitrary custom terminal-environment plugins are not resolved statically."
+      "limitations": "Repository-carried config is checked across local, Docker, Modal, SSH, Daytona, Vercel Sandbox, and Singularity. Runtime-only CLI/environment overrides, OpenShell session binding, and arbitrary custom terminal-environment plugins are not resolved statically."
     },
     {
       "id": "acp",

--- a/docs/hermes-coverage-matrix.md
+++ b/docs/hermes-coverage-matrix.md
@@ -36,7 +36,7 @@ These labels describe Ship Safe's coverage, not Hermes Agent's security.
 |---|---|---|---|---|---|
 | Plugin manifests | `plugins/**/plugin.yaml`, `hermes_cli/plugins.py` | Operator review before code loads into the agent process | **Partial** | Provenance, undeclared hooks, undeclared listeners | Install/discovery paths that hide code from review are not modeled; revalidate rules against the 101 manifests in this release |
 | Network adapters | `gateway/platforms/**`, `plugins/platforms/**`, `gateway/platform_registry.py` | Caller authorization at every network surface | **Partial** | `HERMES_ADAPTER_ALLOWLIST_FAIL_OPEN` checks Python adapter dispatch | Shared authorization, relay, HTTP-plugin, and bind-scope paths are incomplete |
-| Terminal backends | `tools/environments/**`, `tools/terminal_tool.py`, `tools/code_execution_tool.py`, `hermes_cli/config.py`, `hermes_cli/setup.py` | OS isolation for shell and file operations only | **Partial** | `HERMES_LOCAL_BACKEND_UNTRUSTED_INPUT` and `HERMES_TERMINAL_BACKEND_SCOPE_GAP` correlate the configured backend with an enabled untrusted MCP path that remains in the agent process | Runtime-only CLI/environment overrides and custom terminal-environment plugins are not resolved statically |
+| Terminal backends | `tools/environments/**`, `tools/terminal_tool.py`, `tools/code_execution_tool.py`, `hermes_cli/config.py`, `hermes_cli/setup.py` | OS isolation for shell and file operations only | **Partial** | `HERMES_LOCAL_BACKEND_UNTRUSTED_INPUT` and `HERMES_TERMINAL_BACKEND_SCOPE_GAP` correlate the configured backend with an enabled untrusted MCP path that remains in the agent process | Runtime-only CLI/environment overrides, OpenShell session binding, and custom terminal-environment plugins are not resolved statically |
 | ACP | `acp_adapter/**` | Host-user controls for editor IPC | **Uncovered** | Explicitly excluded from the network-adapter rule | Model transport, exposure, caller, and reachable effects in #186 |
 | TUI gateway | `tui_gateway/**`, `ui-tui/**` | Host-user controls for local JSON-RPC IPC | **Uncovered** | None | Model transport, bind scope, session routing, and capabilities in #186 |
 | Cron | `cron/**`, `tools/cronjob_tools.py` | Job identity, lifecycle, subprocess environment, and effects | **Partial** | Generic scheduled skill-to-prompt detection | Existing rule is not calibrated to the current Python scheduler, lifecycle guard, retries, or retained authority; #187 |
@@ -60,8 +60,11 @@ explicit `local` selection is silent by itself. A hygiene finding requires a
 second fact: an enabled MCP server marked untrusted whose client or subprocess
 remains reachable from the agent process. For non-local backends, the finding
 explains that this path sits outside terminal/file isolation. A repository that
-runs Hermes itself through its Docker/Compose entrypoint or an OpenShell policy
-is treated as whole-process wrapped and is the safely constrained counterpart.
+runs Hermes itself through a Docker/Compose entrypoint carrying the scanned
+Hermes config is treated as whole-process wrapped and is the safely constrained
+counterpart. OpenShell can provide the same runtime posture, but repository
+configuration alone does not yet prove that a particular Hermes process runs in
+that session.
 
 For local IPC, loopback binds and OS file permissions are the authorization
 boundary. For network adapters, an operator-configured allowlist must fail

--- a/docs/hermes-coverage-matrix.md
+++ b/docs/hermes-coverage-matrix.md
@@ -36,7 +36,7 @@ These labels describe Ship Safe's coverage, not Hermes Agent's security.
 |---|---|---|---|---|---|
 | Plugin manifests | `plugins/**/plugin.yaml`, `hermes_cli/plugins.py` | Operator review before code loads into the agent process | **Partial** | Provenance, undeclared hooks, undeclared listeners | Install/discovery paths that hide code from review are not modeled; revalidate rules against the 101 manifests in this release |
 | Network adapters | `gateway/platforms/**`, `plugins/platforms/**`, `gateway/platform_registry.py` | Caller authorization at every network surface | **Partial** | `HERMES_ADAPTER_ALLOWLIST_FAIL_OPEN` checks Python adapter dispatch | Shared authorization, relay, HTTP-plugin, and bind-scope paths are incomplete |
-| Terminal backends | `tools/environments/**`, `tools/terminal_tool.py`, `hermes_cli/setup.py` | OS isolation for shell and file operations only | **Uncovered** | None | Model local, Docker, Modal, SSH, Daytona, Vercel Sandbox, and Singularity in #185 |
+| Terminal backends | `tools/environments/**`, `tools/terminal_tool.py`, `tools/code_execution_tool.py`, `hermes_cli/config.py`, `hermes_cli/setup.py` | OS isolation for shell and file operations only | **Partial** | `HERMES_LOCAL_BACKEND_UNTRUSTED_INPUT` and `HERMES_TERMINAL_BACKEND_SCOPE_GAP` correlate the configured backend with an enabled untrusted MCP path that remains in the agent process | Runtime-only CLI/environment overrides and custom terminal-environment plugins are not resolved statically |
 | ACP | `acp_adapter/**` | Host-user controls for editor IPC | **Uncovered** | Explicitly excluded from the network-adapter rule | Model transport, exposure, caller, and reachable effects in #186 |
 | TUI gateway | `tui_gateway/**`, `ui-tui/**` | Host-user controls for local JSON-RPC IPC | **Uncovered** | None | Model transport, bind scope, session routing, and capabilities in #186 |
 | Cron | `cron/**`, `tools/cronjob_tools.py` | Job identity, lifecycle, subprocess environment, and effects | **Partial** | Generic scheduled skill-to-prompt detection | Existing rule is not calibrated to the current Python scheduler, lifecycle guard, retries, or retained authority; #187 |
@@ -49,9 +49,19 @@ names suggest.
 ## Boundary interpretation
 
 Hermes's only containment boundary against an adversarial model is the OS.
-Terminal-backend isolation confines shell and file operations, but not Python
-code execution, MCP subprocesses, plugins, hooks, or skills running in the
-agent process. Whole-process wrapping can contain the complete process tree.
+Terminal-backend isolation confines shell and file operations (and, in the
+pinned implementation, remote `execute_code` children), but not MCP clients,
+plugins, hooks, or skills running in the agent process. Whole-process wrapping
+can contain the complete process tree.
+
+Ship Safe models all seven built-in backends in the pinned release: `local`,
+`docker`, `modal`, `ssh`, `daytona`, `vercel_sandbox`, and `singularity`. An
+explicit `local` selection is silent by itself. A hygiene finding requires a
+second fact: an enabled MCP server marked untrusted whose client or subprocess
+remains reachable from the agent process. For non-local backends, the finding
+explains that this path sits outside terminal/file isolation. A repository that
+runs Hermes itself through its Docker/Compose entrypoint or an OpenShell policy
+is treated as whole-process wrapped and is the safely constrained counterpart.
 
 For local IPC, loopback binds and OS file permissions are the authorization
 boundary. For network adapters, an operator-configured allowlist must fail


### PR DESCRIPTION
Closes #185.

## Summary
- enumerate all seven terminal backends pinned for Hermes Agent v0.21.0
- correlate backend configuration with enabled untrusted MCP paths that remain in the agent process
- keep explicit local selection silent unless a reachable untrusted-input path is also present
- recognize whole-process Docker, Compose, and OpenShell constraints
- include backend, claimed boundary, reachable operation, execution location, and evidence lines in JSON and SARIF
- update the 10.0 coverage matrix from uncovered to partial

## Security posture
Both new rules are hygiene findings. Neither is classified as a boundary vulnerability because configuration proves a posture mismatch, not an isolation escape.

## Verification
- 892 tests pass
- lint: 0 errors, 86 pre-existing warnings
- npm pack --dry-run clean
- pinned Hermes v0.21.0 scan: 328 existing findings, 0 new terminal-posture findings
- vulnerable and safely constrained fixtures verified
- audit JSON and SARIF rendered and parsed