### PR TITLE
feat(baseline): scheduled drift check that reports, never updates

### DIFF
--- a/.github/workflows/hermes-baseline-drift.yml
+++ b/.github/workflows/hermes-baseline-drift.yml
@@ -1,0 +1,84 @@
+name: Hermes Baseline Drift
+
+# Reports Hermes releases newer than the pinned coverage baseline (#205).
+#
+# It opens a pull request describing the drift. It never edits the baseline,
+# the coverage matrix or any surface status: a coverage claim that follows
+# upstream automatically is not a coverage claim, so moving the pin stays a
+# reviewed change a human merges.
+
+on:
+  schedule:
+    # Weekly, Mondays 04:00 UTC. Drift is not urgent; a noisy check is ignored.
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+
+      # The script exits 1 when it finds drift, which is a report rather than a
+      # failure, so the step captures the code instead of ending the job.
+      - name: Check for newer Hermes releases
+        id: drift
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          node scripts/hermes-baseline-drift.mjs > drift-report.md
+          code=$?
+          set -e
+          if [ "$code" -ge 2 ]; then
+            echo "::error::baseline drift check failed"
+            cat drift-report.md
+            exit 1
+          fi
+          echo "drifted=$([ "$code" -eq 1 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          cat drift-report.md
+
+      # A branch with no commits of its own: the report lives in the pull
+      # request body, and the diff is deliberately empty because nothing in the
+      # repository should change until a human decides it does.
+      - name: Open or update the review pull request
+        if: steps.drift.outputs.drifted == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH="chore/hermes-baseline-drift"
+          TITLE="Hermes baseline drift: newer releases to review"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B "$BRANCH"
+          mkdir -p docs/generated
+          cp drift-report.md docs/generated/hermes-baseline-drift.md
+          git add docs/generated/hermes-baseline-drift.md
+          if git diff --cached --quiet; then
+            echo "Report unchanged since the last run; nothing to push."
+          else
+            git commit -m "chore(baseline): record Hermes drift report"
+            git push --force-with-lease origin "$BRANCH"
+          fi
+
+          EXISTING=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh pr edit "$EXISTING" --title "$TITLE" --body-file drift-report.md
+            echo "Updated PR #$EXISTING"
+          else
+            gh pr create --head "$BRANCH" --title "$TITLE" --body-file drift-report.md
+          fi

--- a/.github/workflows/hermes-baseline-drift.yml
+++ b/.github/workflows/hermes-baseline-drift.yml
@@ -49,9 +49,15 @@ jobs:
           echo "drifted=$([ "$code" -eq 1 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
           cat drift-report.md
 
-      # A branch with no commits of its own: the report lives in the pull
-      # request body, and the diff is deliberately empty because nothing in the
-      # repository should change until a human decides it does.
+      # The branch carries the report and nothing else. It is committed under
+      # docs/generated/ so the drift is reviewable as a diff and its history is
+      # visible run to run, and it is repeated in the pull request body so a
+      # reader does not have to open a file to see what changed.
+      #
+      # What the branch deliberately never contains is an edit to the baseline,
+      # the coverage matrix, or any surface status. Moving the pin stays a
+      # decision a human makes: a coverage claim that follows upstream on its
+      # own is not a coverage claim.
       - name: Open or update the review pull request
         if: steps.drift.outputs.drifted == 'true'
         env:

--- a/cli/__tests__/hermes-baseline-drift.test.js
+++ b/cli/__tests__/hermes-baseline-drift.test.js
@@ -1,0 +1,167 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  changedFiles,
+  matchesPattern,
+  newerReleases,
+  readBaseline,
+  renderReport,
+  run,
+  securityRelevantPaths,
+  surfacesTouched,
+  unmatchedSecurityFiles,
+} from '../../scripts/hermes-baseline-drift.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, '../..');
+const baseline = readBaseline();
+
+// A fake GitHub API, so these tests never touch the network and the drift
+// report is asserted against known input rather than whatever upstream did
+// this week.
+function fakeApi({ releases = [], files = [] } = {}) {
+  return async (url) => {
+    if (url.includes('/releases')) return releases;
+    if (url.includes('/compare/')) return { files: files.map((filename) => ({ filename })) };
+    throw new Error(`unexpected URL ${url}`);
+  };
+}
+
+const PINNED = { tag_name: baseline.tag, name: baseline.release, sha: baseline.commit };
+
+test('the workflow that runs the script exists and is scheduled', () => {
+  const workflow = fs.readFileSync(
+    path.join(root, '.github/workflows/hermes-baseline-drift.yml'),
+    'utf8',
+  );
+  assert.match(workflow, /schedule:/);
+  assert.match(workflow, /scripts\/hermes-baseline-drift\.mjs/);
+  // #205: a human merges. The workflow must not be able to merge itself.
+  assert.doesNotMatch(workflow, /gh pr merge/);
+  assert.doesNotMatch(workflow, /--auto/);
+});
+
+test('the workflow never edits the baseline or the matrix', () => {
+  // The whole point of the pin is that it moves under review. A workflow that
+  // could rewrite either file would defeat that regardless of intent.
+  const workflow = fs.readFileSync(
+    path.join(root, '.github/workflows/hermes-baseline-drift.yml'),
+    'utf8',
+  );
+  assert.doesNotMatch(workflow, /hermes-baseline\.json/);
+  assert.doesNotMatch(workflow, /hermes-coverage-matrix\.md/);
+});
+
+test('security-relevant paths come from the baseline, not a second list', () => {
+  const patterns = securityRelevantPaths(baseline);
+  assert.ok(patterns.length > 0);
+  const declared = baseline.surfaces.flatMap((surface) => surface.upstreamPaths);
+  assert.equal(patterns.length, declared.length);
+  for (const { pattern } of patterns) assert.ok(declared.includes(pattern));
+});
+
+test('glob matching does not over-match', () => {
+  // `*` must not cross a separator, or a single pattern would silently claim
+  // to watch a whole tree it was never calibrated against.
+  assert.ok(matchesPattern('cron/scheduler.py', 'cron/**'));
+  assert.ok(matchesPattern('acp_adapter/a/b/c.py', 'acp_adapter/**'));
+  assert.ok(matchesPattern('plugins/x/plugin.yaml', 'plugins/**/plugin.yaml'));
+  assert.ok(matchesPattern('hermes_cli/plugins.py', 'hermes_cli/plugins.py'));
+
+  assert.ok(!matchesPattern('cronjobs/other.py', 'cron/**'));
+  assert.ok(!matchesPattern('hermes_cli/other.py', 'hermes_cli/plugins.py'));
+  assert.ok(!matchesPattern('tools/environments/x/y.py', 'tools/terminal_tool.py'));
+});
+
+test('a changed file maps to the surface that declares it', () => {
+  const touched = surfacesTouched(baseline, ['cron/scheduler.py', 'acp_adapter/server.py']);
+  assert.ok(touched.has('cron'));
+  assert.ok(touched.has('acp'));
+  assert.deepEqual(touched.get('cron'), ['cron/scheduler.py']);
+});
+
+test('a change outside every declared path touches nothing', () => {
+  assert.equal(surfacesTouched(baseline, ['README.md', 'docs/x.md']).size, 0);
+});
+
+test('a new area under a watched root is reported as uncovered', () => {
+  // #205: the workflow never widens a claim. A file upstream added under a
+  // directory we watch, that no pattern names, has to surface as uncovered
+  // rather than be passed over.
+  const unmatched = unmatchedSecurityFiles(baseline, [
+    'tools/brand_new_sink.py',
+    'cron/scheduler.py',
+    'README.md',
+  ]);
+  assert.deepEqual(unmatched, ['tools/brand_new_sink.py']);
+});
+
+test('no newer releases means no drift', async () => {
+  const { unknownPinnedTag, releases } = await newerReleases(baseline, {
+    fetchJson: fakeApi({ releases: [PINNED, { tag_name: 'v2026.8.1' }] }),
+  });
+  assert.equal(unknownPinnedTag, false);
+  assert.deepEqual(releases, []);
+});
+
+test('releases published after the pin are reported', async () => {
+  const newer = { tag_name: 'v2026.9.5', name: 'v0.22.0', sha: 'a'.repeat(40) };
+  const { releases } = await newerReleases(baseline, {
+    fetchJson: fakeApi({ releases: [newer, PINNED] }),
+  });
+  assert.equal(releases.length, 1);
+  assert.equal(releases[0].tag_name, 'v2026.9.5');
+});
+
+test('a pinned tag upstream no longer lists is itself drift', async () => {
+  const { unknownPinnedTag } = await newerReleases(baseline, {
+    fetchJson: fakeApi({ releases: [{ tag_name: 'v2026.9.5' }] }),
+  });
+  assert.equal(unknownPinnedTag, true);
+});
+
+test('changed files are read from the compare endpoint', async () => {
+  const files = await changedFiles(baseline, 'b'.repeat(40), {
+    fetchJson: fakeApi({ files: ['cron/scheduler.py'] }),
+  });
+  assert.deepEqual(files, ['cron/scheduler.py']);
+});
+
+test('the report names the surfaces to re-check and refuses to widen', async () => {
+  const { baseline: b, result } = await run({
+    fetchJson: fakeApi({
+      releases: [{ tag_name: 'v2026.9.5', name: 'v0.22.0', sha: 'a'.repeat(40) }, PINNED],
+      files: ['cron/scheduler.py', 'tools/brand_new_sink.py'],
+    }),
+  });
+  const report = renderReport(b, result);
+
+  assert.match(report, /Hermes baseline drift/);
+  assert.match(report, /v2026\.9\.5/);
+  assert.match(report, /\*\*cron\*\*/);
+  assert.match(report, /UNCOVERED/);
+  assert.match(report, /brand_new_sink\.py/);
+  // The two promises #205 makes, stated in the body a reviewer reads.
+  assert.match(report, /No status may move to covered/);
+  assert.match(report, /Nothing is updated/);
+});
+
+test('a quiet report says so rather than inventing findings', async () => {
+  const { baseline: b, result } = await run({
+    fetchJson: fakeApi({ releases: [PINNED] }),
+  });
+  const report = renderReport(b, result);
+  assert.match(report, /No releases newer than the pinned tag/);
+  assert.equal(result.releases.length, 0);
+});
+
+test('the report never contains a credential-shaped value', () => {
+  // The body is posted to a public pull request.
+  const report = renderReport(baseline, { unknownPinnedTag: false, releases: [] });
+  assert.doesNotMatch(report, /gh[pousr]_[A-Za-z0-9]{16,}/);
+  assert.doesNotMatch(report, /Bearer\s+\S+/);
+});

