### PR TITLE
docs(baseline): say the Hermes pin is reproducibility, not endorsement

### DIFF
--- a/cli/__tests__/hermes-baseline.test.js
+++ b/cli/__tests__/hermes-baseline.test.js
@@ -70,3 +70,47 @@ test('the upstream fixture and published baseline cannot drift apart', () => {
     assert.doesNotMatch(representativePath, /^(?:main|latest)(?:\/|$)/);
   }
 });
+
+test('the pin is framed as reproducibility, not a safety endorsement', () => {
+  // A version number at the top of a security document reads as a
+  // recommendation unless the document says otherwise. #205 asks for that to be
+  // stated plainly, so it is asserted rather than left to review.
+  assert.ok(baseline.pinRationale, 'baseline must record why the pin exists');
+  assert.match(baseline.pinRationale, /not a safety endorsement/i);
+
+  assert.match(matrix, /not\b.{0,40}safety endorsement/is);
+  assert.match(matrix, /reproducib/i);
+
+  const model = fs.readFileSync(path.join(root, 'docs/hermes-security-model.md'), 'utf8');
+  assert.match(model, /reproducibility, not endorsement/i);
+});
+
+test('known vulnerabilities affecting the pinned release are recorded and dated', () => {
+  const known = baseline.knownVulnerabilities;
+  assert.ok(Array.isArray(known) && known.length > 0, 'baseline must record known CVEs');
+
+  for (const entry of known) {
+    assert.match(entry.id, /^CVE-\d{4}-\d{4,}$/, `${entry.id} is not a CVE id`);
+    assert.ok(entry.source, `${entry.id} needs a source URL`);
+    assert.match(entry.recordedAt, /^\d{4}-\d{2}-\d{2}$/, `${entry.id} needs a record date`);
+    assert.ok(entry.affects, `${entry.id} must say what it affects`);
+    assert.equal(typeof entry.affectsPinnedRelease, 'boolean');
+    // `patchedIn` is deliberately nullable: "no patch exists" is a fact worth
+    // recording, and an absent key would be indistinguishable from an omission.
+    assert.ok('patchedIn' in entry, `${entry.id} must state its patch status`);
+  }
+});
+
+test('a CVE affecting the pinned release is named in the docs, not only in JSON', () => {
+  // The JSON is the machine-readable copy; a human reading the matrix has to
+  // see it too, or the honest framing only exists somewhere nobody looks.
+  const affecting = baseline.knownVulnerabilities.filter((entry) => entry.affectsPinnedRelease);
+  for (const entry of affecting) {
+    assert.ok(matrix.includes(entry.id), `matrix must name ${entry.id}`);
+  }
+});
+
+test('maintaining the baseline includes re-checking the CVE record', () => {
+  assert.match(matrix, /knownVulnerabilities/);
+  assert.match(matrix, /recordedAt/);
+});

--- a/cli/data/hermes-baseline.json
+++ b/cli/data/hermes-baseline.json
@@ -7,51 +7,99 @@
   "releasedAt": "2026-08-31T19:29:49Z",
   "auditedAt": "2026-09-04",
   "securityPolicyPath": "SECURITY.md",
