### PR TITLE
fix: negotiate MCP initialize protocol version

### DIFF
--- a/cli/__tests__/mcp-transport.test.js
+++ b/cli/__tests__/mcp-transport.test.js
@@ -49,3 +49,47 @@ test('MCP stdio waits for an asynchronous scan response before exiting', async (
     fs.rmSync(fixture, { recursive: true, force: true });
   }
 });
+
+test('MCP initialize negotiates a supported protocol version', async () => {
+  const cliPath = path.resolve('cli/bin/ship-safe.js');
+
+  const initialize = (id, protocolVersion) => JSON.stringify({
+    jsonrpc: '2.0',
+    id,
+    method: 'initialize',
+    params: {
+      protocolVersion,
+      capabilities: {},
+      clientInfo: { name: 'fixture-client', version: '1.0.0' },
+    },
+  });
+
+  const request = `${initialize(2, '2025-11-25')}\n${initialize(3, '2026-07-28')}`;
+
+  const result = await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [cliPath, 'mcp'], { cwd: process.cwd() });
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error('MCP initialize response timed out'));
+    }, 10000);
+
+    child.stdout.on('data', chunk => { stdout += chunk; });
+    child.stderr.on('data', chunk => { stderr += chunk; });
+    child.on('error', error => { clearTimeout(timer); reject(error); });
+    child.on('close', code => {
+      clearTimeout(timer);
+      resolve({ code, stdout, stderr });
+    });
+    child.stdin.end(`${request}\n`);
+  });
+
+  assert.equal(result.code, 0, result.stderr);
+  const responses = result.stdout.trim().split('\n').map(line => JSON.parse(line));
+  assert.deepEqual(responses.map(item => item.id), [2, 3]);
+  assert.deepEqual(
+    responses.map(item => item.result.protocolVersion),
+    ['2025-11-25', '2025-11-25'],
+  );
+});

--- a/cli/commands/mcp.js
+++ b/cli/commands/mcp.js
@@ -56,6 +56,8 @@ import { DeepAnalyzer } from '../agents/deep-analyzer.js';
 import { PACKAGE_VERSION } from '../utils/package-version.js';
 
 export const MCP_SERVER_VERSION = PACKAGE_VERSION;
+export const MCP_SUPPORTED_PROTOCOL_VERSIONS = ['2025-11-25', '2024-11-05'];
+export const MCP_DEFAULT_PROTOCOL_VERSION = MCP_SUPPORTED_PROTOCOL_VERSIONS[0];
 
 const MAX_MCP_FINDINGS = 200;
 
@@ -606,12 +608,17 @@ async function handleRequest(request) {
   const respondError = (code, message) => ({ jsonrpc: '2.0', id, error: { code, message } });
 
   switch (method) {
-    case 'initialize':
+    case 'initialize': {
+      const requestedProtocolVersion = params?.protocolVersion;
+      const protocolVersion = MCP_SUPPORTED_PROTOCOL_VERSIONS.includes(requestedProtocolVersion)
+        ? requestedProtocolVersion
+        : MCP_DEFAULT_PROTOCOL_VERSION;
       return respond({
-        protocolVersion: '2024-11-05',
+        protocolVersion,
         capabilities: { tools: {} },
         serverInfo: { name: 'ship-safe', version: MCP_SERVER_VERSION },
       });
+    }
 
     case 'tools/list':
       return respond({ tools: TOOLS });


### PR DESCRIPTION
## Summary

- Fix MCP initialize responses that were hard-coded to 2024-11-05.
- Negotiate 2025-11-25 or 2024-11-05 when requested.
- Default unsupported requests to the newest supported legacy revision.
- Add transport coverage for supported-version negotiation and fallback.

This fixes #168. It intentionally does not claim 2026-07-28 or server/discover support; that broader conformance work remains separate.

## Verification

- 930 tests passed
- targeted ESLint: 0 errors, 3 pre-existing warnings
- git diff --check passed
- npm pack --dry-run passed

Reference: https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle