### PR TITLE
feat: cover Hermes cron lifecycle and retained authority

### DIFF
--- a/cli/__tests__/fixtures/hermes-cron/authority-safe/jobs.py
+++ b/cli/__tests__/fixtures/hermes-cron/authority-safe/jobs.py
@@ -1,0 +1,5 @@
+def create_job(schedule, prompt):
+    parsed = parse_schedule(schedule)
+    job = {"schedule": parsed, "prompt": prompt}
+    save_jobs([job])
+    return job

--- a/cli/__tests__/fixtures/hermes-cron/authority-safe/scheduler.py
+++ b/cli/__tests__/fixtures/hermes-cron/authority-safe/scheduler.py
@@ -1,0 +1,8 @@
+def run_one_job(job):
+    token = set_secret_scope(build_profile_secret_scope(job["profile"]))
+    try:
+        return _deliver_result(job, run_job(job))
+    except Exception:
+        return retry(job)
+    finally:
+        reset_secret_scope(token)

--- a/cli/__tests__/fixtures/hermes-cron/authority-vulnerable/jobs.py
+++ b/cli/__tests__/fixtures/hermes-cron/authority-vulnerable/jobs.py
@@ -1,0 +1,5 @@
+def create_job(schedule, prompt):
+    parsed = parse_schedule(schedule)
+    job = {"schedule": parsed, "prompt": prompt}
+    save_jobs([job])
+    return job

--- a/cli/__tests__/fixtures/hermes-cron/authority-vulnerable/scheduler.py
+++ b/cli/__tests__/fixtures/hermes-cron/authority-vulnerable/scheduler.py
@@ -1,0 +1,12 @@
+def run_one_job(job):
+    token = set_secret_scope(build_profile_secret_scope(job["profile"]))
+    try:
+        return _deliver_result(job, run_job(job))
+    except Exception:
+        return retry(job)
+    finally:
+        clear_session_vars([])
+
+
+global_token = None
+reset_secret_scope(global_token)

--- a/cli/__tests__/fixtures/hermes-cron/comment-only/jobs.py
+++ b/cli/__tests__/fixtures/hermes-cron/comment-only/jobs.py
@@ -1,0 +1,8 @@
+def create_job(value):
+    """parse_schedule(schedule); check_gateway_lifecycle(prompt); save_jobs([job])"""
+    return value
+
+
+def update_job(job_id, updates):
+    # _PAYLOAD_FIELDS; save_jobs([updated])
+    return updates

--- a/cli/__tests__/fixtures/hermes-cron/comment-only/scheduler.py
+++ b/cli/__tests__/fixtures/hermes-cron/comment-only/scheduler.py
@@ -1,0 +1,3 @@
+def run_job(job):
+    """set_secret_scope(scope); _run_job_script(job); retry(job)"""
+    return job.get("id")

--- a/cli/__tests__/fixtures/hermes-cron/update-safe/jobs.py
+++ b/cli/__tests__/fixtures/hermes-cron/update-safe/jobs.py
@@ -1,0 +1,16 @@
+def create_job(schedule, prompt, script=None):
+    parsed = parse_schedule(schedule)
+    check_gateway_lifecycle(prompt, script)
+    job = {"schedule": parsed, "prompt": prompt, "script": script}
+    save_jobs([job])
+    return job
+
+
+def update_job(job_id, updates):
+    jobs = load_jobs()
+    job = next(job for job in jobs if job["id"] == job_id)
+    updated = {**job, **updates}
+    if any(key in updates for key in _PAYLOAD_FIELDS):
+        check_gateway_lifecycle(updated.get("prompt"), updated.get("script"))
+    save_jobs([updated])
+    return updated

--- a/cli/__tests__/fixtures/hermes-cron/update-safe/scheduler.py
+++ b/cli/__tests__/fixtures/hermes-cron/update-safe/scheduler.py
@@ -1,0 +1,4 @@
+def run_job(job):
+    if job.get("script"):
+        return _run_job_script_with_claim_heartbeat(job, job["script"])
+    return agent.run(job["prompt"])

--- a/cli/__tests__/fixtures/hermes-cron/update-vulnerable/aaa_cli.py
+++ b/cli/__tests__/fixtures/hermes-cron/update-vulnerable/aaa_cli.py
@@ -1,0 +1,5 @@
+import hermes_agent
+
+
+def run(job):
+    return agent.run(job["prompt"])

--- a/cli/__tests__/fixtures/hermes-cron/update-vulnerable/jobs.py
+++ b/cli/__tests__/fixtures/hermes-cron/update-vulnerable/jobs.py
@@ -1,0 +1,16 @@
+def create_job(schedule, prompt, script=None):
+    parsed = parse_schedule(schedule)
+    check_gateway_lifecycle(prompt, script)
+    job = {"schedule": parsed, "prompt": prompt, "script": script}
+    save_jobs([job])
+    return job
+
+
+def update_job(job_id, updates):
+    jobs = load_jobs()
+    job = next(job for job in jobs if job["id"] == job_id)
+    updated = {**job, **updates}
+    if any(key in updates for key in _PAYLOAD_FIELDS):
+        validate_non_empty(updated)
+    save_jobs([updated])
+    return updated

