### PR TITLE
Trace Hermes credentials to reachable external effects

### DIFF
--- a/cli/__tests__/fixtures/hermes-credentials/adapter-safe/.hermes/config.yaml
+++ b/cli/__tests__/fixtures/hermes-credentials/adapter-safe/.hermes/config.yaml
@@ -1,0 +1,3 @@
+plugins:
+  enabled:
+    - incident-platform

--- a/cli/__tests__/fixtures/hermes-credentials/adapter-safe/.hermes/plugins/incident-platform/adapter.py
+++ b/cli/__tests__/fixtures/hermes-credentials/adapter-safe/.hermes/plugins/incident-platform/adapter.py
@@ -1,0 +1,12 @@
+from agent.secret_scope import get_secret
+import requests
+
+
+def send_incident(message):
+    api_key = get_secret("INCIDENT_API_KEY")
+    requests.post("https://incident.example.test/events", json={"message": message})
+    return api_key is not None
+
+
+def register(ctx):
+    ctx.register_adapter("incident", send_incident)

--- a/cli/__tests__/fixtures/hermes-credentials/adapter-safe/.hermes/plugins/incident-platform/plugin.yaml
+++ b/cli/__tests__/fixtures/hermes-credentials/adapter-safe/.hermes/plugins/incident-platform/plugin.yaml
@@ -1,0 +1,6 @@
+name: incident-platform
+kind: platform
+version: 1.0.0
+requires_env:
+  - name: INCIDENT_API_KEY
+    password: true

--- a/cli/__tests__/fixtures/hermes-credentials/adapter-safe/compose.yaml
+++ b/cli/__tests__/fixtures/hermes-credentials/adapter-safe/compose.yaml
@@ -1,0 +1,5 @@
+services:
+  hermes:
+    image: hermes-agent:test
+    environment:
+      HERMES_ENABLE_PROJECT_PLUGINS: "1"

--- a/cli/__tests__/fixtures/hermes-credentials/adapter-vulnerable/.hermes/config.yaml
+++ b/cli/__tests__/fixtures/hermes-credentials/adapter-vulnerable/.hermes/config.yaml
@@ -1,0 +1,3 @@
+plugins:
+  enabled:
+    - incident-platform

--- a/cli/__tests__/fixtures/hermes-credentials/adapter-vulnerable/.hermes/plugins/incident-platform/adapter.py
+++ b/cli/__tests__/fixtures/hermes-credentials/adapter-vulnerable/.hermes/plugins/incident-platform/adapter.py
@@ -1,0 +1,11 @@
+from agent.secret_scope import get_secret
+import requests
+
+
+def send_incident(message):
+    api_key = get_secret("INCIDENT_API_KEY")
+    return requests.post("https://incident.example.test/events", headers={"X-API-Key": api_key}, json={"message": message})
+
+
+def register(ctx):
+    ctx.register_adapter("incident", send_incident)

--- a/cli/__tests__/fixtures/hermes-credentials/adapter-vulnerable/.hermes/plugins/incident-platform/plugin.yaml
+++ b/cli/__tests__/fixtures/hermes-credentials/adapter-vulnerable/.hermes/plugins/incident-platform/plugin.yaml
@@ -1,0 +1,6 @@
+name: incident-platform
+kind: platform
+version: 1.0.0
+requires_env:
+  - name: INCIDENT_API_KEY
+    password: true

--- a/cli/__tests__/fixtures/hermes-credentials/adapter-vulnerable/compose.yaml
+++ b/cli/__tests__/fixtures/hermes-credentials/adapter-vulnerable/compose.yaml
@@ -1,0 +1,5 @@
+services:
+  hermes:
+    image: hermes-agent:test
+    environment:
+      HERMES_ENABLE_PROJECT_PLUGINS: "1"

--- a/cli/__tests__/fixtures/hermes-credentials/cron-safe/.hermes/config.yaml
+++ b/cli/__tests__/fixtures/hermes-credentials/cron-safe/.hermes/config.yaml
@@ -1,0 +1,6 @@
+terminal:
+  backend: local
+  env_passthrough:
+    - DEPLOY_TOKEN
+toolsets:
+  - terminal

--- a/cli/__tests__/fixtures/hermes-credentials/cron-safe/.hermes/cron/jobs.json
+++ b/cli/__tests__/fixtures/hermes-credentials/cron-safe/.hermes/cron/jobs.json
@@ -1,0 +1,11 @@
+{
+  "jobs": [
+    {
+      "id": "nightly-deploy",
+      "name": "nightly deploy",
+      "enabled": false,
+      "schedule": { "kind": "cron", "expr": "0 2 * * *" },
+      "script": "curl -H 'Authorization: Bearer $DEPLOY_TOKEN' https://deploy.example.test/nightly"
+    }
+  ]
+}

--- a/cli/__tests__/fixtures/hermes-credentials/cron-vulnerable/.hermes/config.yaml
+++ b/cli/__tests__/fixtures/hermes-credentials/cron-vulnerable/.hermes/config.yaml
@@ -1,0 +1,6 @@
+terminal:
+  backend: local
+  env_passthrough:
+    - DEPLOY_TOKEN
+toolsets:
+  - terminal

--- a/cli/__tests__/fixtures/hermes-credentials/cron-vulnerable/.hermes/cron/jobs.json
+++ b/cli/__tests__/fixtures/hermes-credentials/cron-vulnerable/.hermes/cron/jobs.json
@@ -1,0 +1,11 @@
+{
+  "jobs": [
+    {
+      "id": "nightly-deploy",
+      "name": "nightly deploy",
+      "enabled": true,
+      "schedule": { "kind": "cron", "expr": "0 2 * * *" },
+      "script": "curl -H 'Authorization: Bearer $DEPLOY_TOKEN' https://deploy.example.test/nightly"
+    }
+  ]
+}

--- a/cli/__tests__/fixtures/hermes-credentials/plugin-safe/.hermes/config.yaml
+++ b/cli/__tests__/fixtures/hermes-credentials/plugin-safe/.hermes/config.yaml
@@ -1,0 +1,3 @@
+plugins:
+  enabled:
+    - deploy-reporter

--- a/cli/__tests__/fixtures/hermes-credentials/plugin-safe/.hermes/plugins/deploy-reporter/__init__.py
+++ b/cli/__tests__/fixtures/hermes-credentials/plugin-safe/.hermes/plugins/deploy-reporter/__init__.py
@@ -1,0 +1,2 @@
+def format_report(payload):
+    return {"status": "ready", "payload": payload}

--- a/cli/__tests__/fixtures/hermes-credentials/plugin-safe/.hermes/plugins/deploy-reporter/plugin.yaml
+++ b/cli/__tests__/fixtures/hermes-credentials/plugin-safe/.hermes/plugins/deploy-reporter/plugin.yaml
@@ -1,0 +1,8 @@
+name: deploy-reporter
+kind: standalone
+version: 1.0.0
+requires_env:
+  - name: DEPLOY_TOKEN
+    password: true
+provides_tools:
+  - format_report

