### PR TITLE
feat: add MCP modern discovery support

### DIFF
--- a/cli/__tests__/mcp-transport.test.js
+++ b/cli/__tests__/mcp-transport.test.js
@@ -4,6 +4,7 @@ import os from 'node:os';
 import { spawn } from 'node:child_process';
 import path from 'node:path';
 import test from 'node:test';
+import { PACKAGE_VERSION } from '../utils/package-version.js';
 
 test('MCP stdio waits for an asynchronous scan response before exiting', async () => {
   const cliPath = path.resolve('cli/bin/ship-safe.js');
@@ -92,4 +93,93 @@ test('MCP initialize negotiates a supported protocol version', async () => {
     responses.map(item => item.result.protocolVersion),
     ['2025-11-25', '2025-11-25'],
   );
+});
+
+test('MCP modern discovery and result envelopes stay separate from legacy output', async () => {
+  const cliPath = path.resolve('cli/bin/ship-safe.js');
+  const modernMeta = {
+    'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+    'io.modelcontextprotocol/clientCapabilities': {},
+    'io.modelcontextprotocol/clientInfo': { name: 'fixture-client', version: '1.0.0' },
+  };
+  const requests = [
+    { jsonrpc: '2.0', id: 10, method: 'server/discover' },
+    { jsonrpc: '2.0', id: 11, method: 'tools/list', params: { _meta: modernMeta } },
+    {
+      jsonrpc: '2.0',
+      id: 12,
+      method: 'tools/call',
+      params: { name: 'get_checklist', arguments: {}, _meta: modernMeta },
+    },
+    {
+      jsonrpc: '2.0',
+      id: 13,
+      method: 'tools/list',
+      params: {
+        _meta: { ...modernMeta, 'io.modelcontextprotocol/protocolVersion': '1999-01-01' },
+      },
+    },
+    {
+      jsonrpc: '2.0',
+      id: 14,
+      method: 'tools/list',
+      params: { _meta: { ...modernMeta, 'io.modelcontextprotocol/protocolVersion': '2025-11-25' } },
+    },
+  ];
+
+  const result = await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [cliPath, 'mcp'], { cwd: process.cwd() });
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error('MCP modern protocol response timed out'));
+    }, 10000);
+
+    child.stdout.on('data', chunk => { stdout += chunk; });
+    child.stderr.on('data', chunk => { stderr += chunk; });
+    child.on('error', error => { clearTimeout(timer); reject(error); });
+    child.on('close', code => {
+      clearTimeout(timer);
+      resolve({ code, stdout, stderr });
+    });
+    child.stdin.end(`${requests.map(request => JSON.stringify(request)).join('\n')}\n`);
+  });
+
+  assert.equal(result.code, 0, result.stderr);
+  const responses = result.stdout.trim().split('\n').map(line => JSON.parse(line));
+  assert.deepEqual(responses.map(response => response.id), [10, 11, 12, 13, 14]);
+
+  const discovery = responses[0].result;
+  assert.deepEqual(discovery.supportedVersions, ['2026-07-28', '2025-11-25', '2024-11-05']);
+  assert.equal(discovery.resultType, 'complete');
+  assert.equal(discovery.ttlMs, 300000);
+  assert.equal(discovery.cacheScope, 'public');
+  assert.deepEqual(discovery._meta['io.modelcontextprotocol/serverInfo'], {
+    name: 'ship-safe',
+    version: PACKAGE_VERSION,
+  });
+
+  const modernList = responses[1].result;
+  assert.equal(modernList.resultType, 'complete');
+  assert.equal(modernList.ttlMs, 300000);
+  assert.equal(modernList.cacheScope, 'public');
+  assert.ok(Array.isArray(modernList.tools));
+  assert.equal(modernList._meta['io.modelcontextprotocol/serverInfo'].name, 'ship-safe');
+
+  const modernCall = responses[2].result;
+  assert.equal(modernCall.resultType, 'complete');
+  assert.ok(Array.isArray(modernCall.content));
+  assert.equal(modernCall._meta['io.modelcontextprotocol/serverInfo'].name, 'ship-safe');
+
+  assert.equal(responses[3].error.code, -32022);
+  assert.deepEqual(responses[3].error.data.supported, ['2026-07-28', '2025-11-25', '2024-11-05']);
+  assert.equal(responses[3].error.data.requested, '1999-01-01');
+
+  const legacyList = responses[4].result;
+  assert.ok(Array.isArray(legacyList.tools));
+  assert.equal(legacyList.resultType, undefined);
+  assert.equal(legacyList.ttlMs, undefined);
+  assert.equal(legacyList.cacheScope, undefined);
+  assert.equal(legacyList._meta, undefined);
 });

--- a/cli/commands/mcp.js
+++ b/cli/commands/mcp.js
@@ -56,8 +56,17 @@ import { DeepAnalyzer } from '../agents/deep-analyzer.js';
 import { PACKAGE_VERSION } from '../utils/package-version.js';
 
 export const MCP_SERVER_VERSION = PACKAGE_VERSION;