--- a/cli/__tests__/fixtures/hermes-cron/update-vulnerable/scheduler.py
+++ b/cli/__tests__/fixtures/hermes-cron/update-vulnerable/scheduler.py
@@ -1,0 +1,4 @@
+def run_job(job):
+    if job.get("script"):
+        return _run_job_script_with_claim_heartbeat(job, job["script"])
+    return agent.run(job["prompt"])

--- a/cli/__tests__/hermes-cron-lifecycle.test.js
+++ b/cli/__tests__/hermes-cron-lifecycle.test.js
@@ -1,0 +1,155 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  HermesSecurityAgent,
+  HERMES_CRON_LIFECYCLE,
+} from '../agents/hermes-security-agent.js';
+
+const FIXTURES = path.resolve('cli/__tests__/fixtures/hermes-cron');
+
+async function scanFixture(name) {
+  const rootPath = path.join(FIXTURES, name);
+  const files = fs.readdirSync(rootPath).map((file) => path.join(rootPath, file));
+  return new HermesSecurityAgent().analyze({ rootPath, files, recon: {}, options: {} });
+}
+
+describe('Hermes v0.21.0 cron lifecycle and retained authority', () => {
+  it('maps definition, persistence, identity, cancellation, and cleanup', () => {
+    assert.match(HERMES_CRON_LIFECYCLE.definition, /create_job.*update_job/);
+    assert.match(HERMES_CRON_LIFECYCLE.persistence, /jobs\.json/);
+    assert.match(HERMES_CRON_LIFECYCLE.executionIdentity, /execution id.*secret scope/);
+    assert.match(HERMES_CRON_LIFECYCLE.cancellation, /fire-claim/);
+    assert.match(HERMES_CRON_LIFECYCLE.cleanup, /finally/);
+  });
+
+  it('detects a persisted update that bypasses the creation guard', async () => {
+    const findings = await scanFixture('update-vulnerable');
+    const finding = findings.find((item) => item.rule === 'HERMES_CRON_UPDATE_LIFECYCLE_GUARD_BYPASS');
+    assert.ok(finding);
+    assert.equal(finding.posture, 'hygiene');
+    assert.equal(finding.hermesCronLifecycle.stage, 'update');
+    assert.equal(finding.hermesCronLifecycle.evidence.length, 4);
+    assert.match(finding.hermesCronLifecycle.evidence[0].role, /schedule definition/);
+    assert.match(finding.hermesCronLifecycle.evidence[3].role, /privileged action/);
+    assert.match(finding.hermesCronLifecycle.evidence[3].file.replace(/\\/g, '/'), /\/scheduler\.py$/);
+  });
+
+  it('accepts a guard applied to the effective payload before persistence', async () => {
+    const findings = await scanFixture('update-safe');
+    assert.ok(!findings.some((item) => item.rule === 'HERMES_CRON_UPDATE_LIFECYCLE_GUARD_BYPASS'));
+  });
+
+  it('detects authority retained across an exception and retry path', async () => {
+    const findings = await scanFixture('authority-vulnerable');
+    const finding = findings.find((item) => item.rule === 'HERMES_CRON_RETAINED_AUTHORITY');
+    assert.ok(finding);
+    assert.equal(finding.hermesCronLifecycle.stage, 'cleanup');
+    assert.match(finding.description, /Exceptions, cancellation, or retry/);
+    assert.ok(finding.hermesCronLifecycle.evidence.some((item) => /retry/.test(item.role)));
+  });
+
+  it('accepts authority revoked in a function-level finally block', async () => {
+    const findings = await scanFixture('authority-safe');
+    assert.ok(!findings.some((item) => item.rule === 'HERMES_CRON_RETAINED_AUTHORITY'));
+  });
+
+  it('does not treat JavaScript-shaped scheduler text in Python as cron evidence', async () => {
+    const rootPath = path.join(FIXTURES, 'language-scope');
+    fs.mkdirSync(rootPath, { recursive: true });
+    const file = path.join(rootPath, 'hermes_cron.py');
+    fs.writeFileSync(file, `example = "cron.schedule('0 9 * * *', lambda: fs.readFileSync('.hermes/skills/a.md'))"\n`);
+    try {
+      const findings = await new HermesSecurityAgent().analyze({ rootPath, files: [file], recon: {}, options: {} });
+      assert.ok(!findings.some((item) => item.rule === 'HERMES_CRON_SKILL_INJECTION'));
+    } finally {
+      fs.rmSync(rootPath, { recursive: true, force: true });
+    }
+  });
+
+  it('does not build lifecycle evidence from Python comments or docstrings', async () => {
+    const findings = await scanFixture('comment-only');
+    assert.ok(!findings.some((item) => item.rule.startsWith('HERMES_CRON_')));
+  });
+
+  for (const format of ['--json', '--sarif']) {
+    it(`renders the complete cron chain in audit ${format.slice(2).toUpperCase()} output`, () => {
+      const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ship-safe-hermes-cron-'));
+      const rootPath = path.join(tempRoot, 'update-vulnerable');
+      fs.cpSync(path.join(FIXTURES, 'update-vulnerable'), rootPath, { recursive: true });
+      try {
+        const result = spawnSync(process.execPath, [
+          path.resolve('cli/bin/ship-safe.js'),
+          'audit',
+          rootPath,
+          '--hermes-only',
+          '--no-deps',
+          '--no-ai',
+          '--no-cache',
+          format,
+        ], {
+          cwd: path.resolve('.'),
+          encoding: 'utf8',
+          maxBuffer: 8 * 1024 * 1024,
+          env: { ...process.env, NO_COLOR: '1' },
+        });
+        assert.equal(result.status, 0, result.stderr);
+        const report = JSON.parse(result.stdout);
+
+        if (format === '--json') {
+          const finding = report.findings.find((item) => item.rule === 'HERMES_CRON_UPDATE_LIFECYCLE_GUARD_BYPASS');
+          assert.ok(finding);
+          assert.equal(finding.hermesCronLifecycle.stage, 'update');
+          assert.equal(finding.hermesCronLifecycle.evidence.length, 4);
+        } else {
+          const finding = report.runs[0].results.find((item) => item.ruleId === 'HERMES_CRON_UPDATE_LIFECYCLE_GUARD_BYPASS');
+          assert.ok(finding);
+          assert.equal(finding.properties.hermesCronStage, 'update');
+          assert.match(finding.properties.retainedAuthority, /stored schedule/);
+          assert.equal(finding.relatedLocations.length, 4);
+          assert.match(finding.relatedLocations[0].message.text, /schedule definition/);
+          assert.match(finding.relatedLocations[3].physicalLocation.artifactLocation.uri, /scheduler\.py$/);
+        }
+      } finally {
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+      }
+    });
+  }
+
+  it('carries the complete cron chain into CI SARIF output', () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ship-safe-hermes-ci-'));
+    const rootPath = path.join(tempRoot, 'update-vulnerable');
+    const sarifPath = path.join(tempRoot, 'results.sarif');
+    fs.cpSync(path.join(FIXTURES, 'update-vulnerable'), rootPath, { recursive: true });
+    try {
+      const result = spawnSync(process.execPath, [
+        path.resolve('cli/bin/ship-safe.js'),
+        'ci',
+        rootPath,
+        '--no-deps',
+        '--fail-on',
+        'none',
+        '--sarif',
+        sarifPath,
+      ], {
+        cwd: path.resolve('.'),
+        encoding: 'utf8',
+        maxBuffer: 8 * 1024 * 1024,
+        env: { ...process.env, NO_COLOR: '1' },
+      });
+      assert.equal(result.status, 0, result.stderr);
+      const report = JSON.parse(fs.readFileSync(sarifPath, 'utf8'));
+      const finding = report.runs[0].results.find((item) => item.ruleId === 'HERMES_CRON_UPDATE_LIFECYCLE_GUARD_BYPASS');
+      assert.ok(finding);
+      assert.equal(finding.properties.hermesCronStage, 'update');
+      assert.equal(finding.relatedLocations.length, 4);
+      assert.match(finding.relatedLocations[0].message.text, /schedule definition/);
+      assert.match(finding.relatedLocations[3].physicalLocation.artifactLocation.uri, /scheduler\.py$/);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/agents/hermes-security-agent.js
+++ b/cli/agents/hermes-security-agent.js
@@ -111,6 +111,15 @@ export const HERMES_REACHABILITY_BASES = Object.freeze([
   'reproduced',
 ]);
 
+/** Cron lifecycle stages pinned to Hermes Agent v0.21.0. */
+export const HERMES_CRON_LIFECYCLE = Object.freeze({
+  definition: 'create_job / update_job',
+  persistence: 'profile-scoped jobs.json under HERMES_HOME',
+  executionIdentity: 'job id + execution id + profile secret scope',
+  cancellation: 'fire-claim ownership and cooperative cancellation',
+  cleanup: 'finally-scoped session, cwd, secret-scope, and agent teardown',
+});
+
 // =============================================================================
 // SINGLE-LINE REGEX PATTERNS
 // =============================================================================
@@ -640,7 +649,7 @@ function pythonFunctionsWithDecorators(content) {
       continue;
     }
 
-    const match = line.match(/^(\s*)(?:async\s+)?def\s+([A-Za-z_]\w*)\s*\([^)]*\)\s*(?:->[^:]*)?:/);
+    const match = line.match(/^(\s*)(?:async\s+)?def\s+([A-Za-z_]\w*)\s*\(/);
     if (!match) {
       if (trimmed && !trimmed.startsWith('#')) pendingDecorators = [];
       continue;
@@ -648,12 +657,28 @@ function pythonFunctionsWithDecorators(content) {
 
     const indent = match[1].length;
     const body = [line];
-    let end = index + 1;
+    let headerEnd = index;
+    while (headerEnd < lines.length && !/\)\s*(?:->[^:]*)?:\s*(?:#.*)?$/.test(lines[headerEnd])) {
+      headerEnd += 1;
+      if (headerEnd < lines.length) body.push(lines[headerEnd]);
+    }
+    let end = headerEnd + 1;
+    let inTripleQuotedString = false;
     for (; end < lines.length; end += 1) {
       const candidate = lines[end];
       const candidateTrimmed = candidate.trim();
-      if (candidateTrimmed && candidate.length - candidate.trimStart().length <= indent) break;
+      const candidateIndent = candidate.length - candidate.trimStart().length;
+      if (
+        candidateTrimmed
+        && !inTripleQuotedString
+        && candidateIndent <= indent
+      ) break;
       body.push(candidate);
+      // Dedented text inside a function-local docstring/string is not a real
+      // function boundary. Tracking balanced triple-quote delimiters is enough
+      // for slicing; pythonCodeOnly() handles the later structural matching.
+      const tripleQuotes = candidate.match(/(?<!\\)(?:'''|""")/g) || [];
+      if (tripleQuotes.length % 2 === 1) inTripleQuotedString = !inTripleQuotedString;
     }
     functions.push({
       name: match[2],
@@ -1091,6 +1116,11 @@ function checkAuthJsonTOCTOU(content, filePath, agent) {
 function checkCronSkillInjection(content, filePath, agent) {
   const findings = [];
 
+  // This legacy rule models JavaScript callback schedulers. Python cron
+  // lifecycle paths are handled by checkCronLifecycle() below; letting this
+  // regex inspect Python made JS-shaped words look like Python evidence.
+  if (!/\.(?:[cm]?[jt]sx?)$/i.test(String(filePath || ''))) return findings;
+
   const SCHEDULE_RE = /(cron(?:\.schedule)?|@cron|nodeCron|node[-_]?cron|node[-_]?schedule|scheduler\.(?:schedule|every|at)|setInterval|setTimeout)\s*\(/g;
   const SKILL_LOAD_RE = /(?:readFile(?:Sync)?|fs\.read|loadSkill|skills\.get)\s*\([^)]*(?:skill|\.hermes\/skills|hermes-skills|playbook|\.md)/i;
 
@@ -1121,6 +1151,207 @@ function checkCronSkillInjection(content, filePath, agent) {
       owasp: 'ASI01',
       fix: 'Run the assembled prompt through ship-safe scan (or your own prompt-injection scanner) before invoking the agent. Pin the skill commit hash on every scheduled run.',
     }));
+  }
+
+  return findings;
+}
+
+function firstPythonMatch(fn, regex) {
+  const match = fn.text.match(regex);
+  if (!match || match.index == null) return null;
+  return {
+    line: fn.startLine + fn.text.slice(0, match.index).split('\n').length - 1,
+    text: match[0].trim(),
+  };
+}
+
+function pythonStructuralText(content) {
+  return String(content || '')
+    .replace(/'''[\s\S]*?'''|"""[\s\S]*?"""/g, (value) => value.replace(/[^\r\n]/g, ' '))
+    .replace(/^[ \t]*#.*$/gm, (value) => ' '.repeat(value.length));
+}
+
+function firstPythonMatchAfter(fn, regex, afterLine) {
+  const relativeLine = Math.max(0, Number(afterLine || fn.startLine) - fn.startLine + 1);
+  const lines = fn.text.split('\n');
+  const prefix = lines.slice(0, relativeLine).join('\n');
+  const suffix = lines.slice(relativeLine).join('\n');
+  const match = suffix.match(regex);
+  if (!match || match.index == null) return null;
+  return {
+    line: fn.startLine + prefix.split('\n').length - 1 + suffix.slice(0, match.index).split('\n').length,
+    text: match[0].trim(),
+  };
+}
+
+/** Model persisted Python cron mutations and run-scoped authority. */
+function checkCronLifecycle(files, agent) {
+  const findings = [];
+  const pythonFiles = [];
+  for (const filePath of files) {
+    if (!/\.(?:py|pyi)$/i.test(String(filePath || ''))) continue;
+    const content = agent.readFile(filePath);
+    if (!content) continue;
+    pythonFiles.push({ filePath, content, functions: pythonFunctionsWithDecorators(content) });
+  }
+  if (pythonFiles.length === 0) return findings;
+
+  let definition = null;
+  let guardedCreate = null;
+  let privilegedAction = null;
+  const privilegedActions = [];
+  const updateCandidates = [];
+  const authorityCandidates = [];
+
+  for (const file of pythonFiles) {
+    for (const fn of file.functions) {
+      const code = pythonCodeOnly(fn.text);
+      const structuralFn = { ...fn, text: pythonStructuralText(fn.text) };
+      const persisted = firstPythonMatch(structuralFn, /\b(?:save_jobs|persist_job|job_store\.save)\s*\(/i);
+      const schedule = firstPythonMatch(structuralFn, /\b(?:parse_schedule|compute_next_run|schedule)\b/i);
+      if (!definition && persisted && schedule && /\bcreate(?:_cron)?_?job\b/i.test(fn.name)) {
+        definition = { file: file.filePath, line: schedule.line, role: `schedule definition in ${fn.name}` };
+      }
+      if (
+        !guardedCreate
+        && persisted
+        && /\bcreate(?:_cron)?_?job\b/i.test(fn.name)
+        && /\bcheck_gateway_lifecycle\s*\(/.test(code)
+      ) {
+        const guard = firstPythonMatch(structuralFn, /\bcheck_gateway_lifecycle\s*\(/);
+        guardedCreate = { file: file.filePath, line: guard.line };
+      }
+
+      const action = firstPythonMatch(
+        structuralFn,
+        /\b(?:_run_job_script(?:_with_claim_heartbeat)?|run_conversation|agent\.run|execute_tool|_deliver_result)\s*\(/i
+      );
+      if (
+        action
+        && /\b(?:run|execute|fire|dispatch|deliver)/i.test(fn.name)
+        && /\bjob(?:\s*\[|\.get\s*\()/.test(code)
+      ) {
+        const normalizedPath = file.filePath.replace(/\\/g, '/');
+        privilegedActions.push({
+          file: file.filePath,
+          line: action.line,
+          role: `reachable privileged action in ${fn.name}: ${action.text}`,
+          rank: (/(?:^|\/)cron\/scheduler\.py$/i.test(normalizedPath) ? 4 : 0)
+            + (fn.name === 'run_job' ? 2 : 0)
+            + (/^_run_job_script/i.test(action.text) ? 1 : 0),
+        });
+      }
+
+      if (/\bupdate(?:_cron)?_?job\b/i.test(fn.name) && persisted) {
+        const mutatesPayload = /(?:["'](?:prompt|script|skills|enabled_toolsets)["']|_PAYLOAD_FIELDS)/.test(code);
+        if (mutatesPayload) updateCandidates.push({ file, fn, persisted, code });
+      }
+
+      const acquisition = firstPythonMatch(
+        structuralFn,
+        /\b(?:set_secret_scope|set_session_vars|record_session_cwd|grant_(?:permission|capability|authority)|acquire_(?:permission|capability|authority))\s*\(/i
+      );
+      const normalizedPath = file.filePath.replace(/\\/g, '/');
+      const cronExecutor = /job/i.test(fn.name)
+        && (/(?:^|\/)cron(?:\/|$)/i.test(normalizedPath) || /scheduler\.py$/i.test(normalizedPath));
+      const scopedAction = acquisition
+        ? firstPythonMatchAfter(
+          structuralFn,
+          /\b(?:_run_job_script(?:_with_claim_heartbeat)?|run_conversation|agent\.run|execute_tool|_deliver_result)\s*\(/i,
+          acquisition.line
+        )
+        : null;
+      if (cronExecutor && acquisition && scopedAction) {
+        authorityCandidates.push({ file, fn, acquisition, action: scopedAction, code });
+      }
+    }
+  }
+
+  privilegedActions.sort((left, right) => right.rank - left.rank);
+  if (privilegedActions.length > 0) {
+    const { rank: _rank, ...selectedAction } = privilegedActions[0];
+    privilegedAction = selectedAction;
+  }
+
+  if (definition && guardedCreate && privilegedAction) {
+    for (const candidate of updateCandidates) {
+      if (candidate.file.filePath !== definition.file || candidate.file.filePath !== guardedCreate.file) continue;
+      if (/\bcheck_gateway_lifecycle\s*\(/.test(candidate.code)) continue;
+      const finding = createFinding({
+        file: candidate.file.filePath,
+        line: candidate.fn.startLine,
+        severity: 'high',
+        category: agent.category,
+        rule: 'HERMES_CRON_UPDATE_LIFECYCLE_GUARD_BYPASS',
+        title: 'Hermes: Cron Update Bypasses the Creation Lifecycle Guard',
+        description: `The persisted cron update path ${candidate.fn.name} can replace prompt, script, skills, or enabled toolsets without re-running check_gateway_lifecycle. Creation establishes that guard as an invariant, but an update can retain the schedule while changing what the later privileged execution path runs.`,
+        matched: `${candidate.fn.name}() persists updated cron payload`,
+        confidence: 'high',
+        cwe: 'CWE-693',
+        owasp: 'ASI02',
+        fix: 'After merging the update with the stored job, run check_gateway_lifecycle on the effective prompt and script before save_jobs. Keep the guard in the low-level persistence function so CLI, tool, web, retry, and future callers cannot bypass it.',
+        evidenceLevel: 'strong',
+        reachability: 'reachable',
+      });
+      finding.hermesCronLifecycle = {
+        stage: 'update',
+        retainedAuthority: 'stored schedule keeps its execution identity and later runs the mutated payload',
+        errorAndRetryImpact: 'low-level persistence remains reachable from recovery and future callers even when a wrapper validates normal input',
+        evidence: [
+          definition,
+          { file: guardedCreate.file, line: guardedCreate.line, role: 'creation enforces the lifecycle invariant' },
+          { file: candidate.file.filePath, line: candidate.persisted.line, role: 'updated payload is persisted without the lifecycle guard' },
+          privilegedAction,
+        ],
+      };
+      findings.push(finding);
+    }
+  }
+
+  if (definition) {
+    for (const candidate of authorityCandidates) {
+      let cleanupRe = /\bfinally\s*:[\s\S]*(?:revoke|release)_(?:permission|capability|authority)\s*\(/i;
+      if (/\bset_secret_scope\s*\(/i.test(candidate.acquisition.text)) {
+        cleanupRe = /\bfinally\s*:[\s\S]*\breset_secret_scope\s*\(/i;
+      } else if (/\bset_session_vars\s*\(/i.test(candidate.acquisition.text)) {
+        cleanupRe = /\bfinally\s*:[\s\S]*\bclear_session_vars\s*\(/i;
+      } else if (/\brecord_session_cwd\s*\(/i.test(candidate.acquisition.text)) {
+        cleanupRe = /\bfinally\s*:[\s\S]*\b_?clear_(?:tool_)?session_cwd\s*\(/i;
+      }
+      const hasFinallyCleanup = cleanupRe.test(candidate.code);
+      if (hasFinallyCleanup) continue;
+      const retry = firstPythonMatch(
+        { ...candidate.fn, text: pythonStructuralText(candidate.fn.text) },
+        /\b(?:retry|reschedule)\s*\(/i
+      );
+      const finding = createFinding({
+        file: candidate.file.filePath,
+        line: candidate.acquisition.line,
+        severity: 'high',
+        category: agent.category,
+        rule: 'HERMES_CRON_RETAINED_AUTHORITY',
+        title: 'Hermes: Cron Run Authority Is Not Revoked on Every Exit',
+        description: `Cron execution ${candidate.fn.name} acquires run-scoped authority and reaches a privileged action without a matching revocation in a function-level finally block. Exceptions, cancellation, or retry can therefore leave permission, secret, or working-directory state available beyond the intended run.`,
+        matched: `${candidate.acquisition.text} -> ${candidate.action.text}`,
+        confidence: 'high',
+        cwe: 'CWE-672',
+        owasp: 'ASI02',
+        fix: 'Keep the authority token returned by the scope/grant operation and revoke or reset it in a function-level finally block that encloses execution, delivery, bookkeeping, cancellation, and retry handling.',
+        evidenceLevel: 'strong',
+        reachability: 'reachable',
+      });
+      finding.hermesCronLifecycle = {
+        stage: 'cleanup',
+        retainedAuthority: 'run-scoped authority can survive successful, exceptional, cancelled, or retried completion',
+        evidence: [
+          definition,
+          { file: candidate.file.filePath, line: candidate.acquisition.line, role: 'run-scoped authority is acquired' },
+          { file: candidate.file.filePath, line: candidate.action.line, role: 'authority reaches a privileged action' },
+          ...(retry ? [{ file: candidate.file.filePath, line: retry.line, role: 'error or retry path remains inside the unrevoked scope' }] : []),
+        ],
+      };
+      findings.push(finding);
+    }
   }
 
   return findings;
@@ -1470,6 +1701,7 @@ export class HermesSecurityAgent extends BaseAgent {
     if (hermesFiles.length === 0) return findings;
 
     findings.push(...checkTerminalBackendPosture(files, this));
+    findings.push(...checkCronLifecycle(hermesFiles, this));
 
     for (const filePath of hermesFiles) {
       const content = this.readFile(filePath);
@@ -1593,7 +1825,11 @@ export class HermesSecurityAgent extends BaseAgent {
       if (/\.(js|ts|mjs|cjs|py)$/.test(rel)) {
         const content = this.readFile(file);
         if (!content) continue;
-        if (/(?:hermes[-_]agent|@nousresearch\/hermes|hermes\.config|\bacp_adapter\b|\btui_gateway\b|toolRegistry|registerTool|callTool|spawnAgent|createSubAgent|memory\.store|episodicMemory|semanticMemory|loadManifest|\bxurl\b)/i.test(content)) {
+        const hermesPythonCron = /\.py$/i.test(rel) && (
+          /\bdef\s+(?:create_job|update_job|run_job|run_one_job)\s*\(/.test(content)
+          && /\b(?:save_jobs|check_gateway_lifecycle|set_secret_scope|_run_job_script(?:_with_claim_heartbeat)?|_deliver_result)\s*\(/.test(content)
+        );
+        if (hermesPythonCron || /(?:hermes[-_]agent|@nousresearch\/hermes|hermes\.config|\bacp_adapter\b|\btui_gateway\b|toolRegistry|registerTool|callTool|spawnAgent|createSubAgent|memory\.store|episodicMemory|semanticMemory|loadManifest|\bxurl\b)/i.test(content)) {
           hermesFiles.add(file);
         }
       }

--- a/cli/commands/audit.js
+++ b/cli/commands/audit.js
@@ -875,6 +875,7 @@ async function outputJSON(scoreResult, findings, depVulns, recon, agentResults, 
       reachability: f.reachability, exposure: f.exposure,
       ...(f.posture ? { posture: f.posture } : {}),
       ...(f.hermesBoundary ? { hermesBoundary: f.hermesBoundary } : {}),
+      ...(f.hermesCronLifecycle ? { hermesCronLifecycle: f.hermesCronLifecycle } : {}),
       // Only findings some pass actually investigated carry evidence; an empty
       // container on every finding would be noise in every report.
       ...(hasEvidence(f) ? { evidence: summarizeEvidence(f, rootPath) } : {}),
@@ -953,8 +954,8 @@ async function outputSARIF(findings, rootPath) {
             region: { startLine: f.line, startColumn: f.column || 1 },
           }
         }],
-        ...(f.hermesBoundary?.evidence?.length > 1 ? {
-          relatedLocations: f.hermesBoundary.evidence.slice(1).map((item, index) => ({
+        ...((f.hermesBoundary?.evidence?.slice(1) || f.hermesCronLifecycle?.evidence)?.length > 0 ? {
+          relatedLocations: (f.hermesBoundary?.evidence?.slice(1) || f.hermesCronLifecycle.evidence).map((item, index) => ({
             id: index + 1,
             physicalLocation: {
               artifactLocation: { uri: path.relative(rootPath, item.file).replace(/\\/g, '/'), uriBaseId: '%SRCROOT%' },
@@ -963,7 +964,7 @@ async function outputSARIF(findings, rootPath) {
             message: { text: item.role },
           })),
         } : {}),
-        ...((f.posture || f.hermesBoundary) ? {
+        ...((f.posture || f.hermesBoundary || f.hermesCronLifecycle) ? {
           properties: {
             ...(f.posture ? { posture: f.posture } : {}),
             ...(f.hermesBoundary ? {
@@ -981,6 +982,11 @@ async function outputSARIF(findings, rootPath) {
               effect: f.hermesBoundary.effect,
               executesIn: f.hermesBoundary.executesIn,
               reachabilityBasis: f.hermesBoundary.reachabilityBasis,
+            } : {}),
+            ...(f.hermesCronLifecycle ? {
+              hermesCronStage: f.hermesCronLifecycle.stage,
+              retainedAuthority: f.hermesCronLifecycle.retainedAuthority,
+              errorAndRetryImpact: f.hermesCronLifecycle.errorAndRetryImpact,
             } : {}),
           },
         } : {}),

--- a/cli/commands/ci.js
+++ b/cli/commands/ci.js
@@ -422,8 +422,8 @@ function buildSARIF(findings, rootPath) {
             region: { startLine: Math.max(1, f.line || 1), startColumn: f.column || 1 },
           },
         }],
-        ...(f.hermesBoundary?.evidence?.length > 1 ? {
-          relatedLocations: f.hermesBoundary.evidence.slice(1).map((item, index) => ({
+        ...((f.hermesBoundary?.evidence?.slice(1) || f.hermesCronLifecycle?.evidence)?.length > 0 ? {
+          relatedLocations: (f.hermesBoundary?.evidence?.slice(1) || f.hermesCronLifecycle.evidence).map((item, index) => ({
             id: index + 1,
             physicalLocation: {
               artifactLocation: {
@@ -441,7 +441,7 @@ function buildSARIF(findings, rootPath) {
         // The verdict travels into code scanning, where a severity label is
         // otherwise the only thing distinguishing a traced finding from an
         // unexamined one.
-        ...((f.posture || f.evidence?.verdict || f.hermesBoundary) ? {
+        ...((f.posture || f.evidence?.verdict || f.hermesBoundary || f.hermesCronLifecycle) ? {
           properties: {
             ...(f.posture ? { posture: f.posture } : {}),
             ...(f.hermesBoundary ? {
@@ -459,6 +459,11 @@ function buildSARIF(findings, rootPath) {
               effect: f.hermesBoundary.effect,
               executesIn: f.hermesBoundary.executesIn,
               reachabilityBasis: f.hermesBoundary.reachabilityBasis,
+            } : {}),
+            ...(f.hermesCronLifecycle ? {
+              hermesCronStage: f.hermesCronLifecycle.stage,
+              retainedAuthority: f.hermesCronLifecycle.retainedAuthority,
+              errorAndRetryImpact: f.hermesCronLifecycle.errorAndRetryImpact,
             } : {}),
             ...(f.evidence?.verdict ? {
               verdict: f.evidence.verdict,

--- a/cli/data/hermes-baseline.json
+++ b/cli/data/hermes-baseline.json
@@ -53,8 +53,12 @@
       "status": "partial",
       "upstreamPaths": ["cron/**", "tools/cronjob_tools.py"],
       "boundary": "job identity, lifecycle, subprocess environment, and reachable effects",
-      "rules": ["HERMES_CRON_SKILL_INJECTION"],
-      "limitations": "The existing detector covers a generic scheduled skill-to-prompt shape but is not calibrated to Hermes v0.21.0's Python cron lifecycle, scripts, retries, or retained permissions."
+      "rules": [
+        "HERMES_CRON_SKILL_INJECTION",
+        "HERMES_CRON_UPDATE_LIFECYCLE_GUARD_BYPASS",
+        "HERMES_CRON_RETAINED_AUTHORITY"
+      ],
+      "limitations": "Python job creation, persisted updates, scheduled execution, and run-scoped cleanup are calibrated to Hermes v0.21.0. Dynamic call targets, third-party scheduler providers, custom persistence layers, and authority implemented through unknown wrappers are not resolved statically."
     },
     {
       "id": "credential-scoping",

--- a/docs/hermes-coverage-matrix.md
+++ b/docs/hermes-coverage-matrix.md
@@ -39,7 +39,7 @@ These labels describe Ship Safe's coverage, not Hermes Agent's security.
 | Terminal backends | `tools/environments/**`, `tools/terminal_tool.py`, `tools/code_execution_tool.py`, `hermes_cli/config.py`, `hermes_cli/setup.py` | OS isolation for shell and file operations only | **Partial** | `HERMES_LOCAL_BACKEND_UNTRUSTED_INPUT` and `HERMES_TERMINAL_BACKEND_SCOPE_GAP` correlate the configured backend with an enabled untrusted MCP path that remains in the agent process | Runtime-only CLI/environment overrides, OpenShell session binding, and custom terminal-environment plugins are not resolved statically |
 | ACP | `acp_adapter/**` | Host-user controls for editor IPC | **Partial** | `HERMES_ACP_GATEWAY_EXPOSED` traces an unauthenticated, configured non-loopback WebSocket route to `HermesACPAgent.prompt` and agent tool execution | External reverse proxies, inherited deployment binds, and custom ACP transports are not resolved statically |
 | TUI gateway | `tui_gateway/**`, `ui-tui/**` | Host-user controls for local JSON-RPC IPC | **Partial** | `HERMES_TUI_GATEWAY_EXPOSED` traces an unauthenticated, configured non-loopback WebSocket route through `handle_ws` to the shared dispatcher and its prompt, command, plugin, MCP, and terminal effects | Dynamic bind values, external reverse proxies, and authorization hidden in custom middleware are not resolved statically |
-| Cron | `cron/**`, `tools/cronjob_tools.py` | Job identity, lifecycle, subprocess environment, and effects | **Partial** | Generic scheduled skill-to-prompt detection | Existing rule is not calibrated to the current Python scheduler, lifecycle guard, retries, or retained authority; #187 |
+| Cron | `cron/**`, `tools/cronjob_tools.py` | Job identity, lifecycle, subprocess environment, and effects | **Partial** | Creation/update guard symmetry and run-scoped authority cleanup, plus legacy JavaScript skill-to-prompt detection | Dynamic call targets, third-party scheduler providers, custom persistence layers, and unknown authority wrappers remain unresolved |
 | Credential scoping | `tools/environments/local.py`, `tools/code_execution_tool.py`, `tools/credential_files.py`, `cron/scheduler.py` | Filtered flow into lower-trust subprocesses; not containment | **Partial** | Generic sub-agent forwarding and credential-store exposure | Environment presence does not prove reachability or use; build the source-to-consumer-to-effect chain in #188 |
 
 No surface is marked fully covered at this baseline. That is deliberate: the
@@ -107,6 +107,47 @@ The positive fixtures are executable configurations and therefore report
 `configured`. Their loopback ACP and authenticated TUI counterparts remain
 quiet. Reproducing a finding can strengthen it later through Ship Safe's
 investigation layer without changing what the scanner observed.
+
+### Cron lifecycle and retained authority
+
+The pinned scheduler defines jobs through `create_job` and stores them in the
+active profile's `jobs.json`. A fire combines the job ID with an execution ID,
+acquires a durable fire claim, and installs profile-scoped secrets and
+task-scoped working-directory state. Cooperative cancellation and fire-claim
+ownership fence execution, saved output, delivery, and terminal bookkeeping.
+Function-level `finally` blocks clear session state, task working directories,
+secret scopes, and short-lived agent resources on successful, failed,
+cancelled, and retried runs.
+
+Ship Safe checks two lifecycle invariants:
+
+- `HERMES_CRON_UPDATE_LIFECYCLE_GUARD_BYPASS` requires a persisted schedule,
+  a lifecycle check on creation, an update that can change effective prompt,
+  script, skills, or toolsets without the same check, and a reachable scheduled
+  action. The finding cites all four locations. A wrapper-level check does not
+  settle the result because the lower-level persistence API remains callable
+  by recovery code and future entry points.
+- `HERMES_CRON_RETAINED_AUTHORITY` requires a cron execution function that
+  acquires a recognized run-scoped authority and then reaches a scheduled
+  action. It reports only when the matching authority type is not released in
+  a function-level `finally` block. Clearing unrelated context does not count
+  as revoking a secret scope, permission, capability, or working-directory
+  grant.
+
+The v0.21.0 baseline produces one update-guard finding in `cron/jobs.py`: job
+creation checks the effective prompt and script before persistence, while the
+low-level update path persists merged payload fields without repeating that
+check; the retained schedule later reaches script execution in
+`cron/scheduler.py`. The pinned scheduler's normal, error, retry, cancellation,
+and delivery paths do perform matching cleanup, so it produces no retained-
+authority finding.
+
+Cron remains **Partial** rather than Covered. Static analysis cannot resolve
+dynamically selected call targets, scheduler-provider code outside the
+repository, custom persistence implementations, or project-specific authority
+wrappers it does not recognize. The older `HERMES_CRON_SKILL_INJECTION` rule is
+explicitly scoped to JavaScript and TypeScript callback schedulers; JavaScript-
+shaped strings in Python are not lifecycle evidence.
 
 ## Maintaining the baseline
 


### PR DESCRIPTION
## Summary

- model Hermes v0.21.0 cron definition, persistence, identity, cancellation, and cleanup
- detect update paths that bypass creation-time lifecycle guards
- detect run-scoped authority that reaches scheduled actions without matching `finally` cleanup
- preserve the legacy JavaScript/TypeScript cron rule while preventing Python prose from becoming evidence
- carry complete lifecycle evidence through JSON and audit/CI SARIF
- document calibrated coverage and remaining static-analysis limits

## Pinned-source result

The pinned Hermes v0.21.0 source produces exactly one new cron finding: `HERMES_CRON_UPDATE_LIFECYCLE_GUARD_BYPASS` in `cron/jobs.py`, with evidence for schedule definition, creation guard, unguarded update persistence, and scheduled execution. Its existing scheduler cleanup remains quiet for `HERMES_CRON_RETAINED_AUTHORITY`.

## Verification

- 914 tests pass
- ESLint: 0 errors, 86 existing warnings
- deterministic corpus: 13/13 vulnerable and 13/13 clean
- verdict benchmark gate: green
- false-positive corpus: no spillover beyond the intended +1 Hermes finding
- application corpus: no new human confirmation
- `npm pack --dry-run`: clean
- pinned Hermes scan: exactly one expected cron finding

Closes #187