--- a/cli/__tests__/fixtures/hermes-credentials/plugin-safe/compose.yaml
+++ b/cli/__tests__/fixtures/hermes-credentials/plugin-safe/compose.yaml
@@ -1,0 +1,5 @@
+services:
+  hermes:
+    image: hermes-agent:test
+    environment:
+      HERMES_ENABLE_PROJECT_PLUGINS: "true"

--- a/cli/__tests__/fixtures/hermes-credentials/plugin-unregistered/.hermes/config.yaml
+++ b/cli/__tests__/fixtures/hermes-credentials/plugin-unregistered/.hermes/config.yaml
@@ -1,0 +1,3 @@
+plugins:
+  enabled:
+    - deploy-reporter

--- a/cli/__tests__/fixtures/hermes-credentials/plugin-unregistered/.hermes/plugins/deploy-reporter/__init__.py
+++ b/cli/__tests__/fixtures/hermes-credentials/plugin-unregistered/.hermes/plugins/deploy-reporter/__init__.py
@@ -1,0 +1,7 @@
+from agent.secret_scope import get_secret
+import httpx
+
+
+def unused_report_helper(payload):
+    token = get_secret("DEPLOY_TOKEN")
+    return httpx.post("https://deploy.example.test/report", headers={"Authorization": f"Bearer {token}"}, json=payload)

--- a/cli/__tests__/fixtures/hermes-credentials/plugin-unregistered/.hermes/plugins/deploy-reporter/plugin.yaml
+++ b/cli/__tests__/fixtures/hermes-credentials/plugin-unregistered/.hermes/plugins/deploy-reporter/plugin.yaml
@@ -1,0 +1,6 @@
+name: deploy-reporter
+kind: standalone
+version: 1.0.0
+requires_env:
+  - name: DEPLOY_TOKEN
+    password: true

--- a/cli/__tests__/fixtures/hermes-credentials/plugin-unregistered/compose.yaml
+++ b/cli/__tests__/fixtures/hermes-credentials/plugin-unregistered/compose.yaml
@@ -1,0 +1,5 @@
+services:
+  hermes:
+    image: hermes-agent:test
+    environment:
+      HERMES_ENABLE_PROJECT_PLUGINS: "true"

--- a/cli/__tests__/fixtures/hermes-credentials/plugin-vulnerable/.hermes/config.yaml
+++ b/cli/__tests__/fixtures/hermes-credentials/plugin-vulnerable/.hermes/config.yaml
@@ -1,0 +1,3 @@
+plugins:
+  enabled:
+    - deploy-reporter

--- a/cli/__tests__/fixtures/hermes-credentials/plugin-vulnerable/.hermes/plugins/deploy-reporter/__init__.py
+++ b/cli/__tests__/fixtures/hermes-credentials/plugin-vulnerable/.hermes/plugins/deploy-reporter/__init__.py
@@ -1,0 +1,11 @@
+from agent.secret_scope import get_secret
+import httpx
+
+
+def report_deploy(payload):
+    token = get_secret("DEPLOY_TOKEN")
+    return httpx.post("https://deploy.example.test/report", headers={"Authorization": f"Bearer {token}"}, json=payload)
+
+
+def register(ctx):
+    ctx.register_tool("report_deploy", report_deploy)

--- a/cli/__tests__/fixtures/hermes-credentials/plugin-vulnerable/.hermes/plugins/deploy-reporter/plugin.yaml
+++ b/cli/__tests__/fixtures/hermes-credentials/plugin-vulnerable/.hermes/plugins/deploy-reporter/plugin.yaml
@@ -1,0 +1,8 @@
+name: deploy-reporter
+kind: standalone
+version: 1.0.0
+requires_env:
+  - name: DEPLOY_TOKEN
+    password: true
+provides_tools:
+  - report_deploy

--- a/cli/__tests__/fixtures/hermes-credentials/plugin-vulnerable/compose.yaml
+++ b/cli/__tests__/fixtures/hermes-credentials/plugin-vulnerable/compose.yaml
@@ -1,0 +1,5 @@
+services:
+  hermes:
+    image: hermes-agent:test
+    environment:
+      HERMES_ENABLE_PROJECT_PLUGINS: "true"

--- a/cli/__tests__/fixtures/hermes-credentials/terminal-safe/.hermes/config.yaml
+++ b/cli/__tests__/fixtures/hermes-credentials/terminal-safe/.hermes/config.yaml
@@ -1,0 +1,6 @@
+terminal:
+  backend: local
+  env_passthrough:
+    - DEPLOY_TOKEN
+toolsets:
+  - terminal

--- a/cli/__tests__/fixtures/hermes-credentials/terminal-safe/.hermes/skills/deploy.md
+++ b/cli/__tests__/fixtures/hermes-credentials/terminal-safe/.hermes/skills/deploy.md
@@ -1,0 +1,7 @@
+---
+name: deploy
+required_environment_variables:
+  - DEPLOY_TOKEN
+---
+
+Generate a local deployment checklist. Do not run network commands.

--- a/cli/__tests__/fixtures/hermes-credentials/terminal-vulnerable/.hermes/config.yaml
+++ b/cli/__tests__/fixtures/hermes-credentials/terminal-vulnerable/.hermes/config.yaml
@@ -1,0 +1,6 @@
+terminal:
+  backend: local
+  env_passthrough:
+    - DEPLOY_TOKEN
+toolsets:
+  - terminal

--- a/cli/__tests__/fixtures/hermes-credentials/terminal-vulnerable/.hermes/skills/deploy.md
+++ b/cli/__tests__/fixtures/hermes-credentials/terminal-vulnerable/.hermes/skills/deploy.md
@@ -1,0 +1,7 @@
+---
+name: deploy
+required_environment_variables:
+  - DEPLOY_TOKEN
+---
+
+Run `curl -H "Authorization: Bearer $DEPLOY_TOKEN" https://deploy.example.test/release`.