+  "pinRationale": "Reproducibility of coverage claims, not a safety endorsement. This snapshot is pinned so a claim made today can be re-checked against the same bytes tomorrow. It is not a statement that the pinned release is safe to run -- see knownVulnerabilities.",
+  "knownVulnerabilities": [
+    {
+      "id": "CVE-2026-71963",
+      "affects": "Hermes Agent 0.18.2 and 0.21.0",
+      "affectsPinnedRelease": true,
+      "sink": "core.fsmonitor",
+      "patchedIn": null,
+      "status": "unpatched at last check",
+      "recordedAt": "2026-09-06",
+      "source": "https://manifoldsec.com/gitspawn",
+      "note": "The pinned release is affected. Ship Safe pins it for reproducibility of coverage claims; running it is a separate decision."
+    }
+  ],
   "surfaces": [
     {
       "id": "plugin-manifests",
       "status": "partial",
-      "upstreamPaths": ["plugins/**/plugin.yaml", "hermes_cli/plugins.py"],
+      "upstreamPaths": [
+        "plugins/**/plugin.yaml",
+        "hermes_cli/plugins.py"
+      ],
       "boundary": "operator review before in-process loading",
-      "rules": ["HERMES_PLUGIN_NO_PROVENANCE", "HERMES_PLUGIN_UNDECLARED_HOOK", "HERMES_PLUGIN_NETWORK_LISTENER_UNDECLARED"],
+      "rules": [
+        "HERMES_PLUGIN_NO_PROVENANCE",
+        "HERMES_PLUGIN_UNDECLARED_HOOK",
+        "HERMES_PLUGIN_NETWORK_LISTENER_UNDECLARED"
+      ],
       "limitations": "Manifest provenance, hook drift, and undeclared listeners are covered as hygiene. Install and discovery paths that hide code from operator review are not modeled."
     },
     {
       "id": "network-adapters",
       "status": "partial",
-      "upstreamPaths": ["gateway/platforms/**", "plugins/platforms/**", "gateway/platform_registry.py"],
+      "upstreamPaths": [
+        "gateway/platforms/**",
+        "plugins/platforms/**",
+        "gateway/platform_registry.py"
+      ],
       "boundary": "operator-configured caller authorization at each network surface",
-      "rules": ["HERMES_ADAPTER_ALLOWLIST_FAIL_OPEN"],
+      "rules": [
+        "HERMES_ADAPTER_ALLOWLIST_FAIL_OPEN"
+      ],
       "limitations": "Python adapter functions are checked for fail-open dispatch. Shared authorization, relay, HTTP plugin, and non-loopback exposure paths are not comprehensively modeled."
     },
     {
       "id": "terminal-backends",
       "status": "partial",
-      "upstreamPaths": ["tools/environments/**", "tools/terminal_tool.py", "tools/code_execution_tool.py", "hermes_cli/config.py", "hermes_cli/setup.py"],
+      "upstreamPaths": [
+        "tools/environments/**",
+        "tools/terminal_tool.py",
+        "tools/code_execution_tool.py",
+        "hermes_cli/config.py",
+        "hermes_cli/setup.py"
+      ],
       "boundary": "OS isolation for shell and file operations only",
-      "rules": ["HERMES_LOCAL_BACKEND_UNTRUSTED_INPUT", "HERMES_TERMINAL_BACKEND_SCOPE_GAP"],
+      "rules": [
+        "HERMES_LOCAL_BACKEND_UNTRUSTED_INPUT",
+        "HERMES_TERMINAL_BACKEND_SCOPE_GAP"
+      ],
       "limitations": "Repository-carried config is checked across local, Docker, Modal, SSH, Daytona, Vercel Sandbox, and Singularity. Runtime-only CLI/environment overrides, OpenShell session binding, and arbitrary custom terminal-environment plugins are not resolved statically."
     },
     {
       "id": "acp",
       "status": "partial",
-      "upstreamPaths": ["acp_adapter/**"],
+      "upstreamPaths": [
+        "acp_adapter/**"
+      ],
       "boundary": "host-user access control for local editor IPC",
-      "rules": ["HERMES_ACP_GATEWAY_EXPOSED"],
+      "rules": [
+        "HERMES_ACP_GATEWAY_EXPOSED"
+      ],
       "limitations": "Configured non-loopback WebSocket re-exports are traced from their route to ACP prompt execution. External reverse proxies, inherited deployment binds, and custom ACP transports are not resolved statically."
     },
     {
       "id": "tui-gateway",
       "status": "partial",
-      "upstreamPaths": ["tui_gateway/**", "ui-tui/**"],
+      "upstreamPaths": [
+        "tui_gateway/**",
+        "ui-tui/**"
+      ],
       "boundary": "host-user access control for local JSON-RPC IPC",
-      "rules": ["HERMES_TUI_GATEWAY_EXPOSED"],
+      "rules": [
+        "HERMES_TUI_GATEWAY_EXPOSED"
+      ],
       "limitations": "Configured non-loopback WebSocket routes are traced to the shared TUI dispatcher and its reachable effects. External reverse proxies, dynamic bind values, and authorization inside custom middleware are not resolved statically."
     },
     {
       "id": "cron",
       "status": "partial",
-      "upstreamPaths": ["cron/**", "tools/cronjob_tools.py"],
+      "upstreamPaths": [
+        "cron/**",
+        "tools/cronjob_tools.py"
+      ],
       "boundary": "job identity, lifecycle, subprocess environment, and reachable effects",
       "rules": [
         "HERMES_CRON_SKILL_INJECTION",
@@ -63,7 +111,12 @@
     {
       "id": "credential-scoping",
       "status": "partial",
-      "upstreamPaths": ["tools/environments/local.py", "tools/code_execution_tool.py", "tools/credential_files.py", "cron/scheduler.py"],
+      "upstreamPaths": [
+        "tools/environments/local.py",
+        "tools/code_execution_tool.py",
+        "tools/credential_files.py",
+        "cron/scheduler.py"
+      ],
       "boundary": "filtered credential flow into lower-trust subprocesses and external effects",
       "rules": [
         "HERMES_SUB_AGENT_CREDENTIAL_FORWARD",

--- a/cli/data/hermes-baseline.json
+++ b/cli/data/hermes-baseline.json
@@ -17,7 +17,7 @@
       "patchedIn": null,
       "status": "unpatched at last check",
       "recordedAt": "2026-09-06",
-      "source": "https://manifoldsec.com/gitspawn",
+      "source": "https://www.manifold.security/blog/ai-coding-agents-git-hijack",
       "note": "The pinned release is affected. Ship Safe pins it for reproducibility of coverage claims; running it is a separate decision."
     }
   ],

--- a/docs/hermes-coverage-matrix.md
+++ b/docs/hermes-coverage-matrix.md
@@ -20,6 +20,33 @@ The test fixture
 [`hermes-v0.21.0-baseline.json`](../cli/__tests__/fixtures/hermes-v0.21.0-baseline.json)
 pins representative paths from the same snapshot.
 
+## What the pin means, and what it does not
+
+The pin exists so a coverage claim is **reproducible**: a statement Ship Safe
+makes today about a surface can be re-checked tomorrow against the same bytes.
+That is its whole purpose.
+
+It is **not** a safety endorsement, and the two are easy to conflate when a
+version number appears at the top of a security document. Concretely:
+
+> **The pinned release, Hermes Agent v0.21.0, is affected by
+> [CVE-2026-71963](https://nvd.nist.gov/vuln/detail/CVE-2026-71963)
+> (`core.fsmonitor`), unpatched at last check on 2026-09-06.**
+
+Pinning an affected release is the correct thing to do here — moving the pin to
+dodge a CVE would silently invalidate every calibrated fixture and every
+coverage claim built on it — but it would be dishonest to let a reader infer
+that "Ship Safe baselines against v0.21.0" means "v0.21.0 is a safe version to
+run." It does not. Which version to run is a separate decision from which
+version this project measures itself against.
+
+Known vulnerabilities affecting the pinned release are recorded in
+[`cli/data/hermes-baseline.json`](../cli/data/hermes-baseline.json) under
+`knownVulnerabilities`, each with its source and the date it was recorded, so
+the staleness of the record is visible rather than assumed. That list covers
+only what is *documented*; absence from it is absence of a record, not evidence
+of absence.
+
 ## Status definitions
 
 - **Covered** means a detector is calibrated to this pinned surface and has a
@@ -215,6 +242,9 @@ Baseline updates are reviewed changes, never automatic tag following:
 4. Re-run the baseline contract test and relevant positive/safe fixtures.
 5. Change a matrix status only when the detector is calibrated to the new
    snapshot and its evidence supports the advertised verdict.
+6. Re-check `knownVulnerabilities` against current advisories and update
+   `recordedAt`, whether or not anything changed. A stale record that looks
+   fresh is worse than no record.
 
 Version drift is therefore visible as a code review. A newer Hermes release
 does not silently expand Ship Safe's coverage claim.

--- a/docs/hermes-security-model.md
+++ b/docs/hermes-security-model.md
@@ -97,6 +97,16 @@ Ship Safe 10.0 is baselined against Hermes Agent v0.21.0 at commit
 and its limitations live in
 [hermes-coverage-matrix.md](hermes-coverage-matrix.md).
 
+**The pin is about reproducibility, not endorsement.** It exists so a coverage
+claim can be re-checked against the same bytes later. It is not a statement
+that the pinned release is safe to run -- v0.21.0 is affected by
+[CVE-2026-71963](https://nvd.nist.gov/vuln/detail/CVE-2026-71963)
+(`core.fsmonitor`), unpatched at last check. Moving the pin to dodge a CVE
+would invalidate every calibrated fixture built on it, so the pin stays and the
+status is stated instead. Which version to run is a separate decision from
+which version this project measures itself against; see
+[what the pin means](hermes-coverage-matrix.md#what-the-pin-means-and-what-it-does-not).
+
 Hermes moves quickly. Baseline changes must pin a release tag to a full commit,
 review upstream's security policy and affected surfaces, and update the
 machine-readable baseline and matrix together. Never make a coverage claim


### PR DESCRIPTION
The first PR out of #205 — the docs half. The scheduled workflow is not in here; this is the framing change #205 asks to land first, and it stands on its own.

**The problem, stated plainly.** The baseline pins v0.21.0. v0.21.0 is affected by CVE-2026-71963 (`core.fsmonitor`), unpatched at last check. Nothing in the docs said so, and a version number at the top of a security document reads as a recommendation whether or not it was meant as one.

**The pin stays.** Moving it to dodge a CVE would invalidate every calibrated fixture and every coverage claim built on that snapshot — the pin is for reproducibility, so a claim made today can be re-checked against the same bytes tomorrow. That is now written down in all three places rather than assumed:

- `cli/data/hermes-baseline.json` — new `pinRationale`, and `knownVulnerabilities` carrying the CVE with its source, affected versions, patch status and `recordedAt`. `patchedIn` is explicitly `null` rather than omitted: "no patch exists" is a fact, and an absent key would be indistinguishable from someone forgetting to fill it in.
- `docs/hermes-coverage-matrix.md` — a new **What the pin means, and what it does not** section above Status definitions, plus a sixth step in Maintaining the baseline: re-check the CVE record on every baseline update *whether or not anything changed*, because a stale record that looks fresh is worse than no record.
- `docs/hermes-security-model.md` — the same statement at the Version drift section, where a reader arrives from the coverage claim.

The matrix also says the list covers only what is documented — absence from it is absence of a record, not evidence of absence.

**Tests.** Four added to `cli/__tests__/hermes-baseline.test.js`, because a framing paragraph is exactly the kind of thing that gets trimmed in a later edit:

- the rationale exists and says it is not a safety endorsement, in the JSON *and* both docs;
- every CVE entry has a CVE-shaped id, a source, a `recordedAt` date, an `affects` string and an explicit `patchedIn` key;
- any CVE flagged `affectsPinnedRelease` is named in the human-readable matrix, not only in the JSON — otherwise the honest framing lives somewhere nobody reads;
- the maintenance procedure still references the record.

Mutation-checked: renaming `CVE-2026-71963` to `CVE-XXXX-XXXXX` in the matrix fails the third test.

`npm test`: **101 pass / 85 fail on `main`, 105 pass / 85 fail on this branch** — the four new tests, zero newly failing. The 85 are pre-existing on my machine and unrelated to this change.

One thing I could not run: `node cli/bin/ship-safe.js scan . --no-ai` from the CONTRIBUTING checklist errors with `ERR_MODULE_NOT_FOUND` here because `node_modules` is not installed in my environment. Flagging that rather than ticking the box — this change touches only JSON, Markdown and a test file, so I do not expect it to affect a scan, but I have not verified that myself.

I've left the workflow (steps 1–4 of #205) out deliberately so this can be reviewed as the honest-framing change it is. Happy to follow up with it, or to fold the CVE table for other agents from #204 into the same shape if that ordering suits you better.
