### PR TITLE
fix(rag): scope Python model-loading rules

### DIFF
--- a/cli/__tests__/language-scope.test.js
+++ b/cli/__tests__/language-scope.test.js
@@ -153,6 +153,43 @@ describe('APIFuzzer scoping', async () => {
   });
 });
 
+describe('RAGSecurityAgent scoping', async () => {
+  const { RAGSecurityAgent } = await import('../agents/rag-security-agent.js');
+
+  const hits = async (code, ext) => {
+    const { dir, file } = tmpFile(code, ext);
+    try {
+      const f = await new RAGSecurityAgent().analyze({ rootPath: dir, files: [file], recon: {}, options: {} });
+      return f.map(x => x.rule);
+    } finally { cleanup(dir); }
+  };
+
+  it('still catches Python pickle loading and remote model code', async () => {
+    const findings = await hits(
+      'model = torch.load(path)\nmodel = AutoModel.from_pretrained(name, trust_remote_code=True)',
+      '.py'
+    );
+
+    assert.ok(findings.includes('RAG_PICKLE_EMBEDDING_MODEL'));
+    assert.ok(findings.includes('RAG_TRUST_REMOTE_CODE'));
+  });
+
+  it('does not apply Python model-loading rules to JavaScript', async () => {
+    const findings = await hits(
+      'const model = torch.load(path);\nconst options = { trust_remote_code=True };',
+      '.js'
+    );
+
+    assert.ok(!findings.includes('RAG_PICKLE_EMBEDDING_MODEL'));
+    assert.ok(!findings.includes('RAG_TRUST_REMOTE_CODE'));
+  });
+
+  it('leaves cross-language RAG rules active in both languages', async () => {
+    assert.ok((await hits('top_k = 50', '.py')).includes('RAG_EXCESSIVE_CONTEXT'));
+    assert.ok((await hits('top_k = 50;', '.js')).includes('RAG_EXCESSIVE_CONTEXT'));
+  });
+});
+
 describe('LLMRedTeam scoping', async () => {
   const { LLMRedTeam } = await import('../agents/llm-redteam.js');
 

--- a/cli/agents/rag-security-agent.js
+++ b/cli/agents/rag-security-agent.js
@@ -152,6 +152,7 @@ const PATTERNS = [
   // ── Model & Pipeline Safety ──────────────────────────────────────────────
   {
     rule: 'RAG_PICKLE_EMBEDDING_MODEL',
+    langs: ['python'],   // torch.load, pickle.load, and joblib.load are Python APIs.
     title: 'RAG: Embedding Model Loaded via Pickle',
     regex: /(?:torch\.load|pickle\.load|joblib\.load)\s*\(\s*(?!.*safetensors)(?!.*weights_only\s*=\s*True)/g,
     severity: 'critical',
@@ -162,6 +163,7 @@ const PATTERNS = [
   },
   {
     rule: 'RAG_TRUST_REMOTE_CODE',
+    langs: ['python'],   // trust_remote_code=True is a Python keyword argument.
     title: 'RAG: Model Loaded With trust_remote_code=True',
     regex: /trust_remote_code\s*=\s*True/g,
     severity: 'high',


### PR DESCRIPTION
Fixes #125.

Scopes the pickle-based model loader and `trust_remote_code=True` rules to Python. Other RAG rules remain unscoped where their syntax spans ecosystems. Regression tests cover retained Python findings, suppressed JavaScript findings, and preserved cross-language matching.

Validation:
- `npm test` (942 tests)
- `npx eslint cli/agents/rag-security-agent.js cli/__tests__/language-scope.test.js`
- `node cli/bin/ship-safe.js scan .` (112 files, no findings)
- false-positive benchmark: clean corpus held at 743 findings; NodeGoat and DVWA held at 138 with no detection-floor losses

AI assistance was used to draft the patch; I reviewed the full diff and ran the repository's deterministic validation and benchmark gates.