-export const MCP_SUPPORTED_PROTOCOL_VERSIONS = ['2025-11-25', '2024-11-05'];
+export const MCP_MODERN_PROTOCOL_VERSION = '2026-07-28';
+export const MCP_SUPPORTED_PROTOCOL_VERSIONS = [MCP_MODERN_PROTOCOL_VERSION, '2025-11-25', '2024-11-05'];
+export const MCP_LEGACY_PROTOCOL_VERSIONS = MCP_SUPPORTED_PROTOCOL_VERSIONS.filter(
+  version => version !== MCP_MODERN_PROTOCOL_VERSION,
+);
 export const MCP_DEFAULT_PROTOCOL_VERSION = MCP_SUPPORTED_PROTOCOL_VERSIONS[0];
+export const MCP_LEGACY_DEFAULT_PROTOCOL_VERSION = MCP_LEGACY_PROTOCOL_VERSIONS[0];
+
+const MCP_PROTOCOL_VERSION_META = 'io.modelcontextprotocol/protocolVersion';
+const MCP_SERVER_INFO_META = 'io.modelcontextprotocol/serverInfo';
+const MCP_DISCOVERY_TTL_MS = 300000;
 
 const MAX_MCP_FINDINGS = 200;
 
@@ -607,12 +616,47 @@ async function handleRequest(request) {
   const respond = (result) => ({ jsonrpc: '2.0', id, result });
   const respondError = (code, message) => ({ jsonrpc: '2.0', id, error: { code, message } });
 
+  const requestedProtocolVersion = params?._meta?.[MCP_PROTOCOL_VERSION_META];
+  if (requestedProtocolVersion !== undefined
+    && !MCP_SUPPORTED_PROTOCOL_VERSIONS.includes(requestedProtocolVersion)) {
+    return {
+      jsonrpc: '2.0',
+      id,
+      error: {
+        code: -32022,
+        message: 'Unsupported protocol version',
+        data: {
+          supported: MCP_SUPPORTED_PROTOCOL_VERSIONS,
+          requested: requestedProtocolVersion,
+        },
+      },
+    };
+  }
+
+  const modernRequest = params?._meta?.[MCP_PROTOCOL_VERSION_META] === MCP_MODERN_PROTOCOL_VERSION;
+  const modernResult = (result, { cacheable = false } = {}) => ({
+    ...result,
+    resultType: 'complete',
+    ...(cacheable ? { ttlMs: MCP_DISCOVERY_TTL_MS, cacheScope: 'public' } : {}),
+    _meta: {
+      ...(result._meta ?? {}),
+      [MCP_SERVER_INFO_META]: { name: 'ship-safe', version: MCP_SERVER_VERSION },
+    },
+  });
+
   switch (method) {
+    case 'server/discover':
+      return respond(modernResult({
+        supportedVersions: MCP_SUPPORTED_PROTOCOL_VERSIONS,
+        capabilities: { tools: {} },
+        instructions: 'Use Ship Safe tools to inspect repositories and review security findings before code ships.',
+      }, { cacheable: true }));
+
     case 'initialize': {
       const requestedProtocolVersion = params?.protocolVersion;
-      const protocolVersion = MCP_SUPPORTED_PROTOCOL_VERSIONS.includes(requestedProtocolVersion)
+      const protocolVersion = MCP_LEGACY_PROTOCOL_VERSIONS.includes(requestedProtocolVersion)
         ? requestedProtocolVersion
-        : MCP_DEFAULT_PROTOCOL_VERSION;
+        : MCP_LEGACY_DEFAULT_PROTOCOL_VERSION;
       return respond({
         protocolVersion,
         capabilities: { tools: {} },
@@ -621,7 +665,9 @@ async function handleRequest(request) {
     }
 
     case 'tools/list':
-      return respond({ tools: TOOLS });
+      return respond(modernRequest
+        ? modernResult({ tools: TOOLS }, { cacheable: true })
+        : { tools: TOOLS });
 
     case 'tools/call': {
       const { name, arguments: args } = params;
@@ -654,9 +700,10 @@ async function handleRequest(request) {
             return respondError(-32601, `Unknown tool: ${name}`);
         }
 
-        return respond({
+        const toolResult = {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        });
+        };
+        return respond(modernRequest ? modernResult(toolResult) : toolResult);
       } catch (err) {
         return respondError(-32603, err.message);
       }


### PR DESCRIPTION
## Summary

- Add handshake-free `server/discover` for MCP 2026-07-28.
- Advertise the supported modern and legacy protocol revisions and tools capability.
- Add cache hints, result envelopes, server identity metadata, and instructions for modern responses.
- Reject unsupported per-request protocol versions with the advertised supported list.
- Preserve legacy initialize and response shapes for 2025-11-25 and earlier clients.
- Add regression coverage for discovery, modern results, version errors, and legacy-field isolation.

Fixes #167.

## Verification

- Full test suite: 931 passed, 0 failed
- Targeted ESLint: 0 errors; existing warnings only
- `git diff --check`: passed
- `npm pack --dry-run`: passed
- `@hasmcp/mcp-spec-test` against the local CLI: 27 passed, 0 failed, 9 not verified because Ship Safe does not advertise prompts/resources/subscriptions, and 1 optional pagination recommendation remains

The implementation does not advertise capabilities it does not implement. The modern MCP discovery contract is documented at https://modelcontextprotocol.io/specification/draft/server/discover