### PR TITLE
Align the npm description with the README, and fix repo metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ship-safe",
   "version": "10.0.0",
-  "description": "AI-powered multi-agent security platform. 29 agents scan 80+ attack classes including AI integration supply chain (Vercel-class attacks), Hermes Agent deployment scanning (ASI-01–ASI-10), tool registry poisoning, function-call injection, skill permission drift, and agent attestation.",
+  "description": "The independent security agent for AI-written software. A deterministic engine finds issues across application code, AI agents, MCP servers, skills, dependencies, CI/CD, and secrets. An investigation layer traces whether each one is real and reports the evidence as JSON and SARIF.",
   "main": "cli/index.js",
   "bin": {
     "ship-safe": "cli/bin/ship-safe.js"
@@ -17,8 +17,6 @@
     "benchmark:hermes-release": "node benchmarks/hermes-release-evidence/run.mjs",
     "benchmark:fp:write": "node benchmarks/false-positives/run.mjs --write",
     "benchmark:corpus:write": "node benchmarks/run.mjs --write",
-    "benchmark:fp": "node benchmarks/false-positives/run.mjs",
-    "benchmark:fp:write": "node benchmarks/false-positives/run.mjs --write",
     "lint": "eslint cli/",
     "lint:fix": "eslint cli/ --fix",
     "ship-safe": "node cli/bin/ship-safe.js",
@@ -48,7 +46,13 @@
     "mobile-security",
     "jwt",
     "cors",
-    "cli"
+    "cli",
+    "mcp",
+    "sarif",
+    "agent-security",
+    "ai-agents",
+    "hermes",
+    "static-analysis"
   ],
   "author": "ship-safe contributors",
   "license": "MIT",


### PR DESCRIPTION
Three small things, none of them behavioural.

## The npm description said something different from the README

The README has said "the independent security agent for AI-written software. It finds issues, investigates whether they are real, and shows you the evidence" since the investigation layer landed. `package.json` still said "AI-powered multi-agent security platform", which leads with a category instead of a capability and undersells the part that actually distinguishes the tool: the deterministic engine needs no API key at all.

npm, GitHub, and the README now say the same thing.

## Keywords

Adds `mcp`, `sarif`, `agent-security`, `ai-agents`, `hermes`, `static-analysis`. Every existing keyword is untouched, so nothing loses search ranking.

## Two duplicate keys in `scripts`

`benchmark:fp` and `benchmark:fp:write` were each declared twice with identical values. JSON keeps the last occurrence, so behaviour was already correct and is unchanged. It is removed because a duplicate key is a trap for whoever edits the first copy next and wonders why nothing happened.

## Also done outside this PR

The GitHub topic `devscops` was a typo for `devsecops`, so the repo was invisible on a topic that gets real browse traffic. Fixed, and added `sarif`, `agent-security`, `prompt-injection`, `supply-chain-security`, and `hermes`. The repo description also had a leading space, now removed.

## What is deliberately not changed

**The "29 agents" claim is correct.** I had previously flagged it as stale and that was wrong. The scanning pool holds exactly 29; the 49 files in `cli/agents/` include post-processors, generators, and reporters that never enter the pool, which `cli/agents/index.js` already documents. Verified with `buildOrchestrator().agents.length`.

`#203` takes the pool to 30 by adding `WorkspaceTrustAgent`, and that branch updates the copy and adds a test tying every "<n> agents" claim to the real registry length, so this cannot drift silently again.

## Verification

- `npm test`: 939 pass
- `npm run lint`: 0 errors
- `npm pack --dry-run`: 146 files, unchanged
- `npm run benchmark:fp`: runs, confirming the deduplicated script still resolves