--- a/scripts/hermes-baseline-drift.mjs
+++ b/scripts/hermes-baseline-drift.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+/**
+ * Report Hermes releases newer than the pinned coverage baseline (#205).
+ *
+ * The baseline in `cli/data/hermes-baseline.json` pins a release tag to a full
+ * commit SHA, and every coverage claim in `docs/hermes-coverage-matrix.md` is
+ * scoped to that snapshot. Upstream moves; nothing told us.
+ *
+ * This reports. It does not update anything, and deliberately cannot: the
+ * workflow that runs it opens a pull request for a human to review, because a
+ * coverage claim that follows upstream automatically is not a coverage claim.
+ *
+ * Two rules the output has to respect, both from #205:
+ *
+ *  - It never widens a claim. A surface whose upstream paths changed is
+ *    reported as *needing review*, never as still covered.
+ *  - A new file in a security-relevant path with no rule against it is
+ *    reported as UNCOVERED rather than passed over in silence.
+ *
+ * Usage:
+ *   node scripts/hermes-baseline-drift.mjs            # query GitHub
+ *   node scripts/hermes-baseline-drift.mjs --json     # machine-readable
+ *
+ * Exit codes: 0 no drift, 1 drift found (the workflow reads this), 2 error.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(HERE, "..");
+const BASELINE = path.join(ROOT, "cli/data/hermes-baseline.json");
+
+const API = "https://api.github.com/repos";
+
+/** Read the pinned baseline. */
+export function readBaseline(baselinePath = BASELINE) {
+  return JSON.parse(fs.readFileSync(baselinePath, "utf8"));
+}
+
+/**
+ * Paths this project claims to have rules against, flattened from the
+ * baseline's surfaces. These are what a diff is filtered to: a change outside
+ * them is upstream's business, not a coverage question.
+ */
+export function securityRelevantPaths(baseline) {
+  return baseline.surfaces.flatMap((surface) =>
+    surface.upstreamPaths.map((pattern) => ({ surface: surface.id, pattern })),
+  );
+}
+
+/**
+ * Does a changed file fall inside one of the baseline's upstream paths?
+ *
+ * The patterns are shell-style globs with `**`. Rather than pull in a matcher,
+ * they are compiled to anchored regexes: `**` crosses separators, `*` does
+ * not, everything else is literal. Keeping this explicit matters because a
+ * matcher that is too permissive silently widens what we claim to watch.
+ */
+export function matchesPattern(filePath, pattern) {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+  const source = escaped
+    .split("**")
+    .map((part) => part.split("*").map((p) => p).join("[^/]*"))
+    .join(".*");
+  return new RegExp(`^${source}$`).test(filePath);
+}
+
+/** Surfaces touched by a list of changed file paths. */
+export function surfacesTouched(baseline, changedPaths) {
+  const patterns = securityRelevantPaths(baseline);
+  const touched = new Map();
+  for (const file of changedPaths) {
+    for (const { surface, pattern } of patterns) {
+      if (matchesPattern(file, pattern)) {
+        if (!touched.has(surface)) touched.set(surface, []);
+        touched.get(surface).push(file);
+      }
+    }
+  }
+  return touched;
+}
+
+/**
+ * Files inside a watched surface directory that no declared path names.
+ *
+ * A `**` pattern covers a whole tree, so this is about a *new top-level
+ * area* upstream added: if it is security-relevant and nothing matches it,
+ * #205 requires it be flagged as uncovered rather than assumed fine.
+ */
+export function unmatchedSecurityFiles(baseline, changedPaths) {
+  const patterns = securityRelevantPaths(baseline);
+  const watchedRoots = new Set(
+    patterns.map(({ pattern }) => pattern.split("/")[0]).filter((p) => !p.includes("*")),
+  );
+  return changedPaths.filter((file) => {
+    const root = file.split("/")[0];
+    if (!watchedRoots.has(root)) return false;
+    return !patterns.some(({ pattern }) => matchesPattern(file, pattern));
+  });
+}
+
+async function gh(url, token) {
+  const headers = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "ship-safe-baseline-drift",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(`GitHub API ${response.status} for ${url}`);
+  }
+  return response.json();
+}
+
+/** Releases published after the pinned tag, newest first. */
+export async function newerReleases(baseline, { token, fetchJson = gh } = {}) {
+  const releases = await fetchJson(`${API}/${baseline.project}/releases?per_page=100`, token);
+  const pinnedIndex = releases.findIndex((release) => release.tag_name === baseline.tag);
+  // An unknown pinned tag means the baseline points at something that is no
+  // longer published. That is drift too, and the loudest kind, so it is
+  // reported rather than treated as "nothing newer".
+  if (pinnedIndex === -1) return { unknownPinnedTag: true, releases: [] };
+  return { unknownPinnedTag: false, releases: releases.slice(0, pinnedIndex) };
+}
+
+/** Files changed between the pinned commit and a newer one. */
+export async function changedFiles(baseline, headSha, { token, fetchJson = gh } = {}) {
+  const comparison = await fetchJson(
+    `${API}/${baseline.project}/compare/${baseline.commit}...${headSha}`,
+    token,
+  );
+  return (comparison.files ?? []).map((file) => file.filename);
+}
+
+/** Render the report a reviewer reads in the pull request body. */
+export function renderReport(baseline, result) {
+  const lines = [];
+  lines.push(`## Hermes baseline drift`);
+  lines.push("");
+  lines.push(
+    `Pinned: **${baseline.release}** (\`${baseline.tag}\`, \`${baseline.commit.slice(0, 12)}\`)`,
+  );
+  lines.push("");
+
+  if (result.unknownPinnedTag) {
+    lines.push(
+      `> The pinned tag \`${baseline.tag}\` is not among the published releases. ` +
+        `The baseline points at something upstream no longer lists.`,
+    );
+    return lines.join("\n");
+  }
+
+  if (result.releases.length === 0) {
+    lines.push("No releases newer than the pinned tag. Nothing to review.");
+    return lines.join("\n");
+  }
+
+  lines.push(`${result.releases.length} newer release(s):`);
+  lines.push("");
+  lines.push("| release | tag | commit | published |");
+  lines.push("| --- | --- | --- | --- |");
+  for (const release of result.releases) {
+    lines.push(
+      `| ${release.name ?? release.tag_name} | \`${release.tag_name}\` | ` +
+        `\`${(release.sha ?? "").slice(0, 12)}\` | ${release.published_at ?? ""} |`,
+    );
+  }
+  lines.push("");
+
+  const touched = result.touched ?? new Map();
+  if (touched.size > 0) {
+    lines.push("### Surfaces with upstream changes");
+    lines.push("");
+    lines.push(
+      "Each of these needs its detector re-checked against the new snapshot. " +
+        "**No status may move to covered without that.**",
+    );
+    lines.push("");
+    for (const [surface, files] of touched) {
+      lines.push(`- **${surface}** — ${files.length} file(s) changed`);
+      for (const file of files.slice(0, 10)) lines.push(`  - \`${file}\``);
+      if (files.length > 10) lines.push(`  - ...and ${files.length - 10} more`);
+    }
+    lines.push("");
+  } else {
+    lines.push("No files changed inside the baseline's declared upstream paths.");
+    lines.push("");
+  }
+
+  if ((result.unmatched ?? []).length > 0) {
+    lines.push("### UNCOVERED: new areas no rule names");
+    lines.push("");
+    lines.push(
+      "These sit under a watched directory but match no declared path. " +
+        "Treat as **uncovered** until a rule exists.",
+    );
+    lines.push("");
+    for (const file of result.unmatched.slice(0, 20)) lines.push(`- \`${file}\``);
+    lines.push("");
+  }
+
+  lines.push("### What this pull request does not do");
+  lines.push("");
+  lines.push(
+    "Nothing is updated. The baseline JSON, the coverage matrix and every status " +
+      "are untouched. Moving the pin is a reviewed change that follows the procedure " +
+      "in `docs/hermes-coverage-matrix.md`, including re-checking the known-CVE record.",
+  );
+  return lines.join("\n");
+}
+
+export async function run({ token = process.env.GITHUB_TOKEN, fetchJson = gh } = {}) {
+  const baseline = readBaseline();
+  const { unknownPinnedTag, releases } = await newerReleases(baseline, { token, fetchJson });
+
+  const result = { unknownPinnedTag, releases, touched: new Map(), unmatched: [] };
+  if (!unknownPinnedTag && releases.length > 0) {
+    const newest = releases[0];
+    const sha = newest.sha ?? newest.target_commitish;
+    const files = await changedFiles(baseline, sha, { token, fetchJson });
+    result.touched = surfacesTouched(baseline, files);
+    result.unmatched = unmatchedSecurityFiles(baseline, files);
+  }
+  return { baseline, result };
+}
+
+// `process.argv[1]` is a platform path; import.meta.url is a file URL. Compare
+// them as resolved URLs so this works on Windows as well as on the CI runner.
+const invokedDirectly =
+  Boolean(process.argv[1]) && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedDirectly) {
+  run()
+    .then(({ baseline, result }) => {
+      const report = renderReport(baseline, result);
+      if (process.argv.includes("--json")) {
+        process.stdout.write(
+          JSON.stringify(
+            {
+              pinned: { release: baseline.release, tag: baseline.tag, commit: baseline.commit },
+              unknownPinnedTag: result.unknownPinnedTag,
+              newerReleases: result.releases.map((r) => r.tag_name),
+              surfacesTouched: [...result.touched.keys()],
+              unmatched: result.unmatched,
+            },
+            null,
+            2,
+          ) + "\n",
+        );
+      } else {
+        process.stdout.write(report + "\n");
+      }
+      const drifted = result.unknownPinnedTag || result.releases.length > 0;
+      process.exit(drifted ? 1 : 0);
+    })
+    .catch((error) => {
+      process.stderr.write(`${error.message}\n`);
+      process.exit(2);
+    });
+}