--- a/cli/__tests__/hermes-credential-reachability.test.js
+++ b/cli/__tests__/hermes-credential-reachability.test.js
@@ -1,0 +1,236 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  HermesSecurityAgent,
+  HERMES_CREDENTIAL_FLOW,
+} from '../agents/hermes-security-agent.js';
+
+const FIXTURES = path.resolve('cli/__tests__/fixtures/hermes-credentials');
+
+function fixtureFiles(root) {
+  const files = [];
+  const visit = (directory) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const item = path.join(directory, entry.name);
+      if (entry.isDirectory()) visit(item);
+      else files.push(item);
+    }
+  };
+  visit(root);
+  return files;
+}
+
+async function scanFixture(name) {
+  const rootPath = path.join(FIXTURES, name);
+  return scanRoot(rootPath);
+}
+
+async function scanRoot(rootPath) {
+  return new HermesSecurityAgent().analyze({
+    rootPath,
+    files: fixtureFiles(rootPath),
+    recon: {},
+    options: {},
+  });
+}
+
+function credentialFindings(findings) {
+  return findings.filter((item) => item.rule === 'HERMES_CREDENTIAL_REACHABLE_EFFECT');
+}
+
+describe('Hermes credential reachability', () => {
+  it('requires source, scope, recipient, operation, and effect evidence', () => {
+    assert.deepEqual(HERMES_CREDENTIAL_FLOW, [
+      'source',
+      'scope',
+      'recipient',
+      'reachableOperation',
+      'externalEffect',
+    ]);
+  });
+
+  it('traces an enabled project plugin credential to its network effect', async () => {
+    const findings = credentialFindings(await scanFixture('plugin-vulnerable'));
+    assert.equal(findings.length, 1);
+    assert.match(findings[0].hermesCredentialFlow.recipient, /plugin deploy-reporter/);
+    assert.equal(findings[0].hermesCredentialFlow.reachabilityBasis, 'configured');
+    assert.equal(findings[0].hermesCredentialFlow.evidence.length, 6);
+  });
+
+  it('does not elevate a declared but unused plugin credential', async () => {
+    assert.equal(credentialFindings(await scanFixture('plugin-safe')).length, 0);
+  });
+
+  it('does not treat an unregistered helper as reachable plugin code', async () => {
+    assert.equal(credentialFindings(await scanFixture('plugin-unregistered')).length, 0);
+  });
+
+  it('does not treat project-plugin opt-in prose as executable configuration', async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ship-safe-hermes-plugin-prose-'));
+    fs.cpSync(path.join(FIXTURES, 'plugin-vulnerable'), tempRoot, { recursive: true });
+    fs.rmSync(path.join(tempRoot, 'compose.yaml'));
+    fs.writeFileSync(path.join(tempRoot, 'README.md'), 'Set HERMES_ENABLE_PROJECT_PLUGINS=true to opt in.\n');
+    try {
+      assert.equal(credentialFindings(await scanRoot(tempRoot)).length, 0);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('traces a platform adapter credential to its network effect', async () => {
+    const findings = credentialFindings(await scanFixture('adapter-vulnerable'));
+    assert.equal(findings.length, 1);
+    assert.match(findings[0].hermesCredentialFlow.recipient, /adapter incident-platform/);
+  });
+
+  it('does not elevate an adapter credential that never reaches its network call', async () => {
+    assert.equal(credentialFindings(await scanFixture('adapter-safe')).length, 0);
+  });
+
+  it('does not use Python comments or strings as credential-flow edges', async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ship-safe-hermes-plugin-prose-code-'));
+    fs.cpSync(path.join(FIXTURES, 'plugin-vulnerable'), tempRoot, { recursive: true });
+    const sourcePath = path.join(tempRoot, '.hermes/plugins/deploy-reporter/__init__.py');
+    fs.writeFileSync(sourcePath, [
+      'import httpx',
+      '',
+      'def report(payload):',
+      '    example = """token = get_secret("DEPLOY_TOKEN")"""',
+      '    return httpx.post("https://deploy.example.test/report", json=payload)',
+      '',
+      '# register_tool("report", report)',
+      '',
+    ].join('\n'));
+    try {
+      assert.equal(credentialFindings(await scanRoot(tempRoot)).length, 0);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('traces terminal passthrough only when a skill consumes it externally', async () => {
+    const vulnerable = credentialFindings(await scanFixture('terminal-vulnerable'));
+    const safe = credentialFindings(await scanFixture('terminal-safe'));
+    assert.equal(vulnerable.length, 1);
+    assert.match(vulnerable[0].hermesCredentialFlow.scope, /env_passthrough/);
+    assert.equal(safe.length, 0);
+  });
+
+  it('does not join a credential reference to an unrelated nearby network command', async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ship-safe-hermes-terminal-proximity-'));
+    fs.cpSync(path.join(FIXTURES, 'terminal-vulnerable'), tempRoot, { recursive: true });
+    fs.writeFileSync(path.join(tempRoot, '.hermes/skills/deploy.md'), [
+      '---',
+      'name: deploy',
+      'required_environment_variables:',
+      '  - DEPLOY_TOKEN',
+      '---',
+      '',
+      'Print `$DEPLOY_TOKEN` for a local diagnostic.',
+      'Run `curl https://status.example.test` separately.',
+      '',
+    ].join('\n'));
+    try {
+      assert.equal(credentialFindings(await scanRoot(tempRoot)).length, 0);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('traces an enabled cron credential effect and ignores a disabled job', async () => {
+    const vulnerable = credentialFindings(await scanFixture('cron-vulnerable'));
+    const safe = credentialFindings(await scanFixture('cron-safe'));
+    assert.equal(vulnerable.length, 1);
+    assert.match(vulnerable[0].hermesCredentialFlow.recipient, /cron job nightly deploy/);
+    assert.match(vulnerable[0].hermesCredentialFlow.externalEffect, /unattended/);
+    assert.equal(safe.length, 0);
+  });
+
+  it('reports names and evidence locations without credential values', async () => {
+    const [finding] = credentialFindings(await scanFixture('plugin-vulnerable'));
+    assert.equal(finding.hermesCredentialFlow.credential, 'DEPLOY_TOKEN');
+    assert.ok(!JSON.stringify(finding).includes('super-secret-value'));
+    for (const item of finding.hermesCredentialFlow.evidence) {
+      assert.ok(item.file);
+      assert.ok(item.line > 0);
+      assert.ok(item.role);
+    }
+  });
+
+  for (const format of ['--json', '--sarif']) {
+    it(`renders credential-chain evidence in audit ${format.slice(2).toUpperCase()} output`, () => {
+      const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ship-safe-hermes-credential-'));
+      const rootPath = path.join(tempRoot, 'plugin-vulnerable');
+      fs.cpSync(path.join(FIXTURES, 'plugin-vulnerable'), rootPath, { recursive: true });
+      try {
+        const result = spawnSync(process.execPath, [
+          path.resolve('cli/bin/ship-safe.js'),
+          'audit',
+          rootPath,
+          '--hermes-only',
+          '--no-deps',
+          '--no-ai',
+          '--no-cache',
+          format,
+        ], {
+          cwd: path.resolve('.'),
+          encoding: 'utf8',
+          maxBuffer: 8 * 1024 * 1024,
+          env: { ...process.env, NO_COLOR: '1' },
+        });
+        assert.equal(result.status, 0, result.stderr);
+        const report = JSON.parse(result.stdout);
+        if (format === '--json') {
+          const finding = report.findings.find((item) => item.rule === 'HERMES_CREDENTIAL_REACHABLE_EFFECT');
+          assert.ok(finding);
+          assert.equal(finding.hermesCredentialFlow.credential, 'DEPLOY_TOKEN');
+          assert.equal(finding.hermesCredentialFlow.evidence.length, 6);
+        } else {
+          const finding = report.runs[0].results.find((item) => item.ruleId === 'HERMES_CREDENTIAL_REACHABLE_EFFECT');
+          assert.ok(finding);
+          assert.equal(finding.properties.credential, 'DEPLOY_TOKEN');
+          assert.equal(finding.properties.reachabilityBasis, 'configured');
+          assert.equal(finding.relatedLocations.length, 6);
+        }
+      } finally {
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+      }
+    });
+  }
+
+  it('carries credential-chain evidence into CI SARIF output', () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ship-safe-hermes-credential-ci-'));
+    const rootPath = path.join(tempRoot, 'plugin-vulnerable');
+    const sarifPath = path.join(tempRoot, 'results.sarif');
+    fs.cpSync(path.join(FIXTURES, 'plugin-vulnerable'), rootPath, { recursive: true });
+    try {
+      const result = spawnSync(process.execPath, [
+        path.resolve('cli/bin/ship-safe.js'),
+        'ci',
+        rootPath,
+        '--no-deps',
+        '--fail-on',
+        'none',
+        '--sarif',
+        sarifPath,
+      ], {
+        cwd: path.resolve('.'),
+        encoding: 'utf8',
+        maxBuffer: 8 * 1024 * 1024,
+        env: { ...process.env, NO_COLOR: '1' },
+      });
+      assert.equal(result.status, 0, result.stderr);
+      const report = JSON.parse(fs.readFileSync(sarifPath, 'utf8'));
+      const finding = report.runs[0].results.find((item) => item.ruleId === 'HERMES_CREDENTIAL_REACHABLE_EFFECT');
+      assert.ok(finding);
+      assert.equal(finding.properties.credentialRecipient, 'plugin deploy-reporter');
+      assert.equal(finding.relatedLocations.length, 6);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/__tests__/hermes-posture.test.js
+++ b/cli/__tests__/hermes-posture.test.js
@@ -36,6 +36,7 @@ describe('postureFor', () => {
       'HERMES_MEMORY_EXFIL_PATTERN',
       'HERMES_BROWSER_CLOUD_METADATA_SSRF',
       'HERMES_ADAPTER_ALLOWLIST_FAIL_OPEN',
+      'HERMES_CREDENTIAL_REACHABLE_EFFECT',
     ]) {
       assert.equal(postureFor(rule), 'boundary', rule);
     }

--- a/cli/agents/hermes-security-agent.js
+++ b/cli/agents/hermes-security-agent.js
@@ -120,6 +120,15 @@ export const HERMES_CRON_LIFECYCLE = Object.freeze({
   cleanup: 'finally-scoped session, cwd, secret-scope, and agent teardown',
 });
 
+/** Evidence fields required before a configured credential path is actionable. */
+export const HERMES_CREDENTIAL_FLOW = Object.freeze([
+  'source',
+  'scope',
+  'recipient',
+  'reachableOperation',
+  'externalEffect',
+]);
+
 // =============================================================================
 // SINGLE-LINE REGEX PATTERNS
 // =============================================================================
@@ -182,6 +191,9 @@ const BOUNDARY_RULES = new Set([
   // crosses that boundary.
   'HERMES_ACP_GATEWAY_EXPOSED',
   'HERMES_TUI_GATEWAY_EXPOSED',
+  // A credential declaration becomes a boundary issue only when the complete
+  // path to a lower-trust recipient and external side effect resolves.
+  'HERMES_CREDENTIAL_REACHABLE_EFFECT',
 ]);
 
 /** Which half of Hermes's policy a rule falls under. */
@@ -540,6 +552,13 @@ function pythonCodeOnly(content) {
   return String(content || '')
     .replace(/^[ \t]*#.*$/gm, '')
     .replace(/'''[\s\S]*?'''|"""[\s\S]*?"""/g, '');
+}
+
+/** Remove Python prose while retaining line offsets for evidence locations. */
+function pythonCodeOnlyWithLines(content) {
+  return String(content || '')
+    .replace(/^[ \t]*#.*$/gm, (match) => ' '.repeat(match.length))
+    .replace(/'''[\s\S]*?'''|"""[\s\S]*?"""/g, (match) => match.replace(/[^\n]/g, ' '));
 }
 
 /**
@@ -1589,6 +1608,355 @@ function isHermesRuntimeConfig(content, filePath) {
   return /^\s*terminal\s*:/m.test(content) && /^\s*(?:mcp_servers|toolsets|model|plugins)\s*:/m.test(content);
 }
 
+const CREDENTIAL_NAME_RE = /(?:TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|CREDENTIAL|AUTH)/i;
+
+function regexEscape(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function yamlListProperty(content, sectionName, propertyName) {
+  const lines = content.split(/\r?\n/);
+  const results = [];
+  let sectionIndent = null;
+  let propertyIndent = null;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const raw = lines[index];
+    if (!raw.trim() || raw.trimStart().startsWith('#')) continue;
+    const indent = raw.length - raw.trimStart().length;
+
+    if (sectionIndent === null) {
+      const section = raw.match(new RegExp(`^(\\s*)${regexEscape(sectionName)}\\s*:\\s*(?:#.*)?$`, 'i'));
+      if (section) sectionIndent = section[1].length;
+      continue;
+    }
+    if (indent <= sectionIndent) break;
+
+    if (propertyIndent === null) {
+      const property = raw.match(new RegExp(`^(\\s*)${regexEscape(propertyName)}\\s*:\\s*(.*?)\\s*(?:#.*)?$`, 'i'));
+      if (!property) continue;
+      propertyIndent = property[1].length;
+      const inline = property[2].trim();
+      if (inline.startsWith('[') && inline.endsWith(']')) {
+        for (const value of inline.slice(1, -1).split(',')) {
+          const normalized = value.trim().replace(/^['"]|['"]$/g, '');
+          if (normalized) results.push({ value: normalized, line: index + 1 });
+        }
+      }
+      continue;
+    }
+
+    if (indent <= propertyIndent) break;
+    const item = raw.trim().match(/^-\s*['"]?([^#'"]+?)['"]?\s*(?:#.*)?$/);
+    if (item) results.push({ value: item[1].trim(), line: index + 1 });
+  }
+  return results;
+}
+
+function configuredCredentialPaths(content, filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === '.json') {
+    try {
+      const parsed = JSON.parse(content);
+      const locate = (value) => {
+        const match = content.match(new RegExp(`["']${regexEscape(value)}["']`));
+        return match ? lineNumberAt(content, match.index) : 1;
+      };
+      return {
+        passthrough: (parsed?.terminal?.env_passthrough || [])
+          .filter((value) => typeof value === 'string')
+          .map((value) => ({ value, line: locate(value) })),
+        enabledPlugins: (parsed?.plugins?.enabled || [])
+          .filter((value) => typeof value === 'string')
+          .map((value) => ({ value, line: locate(value) })),
+      };
+    } catch {
+      return { passthrough: [], enabledPlugins: [] };
+    }
+  }
+  return {
+    passthrough: yamlListProperty(content, 'terminal', 'env_passthrough'),
+    enabledPlugins: yamlListProperty(content, 'plugins', 'enabled'),
+  };
+}
+
+function manifestCredentialEntries(content) {
+  const lines = content.split(/\r?\n/);
+  const entries = [];
+  let sectionIndent = null;
+  let current = null;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const raw = lines[index];
+    if (!raw.trim() || raw.trimStart().startsWith('#')) continue;
+    const indent = raw.length - raw.trimStart().length;
+    const section = raw.match(/^(\s*)(?:requires_env|optional_env)\s*:\s*(?:#.*)?$/i);
+    if (section) {
+      sectionIndent = section[1].length;
+      current = null;
+      continue;
+    }
+    if (sectionIndent === null) continue;
+    if (indent <= sectionIndent) {
+      sectionIndent = null;
+      current = null;
+      continue;
+    }
+    const name = raw.trim().match(/^-\s*name\s*:\s*['"]?([A-Za-z_][A-Za-z0-9_]*)/i);
+    if (name) {
+      current = { name: name[1], line: index + 1, password: false };
+      entries.push(current);
+      continue;
+    }
+    if (current && /^password\s*:\s*true\b/i.test(raw.trim())) current.password = true;
+  }
+  return entries.filter((entry) => entry.password || CREDENTIAL_NAME_RE.test(entry.name));
+}
+
+function manifestIdentity(content, filePath) {
+  const name = content.match(/^\s*name\s*:\s*['"]?([^#'"\n]+)/im)?.[1]?.trim() || path.basename(path.dirname(filePath));
+  const kind = content.match(/^\s*kind\s*:\s*['"]?([^#'"\n]+)/im)?.[1]?.trim().toLowerCase() || 'standalone';
+  return { name, kind, key: path.basename(path.dirname(filePath)) };
+}
+
+function projectPluginOptIn(files, agent) {
+  for (const filePath of files) {
+    const normalized = filePath.replace(/\\/g, '/');
+    if (!/(?:^|\/)(?:Dockerfile(?:\.[^/]*)?|(?:docker-)?compose\.ya?ml|[^/]*\.env(?:\.[^/]*)?|[^/]+\.(?:ya?ml|sh))$/i.test(normalized)) continue;
+    const content = agent.readFile(filePath);
+    if (!content) continue;
+    const lines = content.split(/\r?\n/);
+    const index = lines.findIndex((line) => (
+      !line.trimStart().startsWith('#')
+      && /\bHERMES_ENABLE_PROJECT_PLUGINS\b\s*(?::|=)\s*['"]?(?:1|true|yes|on)\b/i.test(line)
+    ));
+    if (index !== -1) return { file: filePath, line: index + 1 };
+  }
+  return null;
+}
+
+function findPythonCredentialEffect(content, credentialName) {
+  const functions = pythonFunctionsWithDecorators(content);
+  const namePattern = regexEscape(credentialName);
+  const sourceRe = new RegExp(`^\\s*([A-Za-z_]\\w*)\\s*=.*\\b(?:_?scoped_)?get_secret\\s*\\(\\s*["']${namePattern}["']|^\\s*([A-Za-z_]\\w*)\\s*=.*\\bos\\.(?:getenv|environ\\.get)\\s*\\(\\s*["']${namePattern}["']`, 'i');
+  const networkRe = /\b(?:(?:requests|httpx|aiohttp|urllib)(?:\.[A-Za-z_]\w*)*\.(?:get|post|put|patch|delete|request)|urlopen|fetch|[A-Za-z_]\w*\.(?:get|post|put|patch|delete|request))\s*\(/i;
+
+  for (const fn of functions) {
+    const lines = pythonCodeOnlyWithLines(fn.text).split('\n');
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index];
+      if (line.trimStart().startsWith('#')) continue;
+      const source = line.match(sourceRe);
+      if (!source) continue;
+      const variable = source[1] || source[2];
+      const variableRe = new RegExp(`\\b${regexEscape(variable)}\\b`);
+      for (let sinkIndex = index + 1; sinkIndex < lines.length; sinkIndex += 1) {
+        const window = lines.slice(sinkIndex, sinkIndex + 5).join('\n');
+        const network = window.match(networkRe);
+        if (!network) continue;
+
+        let depth = 1;
+        let end = network.index + network[0].length;
+        for (; end < window.length; end += 1) {
+          if (window[end] === '(') depth += 1;
+          if (window[end] === ')') {
+            depth -= 1;
+            if (depth <= 0) {
+              end += 1;
+              break;
+            }
+          }
+        }
+        const call = window.slice(network.index, end);
+        if (variableRe.test(call)) {
+          const lineOffset = window.slice(0, network.index).split('\n').length - 1;
+          return {
+            sourceLine: fn.startLine + index,
+            sinkLine: fn.startLine + sinkIndex + lineOffset,
+            functionName: fn.name,
+          };
+        }
+      }
+    }
+  }
+  return null;
+}
+
+function findPluginRegistration(sources, functionName, agent) {
+  const functionRe = regexEscape(functionName);
+  const registrationRe = new RegExp(`\\bregister_(?:tool|hook|platform|adapter)\\s*\\([^)]*\\b${functionRe}\\b|\\b${functionRe}\\b[^\\n]*\\bregister_(?:tool|hook|platform|adapter)\\s*\\(`, 'i');
+  for (const file of sources) {
+    const content = pythonCodeOnlyWithLines(agent.readFile(file) || '');
+    const match = content.match(registrationRe);
+    if (match) return { file, line: lineNumberAt(content, match.index) };
+  }
+  return null;
+}
+
+function externalCommandForCredential(content, credentialName) {
+  const lines = content.split(/\r?\n/);
+  const credentialRe = new RegExp(`(?:\\$\\{?${regexEscape(credentialName)}\\}?|%${regexEscape(credentialName)}%)`, 'i');
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (credentialRe.test(line) && /\b(?:curl|wget|http|Invoke-WebRequest)\b/i.test(line)) {
+      return { line: index + 1 };
+    }
+  }
+  return null;
+}
+
+function credentialFinding({ agent, name, surface, primary, scope, recipient, operation, effect, evidence }) {
+  const finding = createFinding({
+    file: primary.file,
+    line: primary.line,
+    severity: 'high',
+    category: agent.category,
+    rule: 'HERMES_CREDENTIAL_REACHABLE_EFFECT',
+    title: `Hermes: Configured Credential Reaches a ${surface === 'adapter' ? 'Platform Adapter' : surface[0].toUpperCase() + surface.slice(1)} Effect`,
+    description: `Hermes configuration makes credential ${name} available to a lower-trust ${recipient}, and executable code consumes it on ${operation}. This is a resolved path to ${effect}; credential presence without these recipient and effect links is not reported.`,
+    matched: `${name} -> ${surface} -> external effect`,
+    confidence: 'high',
+    cwe: 'CWE-200',
+    owasp: 'ASI02',
+    fix: 'Remove the credential from this recipient, replace it with a dedicated least-privilege token, or require an approval boundary before the external operation. Keep project plugins disabled unless their code and declared capabilities have been reviewed.',
+    evidenceLevel: 'strong',
+    reachability: 'reachable',
+    exposure: 'external',
+  });
+  finding.hermesCredentialFlow = {
+    credential: name,
+    source: 'Hermes configuration declaration',
+    scope,
+    recipient,
+    reachableOperation: operation,
+    externalEffect: effect,
+    reachabilityBasis: 'configured',
+    evidence,
+  };
+  return finding;
+}
+
+/** Resolve configured credentials to actual lower-trust consumers and effects. */
+function checkCredentialReachability(files, agent) {
+  const findings = [];
+  const configs = [];
+  for (const file of files) {
+    const content = agent.readFile(file);
+    if (!content || !isHermesRuntimeConfig(content, file)) continue;
+    configs.push({ file, content, ...configuredCredentialPaths(content, file) });
+  }
+
+  const optIn = projectPluginOptIn(files, agent);
+  if (optIn) {
+    for (const manifestFile of files) {
+      const normalized = manifestFile.replace(/\\/g, '/');
+      if (!/(?:^|\/)\.hermes\/plugins\/.+\/plugin\.ya?ml$/i.test(normalized)) continue;
+      const manifestContent = agent.readFile(manifestFile);
+      if (!manifestContent) continue;
+      const identity = manifestIdentity(manifestContent, manifestFile);
+      const enabled = configs.flatMap((config) => config.enabledPlugins.map((entry) => ({ ...entry, file: config.file })))
+        .find((entry) => entry.value === identity.key || entry.value === identity.name);
+      if (!enabled) continue;
+
+      const pluginDir = path.dirname(manifestFile);
+      const sources = files.filter((file) => {
+        const relative = path.relative(pluginDir, file);
+        return relative && !relative.startsWith('..') && !path.isAbsolute(relative) && /\.py$/i.test(file);
+      });
+      for (const credential of manifestCredentialEntries(manifestContent)) {
+        for (const sourceFile of sources) {
+          const effect = findPythonCredentialEffect(agent.readFile(sourceFile) || '', credential.name);
+          if (!effect) continue;
+          const registration = findPluginRegistration(sources, effect.functionName, agent);
+          if (!registration) continue;
+          const surface = identity.kind === 'platform' ? 'adapter' : 'plugin';
+          findings.push(credentialFinding({
+            agent,
+            name: credential.name,
+            surface,
+            primary: { file: sourceFile, line: effect.sinkLine },
+            scope: 'enabled project plugin in the active profile',
+            recipient: `${surface} ${identity.key}`,
+            operation: `network operation in ${effect.functionName}()`,
+            effect: 'an external service request authenticated with the configured credential',
+            evidence: [
+              { file: manifestFile, line: credential.line, role: 'credential name is declared; no value is recorded' },
+              { file: enabled.file, line: enabled.line, role: 'project plugin is enabled' },
+              { file: optIn.file, line: optIn.line, role: 'project plugin loading is explicitly enabled' },
+              { file: registration.file, line: registration.line, role: 'Hermes registers the credential-consuming operation' },
+              { file: sourceFile, line: effect.sourceLine, role: 'plugin or adapter consumes the scoped credential' },
+              { file: sourceFile, line: effect.sinkLine, role: 'credential reaches an external network operation' },
+            ],
+          }));
+          break;
+        }
+      }
+    }
+  }
+
+  const passthrough = configs.flatMap((config) => config.passthrough.map((entry) => ({ ...entry, file: config.file })));
+  for (const credential of passthrough.filter((entry) => CREDENTIAL_NAME_RE.test(entry.value))) {
+    for (const file of files) {
+      const normalized = file.replace(/\\/g, '/');
+      const content = agent.readFile(file);
+      if (!content) continue;
+      const command = externalCommandForCredential(content, credential.value);
+      if (!command) continue;
+
+      if (/(?:^|\/)\.hermes\/skills\/.*\.md$/i.test(normalized)) {
+        const declarationRe = new RegExp(`required_environment_variables[\\s\\S]{0,500}\\b${regexEscape(credential.value)}\\b`, 'i');
+        if (!declarationRe.test(content)) continue;
+        findings.push(credentialFinding({
+          agent,
+          name: credential.value,
+          surface: 'terminal',
+          primary: { file, line: command.line },
+          scope: 'terminal.env_passthrough into the skill execution child',
+          recipient: `skill ${path.basename(file)}`,
+          operation: 'credential-bearing terminal command',
+          effect: 'an external network request from the terminal child',
+          evidence: [
+            { file: credential.file, line: credential.line, role: 'credential name is explicitly allowlisted; no value is recorded' },
+            { file, line: lineNumberAt(content, content.search(declarationRe)), role: 'skill declares the credential as a required input' },
+            { file, line: command.line, role: 'skill command consumes the credential in an external operation' },
+          ],
+        }));
+      }
+
+      if (/(?:^|\/)\.hermes\/cron\/jobs\.json$/i.test(normalized)) {
+        try {
+          const parsed = JSON.parse(content);
+          const jobs = Array.isArray(parsed) ? parsed : (Array.isArray(parsed?.jobs) ? parsed.jobs : []);
+          const referenceRe = new RegExp(`(?:\\$\\{?${regexEscape(credential.value)}\\}?|%${regexEscape(credential.value)}%)`, 'i');
+          const job = jobs.find((item) => item && item.enabled !== false && referenceRe.test(String(item.script || '')) && /\b(?:curl|wget|http|Invoke-WebRequest)\b/i.test(String(item.script || '')));
+          if (!job) continue;
+          const marker = String(job.id || job.name || credential.value);
+          const markerIndex = content.indexOf(marker);
+          findings.push(credentialFinding({
+            agent,
+            name: credential.value,
+            surface: 'cron',
+            primary: { file, line: markerIndex >= 0 ? lineNumberAt(content, markerIndex) : command.line },
+            scope: 'profile-scoped cron execution with terminal env passthrough',
+            recipient: `enabled cron job ${String(job.name || job.id || 'scheduled job')}`,
+            operation: 'scheduled credential-bearing command',
+            effect: 'an unattended external network request',
+            evidence: [
+              { file: credential.file, line: credential.line, role: 'credential name is explicitly allowlisted; no value is recorded' },
+              { file, line: markerIndex >= 0 ? lineNumberAt(content, markerIndex) : command.line, role: 'enabled persisted cron job receives the credential scope' },
+              { file, line: command.line, role: 'scheduled command consumes the credential in an external operation' },
+            ],
+          }));
+        } catch {
+          // Invalid or templated jobs files do not establish a configured path.
+        }
+      }
+    }
+  }
+
+  return findings;
+}
+
 /**
  * Compare a declared terminal backend with an input path that demonstrably
  * remains in the agent process. This is deliberately a project-level check:
@@ -1702,6 +2070,7 @@ export class HermesSecurityAgent extends BaseAgent {
 
     findings.push(...checkTerminalBackendPosture(files, this));
     findings.push(...checkCronLifecycle(hermesFiles, this));
+    findings.push(...checkCredentialReachability(files, this));
 
     for (const filePath of hermesFiles) {
       const content = this.readFile(filePath);

--- a/cli/commands/audit.js
+++ b/cli/commands/audit.js
@@ -876,6 +876,7 @@ async function outputJSON(scoreResult, findings, depVulns, recon, agentResults, 
       ...(f.posture ? { posture: f.posture } : {}),
       ...(f.hermesBoundary ? { hermesBoundary: f.hermesBoundary } : {}),
       ...(f.hermesCronLifecycle ? { hermesCronLifecycle: f.hermesCronLifecycle } : {}),
+      ...(f.hermesCredentialFlow ? { hermesCredentialFlow: f.hermesCredentialFlow } : {}),
       // Only findings some pass actually investigated carry evidence; an empty
       // container on every finding would be noise in every report.
       ...(hasEvidence(f) ? { evidence: summarizeEvidence(f, rootPath) } : {}),
@@ -954,8 +955,8 @@ async function outputSARIF(findings, rootPath) {
             region: { startLine: f.line, startColumn: f.column || 1 },
           }
         }],
-        ...((f.hermesBoundary?.evidence?.slice(1) || f.hermesCronLifecycle?.evidence)?.length > 0 ? {
-          relatedLocations: (f.hermesBoundary?.evidence?.slice(1) || f.hermesCronLifecycle.evidence).map((item, index) => ({
+        ...((f.hermesBoundary?.evidence?.slice(1) || f.hermesCronLifecycle?.evidence || f.hermesCredentialFlow?.evidence)?.length > 0 ? {
+          relatedLocations: (f.hermesBoundary?.evidence?.slice(1) || f.hermesCronLifecycle?.evidence || f.hermesCredentialFlow.evidence).map((item, index) => ({
             id: index + 1,
             physicalLocation: {
               artifactLocation: { uri: path.relative(rootPath, item.file).replace(/\\/g, '/'), uriBaseId: '%SRCROOT%' },
@@ -964,7 +965,7 @@ async function outputSARIF(findings, rootPath) {
             message: { text: item.role },
           })),
         } : {}),
-        ...((f.posture || f.hermesBoundary || f.hermesCronLifecycle) ? {
+        ...((f.posture || f.hermesBoundary || f.hermesCronLifecycle || f.hermesCredentialFlow) ? {
           properties: {
             ...(f.posture ? { posture: f.posture } : {}),
             ...(f.hermesBoundary ? {
@@ -987,6 +988,14 @@ async function outputSARIF(findings, rootPath) {
               hermesCronStage: f.hermesCronLifecycle.stage,
               retainedAuthority: f.hermesCronLifecycle.retainedAuthority,
               errorAndRetryImpact: f.hermesCronLifecycle.errorAndRetryImpact,
+            } : {}),
+            ...(f.hermesCredentialFlow ? {
+              credential: f.hermesCredentialFlow.credential,
+              credentialScope: f.hermesCredentialFlow.scope,
+              credentialRecipient: f.hermesCredentialFlow.recipient,
+              reachableOperation: f.hermesCredentialFlow.reachableOperation,
+              externalEffect: f.hermesCredentialFlow.externalEffect,
+              reachabilityBasis: f.hermesCredentialFlow.reachabilityBasis,
             } : {}),
           },
         } : {}),

--- a/cli/commands/ci.js
+++ b/cli/commands/ci.js
@@ -422,8 +422,8 @@ function buildSARIF(findings, rootPath) {
             region: { startLine: Math.max(1, f.line || 1), startColumn: f.column || 1 },
           },
         }],
-        ...((f.hermesBoundary?.evidence?.slice(1) || f.hermesCronLifecycle?.evidence)?.length > 0 ? {
-          relatedLocations: (f.hermesBoundary?.evidence?.slice(1) || f.hermesCronLifecycle.evidence).map((item, index) => ({
+        ...((f.hermesBoundary?.evidence?.slice(1) || f.hermesCronLifecycle?.evidence || f.hermesCredentialFlow?.evidence)?.length > 0 ? {
+          relatedLocations: (f.hermesBoundary?.evidence?.slice(1) || f.hermesCronLifecycle?.evidence || f.hermesCredentialFlow.evidence).map((item, index) => ({
             id: index + 1,
             physicalLocation: {
               artifactLocation: {
@@ -441,7 +441,7 @@ function buildSARIF(findings, rootPath) {
         // The verdict travels into code scanning, where a severity label is
         // otherwise the only thing distinguishing a traced finding from an
         // unexamined one.
-        ...((f.posture || f.evidence?.verdict || f.hermesBoundary || f.hermesCronLifecycle) ? {
+        ...((f.posture || f.evidence?.verdict || f.hermesBoundary || f.hermesCronLifecycle || f.hermesCredentialFlow) ? {
           properties: {
             ...(f.posture ? { posture: f.posture } : {}),
             ...(f.hermesBoundary ? {
@@ -464,6 +464,14 @@ function buildSARIF(findings, rootPath) {
               hermesCronStage: f.hermesCronLifecycle.stage,
               retainedAuthority: f.hermesCronLifecycle.retainedAuthority,
               errorAndRetryImpact: f.hermesCronLifecycle.errorAndRetryImpact,
+            } : {}),
+            ...(f.hermesCredentialFlow ? {
+              credential: f.hermesCredentialFlow.credential,
+              credentialScope: f.hermesCredentialFlow.scope,
+              credentialRecipient: f.hermesCredentialFlow.recipient,
+              reachableOperation: f.hermesCredentialFlow.reachableOperation,
+              externalEffect: f.hermesCredentialFlow.externalEffect,
+              reachabilityBasis: f.hermesCredentialFlow.reachabilityBasis,
             } : {}),
             ...(f.evidence?.verdict ? {
               verdict: f.evidence.verdict,

--- a/cli/data/hermes-baseline.json
+++ b/cli/data/hermes-baseline.json
@@ -65,8 +65,12 @@
       "status": "partial",
       "upstreamPaths": ["tools/environments/local.py", "tools/code_execution_tool.py", "tools/credential_files.py", "cron/scheduler.py"],
       "boundary": "filtered credential flow into lower-trust subprocesses and external effects",
-      "rules": ["HERMES_SUB_AGENT_CREDENTIAL_FORWARD", "HERMES_XURL_TOKEN_STORE_EXPOSURE"],
-      "limitations": "Generic forwarding and credential-store exposure are covered. Ship Safe does not yet prove that a configured credential reaches and is consumed by a lower-trust component."
+      "rules": [
+        "HERMES_SUB_AGENT_CREDENTIAL_FORWARD",
+        "HERMES_XURL_TOKEN_STORE_EXPOSURE",
+        "HERMES_CREDENTIAL_REACHABLE_EFFECT"
+      ],
+      "limitations": "Configured project-plugin, platform-adapter, terminal-skill, and persisted-cron flows are correlated to literal credential consumers and external operations. Dynamic credential names, indirect registrations, pip/user plugins outside the repository, templated jobs, and effects hidden behind unknown wrappers remain unresolved."
     }
   ]
 }

--- a/docs/hermes-coverage-matrix.md
+++ b/docs/hermes-coverage-matrix.md
@@ -40,7 +40,7 @@ These labels describe Ship Safe's coverage, not Hermes Agent's security.
 | ACP | `acp_adapter/**` | Host-user controls for editor IPC | **Partial** | `HERMES_ACP_GATEWAY_EXPOSED` traces an unauthenticated, configured non-loopback WebSocket route to `HermesACPAgent.prompt` and agent tool execution | External reverse proxies, inherited deployment binds, and custom ACP transports are not resolved statically |
 | TUI gateway | `tui_gateway/**`, `ui-tui/**` | Host-user controls for local JSON-RPC IPC | **Partial** | `HERMES_TUI_GATEWAY_EXPOSED` traces an unauthenticated, configured non-loopback WebSocket route through `handle_ws` to the shared dispatcher and its prompt, command, plugin, MCP, and terminal effects | Dynamic bind values, external reverse proxies, and authorization hidden in custom middleware are not resolved statically |
 | Cron | `cron/**`, `tools/cronjob_tools.py` | Job identity, lifecycle, subprocess environment, and effects | **Partial** | Creation/update guard symmetry and run-scoped authority cleanup, plus legacy JavaScript skill-to-prompt detection | Dynamic call targets, third-party scheduler providers, custom persistence layers, and unknown authority wrappers remain unresolved |
-| Credential scoping | `tools/environments/local.py`, `tools/code_execution_tool.py`, `tools/credential_files.py`, `cron/scheduler.py` | Filtered flow into lower-trust subprocesses; not containment | **Partial** | Generic sub-agent forwarding and credential-store exposure | Environment presence does not prove reachability or use; build the source-to-consumer-to-effect chain in #188 |
+| Credential scoping | `tools/environments/local.py`, `tools/code_execution_tool.py`, `tools/credential_files.py`, `cron/scheduler.py` | Filtered flow into lower-trust subprocesses; not containment | **Partial** | Configured credential declarations are correlated to registered project plugins, platform adapters, terminal skills, and persisted cron effects | Dynamic names, indirect registrations, external plugin installations, templated jobs, and unknown wrappers remain unresolved |
 
 No surface is marked fully covered at this baseline. That is deliberate: the
 matrix records what the current implementation can prove, not what its rule
@@ -148,6 +148,42 @@ repository, custom persistence implementations, or project-specific authority
 wrappers it does not recognize. The older `HERMES_CRON_SKILL_INJECTION` rule is
 explicitly scoped to JavaScript and TypeScript callback schedulers; JavaScript-
 shaped strings in Python are not lifecycle evidence.
+
+### Credential reachability
+
+Credential presence is not a verdict. Hermes intentionally keeps provider and
+platform secrets in profile-scoped storage, allows selected third-party values
+through `terminal.env_passthrough`, and makes project plugins opt-in. Reporting
+each declaration would confuse intended configuration with a demonstrated
+exposure path.
+
+`HERMES_CREDENTIAL_REACHABLE_EFFECT` therefore requires five resolved facts:
+
+1. a credential name declared in Hermes configuration or a plugin manifest;
+2. a scope that makes it available to a specific execution context;
+3. a lower-trust recipient that is enabled and reachable;
+4. executable code or a scheduled command that consumes that credential; and
+5. an external network effect reached by the consuming operation.
+
+For project plugins and platform adapters, the plugin must be listed in
+`plugins.enabled`, project-plugin loading must be explicitly enabled, Hermes's
+plugin API must register the consuming function, and that function must read
+the named secret and pass it to a network operation. A declaration, dead
+helper, or unregistered function decides nothing. For terminal skills, an
+explicit passthrough entry, matching skill requirement, credential-bearing
+command, and external operation are all required. Cron additionally requires
+an enabled persisted job whose scheduled script consumes the credential.
+
+Findings record only credential identifiers such as `DEPLOY_TOKEN`, never the
+resolved value. JSON and SARIF carry the source, scope, recipient, reachable
+operation, external effect, reachability basis, and resolvable locations. The
+deterministic finding remains visible; static evidence does not claim a
+reproduced or human-confirmed verdict.
+
+Credential coverage remains **Partial**. Dynamic secret names, registration
+through unknown wrappers, user and pip plugins outside the scanned repository,
+generated job definitions, and network effects hidden behind custom clients
+cannot be connected safely by this structural pass.
 
 ## Maintaining the baseline
 


### PR DESCRIPTION
## Summary

- add a deterministic Hermes credential-flow rule that requires source, scope, recipient, registered operation, and external effect evidence
- cover enabled project plugins, platform adapters, terminal skills, and persisted cron jobs
- keep declarations, unused credentials, unregistered helpers, comments, strings, disabled jobs, and unrelated nearby commands quiet
- serialize resolvable evidence in audit JSON and audit/CI SARIF without exposing credential values
- update the Hermes baseline and coverage matrix

## Verification

- 929 tests pass
- lint: 0 errors
- deterministic corpus: 13/13 detections and 13/13 clean controls
- verdict benchmark: 0 false refutations and 0 unlabeled findings
- false-positive corpus: vulnerable detection floors preserved
- pinned Hermes v0.21.0: 0 HERMES_CREDENTIAL_REACHABLE_EFFECT findings
- npm pack --dry-run clean
- git diff --check clean

Closes #188