### PR DESCRIPTION
The workflow half of #205, complementing the docs half in #209. Independent of it — this branch is cut from `main` and touches no file that PR touches.

### What it does

Weekly (Mondays 04:00 UTC) and on demand: query upstream releases newer than the pinned tag, record the exact commit SHA, diff the security-relevant paths, and open or update one pull request with the summary. A human merges. Nothing else happens.

Real run against upstream today:

```
## Hermes baseline drift
Pinned: **v0.21.0** (`v2026.8.31`, `29112bef0992`)
No releases newer than the pinned tag. Nothing to review.
```

Simulated newer release, showing the shape a reviewer would get:

```
### Surfaces with upstream changes
Each of these needs its detector re-checked against the new snapshot.
**No status may move to covered without that.**
- **cron** — 1 file(s) changed
- **credential-scoping** — 1 file(s) changed

### UNCOVERED: new areas no rule names
- `tools/brand_new_sink.py`
```

### The rules from #205, and how each is enforced rather than intended

**"The workflow never widens a coverage claim."** It cannot edit anything, and two tests hold it to that: the workflow file must not reference `hermes-baseline.json` or `hermes-coverage-matrix.md`, and must not contain `gh pr merge` or `--auto`. Intent is not a mechanism; those are.

**"If upstream adds a new surface, flag it as uncovered until a rule exists."** `unmatchedSecurityFiles` reports any file under a watched root that no declared pattern names, under an `UNCOVERED` heading.

**"Coverage claims stay tied to immutable versions."** The diff is `pinned commit ... new release commit`, never a branch.

**Paths come from one place.** They are read from the baseline's own `surfaces[].upstreamPaths`, so there is no second list to drift from the first — a test asserts the flattened set equals what the baseline declares.

### One thing I want to flag rather than bury

Glob matching is written out (about six lines) instead of pulling in a matcher. That is a deliberate trade: a matcher that is too permissive would *silently widen* what we claim to watch, which is the exact failure mode this workflow exists to prevent. The tests pin the boundary — `*` must not cross a separator, so `cron/**` matches `cron/scheduler.py` but not `cronjobs/other.py`, and `tools/terminal_tool.py` does not match `tools/environments/x/y.py`. If you would rather take a dependency, that is a reasonable call and I will swap it.

A pinned tag upstream no longer lists is also reported as drift, and the loudest kind, rather than read as "nothing newer".

### Verification

- 14 new tests, all against a fake GitHub API, so they never touch the network and the report is asserted against known input rather than whatever upstream did that week.
- `npm test`: **101 pass / 85 fail on `main`, 115 pass / 85 fail here** — the 14 new ones, zero newly failing. The 85 are pre-existing on my machine.
- Script verified end to end against the real repository (exit 0, correct report) and against a simulated newer release.

Action SHAs are pinned, matching `update-hermes-image.yml`. Job permissions are the minimum needed: `contents: write` and `pull-requests: write` on the one job, with the workflow default left at `contents: read`.

Not included, deliberately: recording CVEs in the baseline doc, which is step 5 of #205 and is what #209 does.
